### PR TITLE
Make UserInfoAuthenticationConverter.extractAuthorities enhancable

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/xs2/security/container/UserInfoAuthenticationConverter.java
+++ b/spring-xsuaa/src/main/java/com/sap/xs2/security/container/UserInfoAuthenticationConverter.java
@@ -37,7 +37,7 @@ public class UserInfoAuthenticationConverter implements Converter<Jwt, AbstractA
 		}
 	}
 
-	Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
+	protected Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
 		Collection<String> scopes = this.getScopes(jwt);
 		return scopes.stream().map(authority -> authority).map(SimpleGrantedAuthority::new).collect(Collectors.toList());
 	}


### PR DESCRIPTION
This is required, when i would like to add xs.user.attributes into the list of Authorities.