### PR TITLE
Make XsuaaAudienceValidator more robust

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidator.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidator.java
@@ -1,11 +1,10 @@
 package com.sap.cloud.security.xsuaa.token.authentication;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.sap.cloud.security.xsuaa.token.TokenImpl;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
@@ -13,6 +12,7 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
+import com.sap.cloud.security.xsuaa.token.Token;
 
 /**
  * Validate audience using audience field content. in case this field is empty, the audience is derived from the scope field
@@ -45,26 +45,26 @@ public class XsuaaAudienceValidator implements OAuth2TokenValidator<Jwt> {
 	 * Retrieve audiences from token. In case the audience list is empty, take audiences based on the scope names.
 	 * 
 	 * @param token
-	 * @return list of audiences
+	 * @return (empty) list of audiences
 	 */
 	private List<String> allowedAudiences(Jwt token) {
 		List<String> allAudiences = new ArrayList<>();
-		if (token.getClaimAsString("aud") != null) {
-			for(String audience:token.getClaimAsStringList("aud"))
-			{
+		List<String> tokenAudiences = token.getAudience();
+
+		if (tokenAudiences != null) {
+			for (String audience : tokenAudiences) {
 				if (audience.contains(".")) {
 					String aud = audience.substring(0, audience.indexOf("."));
 					allAudiences.add(aud);
-				}
-				else
-				{
+				} else {
 					allAudiences.add(audience);
 				}
 			}
 		}
 
-		if (allAudiences.size() == 0 && token.getClaimAsStringList("scope").size()>0) {
-			for (String scope : token.getClaimAsStringList("scope")) {
+		// extract audience (app-id) from scopes
+		if (allAudiences.size() == 0) {
+			for (String scope : getScopes(token)) {
 				if (scope.contains(".")) {
 					String aud = scope.substring(0, scope.indexOf("."));
 					allAudiences.add(aud);
@@ -73,4 +73,13 @@ public class XsuaaAudienceValidator implements OAuth2TokenValidator<Jwt> {
 		}
 		return allAudiences;
 	}
+
+	private List<String> getScopes(Jwt token) {
+		List<String> scopes = null;
+		//if (token.containsClaim(Token.CLAIM_SCOPES)) {
+			scopes = token.getClaimAsStringList(Token.CLAIM_SCOPES);
+		//}
+		return scopes != null ? scopes : new ArrayList<>();
+	}
+
 }

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidatorTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidatorTest.java
@@ -1,69 +1,115 @@
 package com.sap.cloud.security.xsuaa.token.authentication;
 
-import com.sap.cloud.security.xsuaa.token.JwtGenerator;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jwt.Jwt;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
-
+import com.sap.cloud.security.xsuaa.token.JwtGenerator;
+import com.sap.cloud.security.xsuaa.token.Token;
 
 public class XsuaaAudienceValidatorTest {
 
-	private Jwt tokenWithAudience = null;
-	private Jwt tokenWithoutAudience = null;
+	private Jwt tokenWithAudience;
+	private Jwt tokenWithoutAudience;
+	private XsuaaServiceConfiguration serviceConfigurationSameClientId;
+	private XsuaaServiceConfiguration serviceConfigurationOtherGrantedClientId;
+	private XsuaaServiceConfiguration serviceConfigurationUnGrantedClientId;
+	private JWTClaimsSet.Builder claimsBuilder;
 
 	@Before
 	public void setup() throws Exception {
+		serviceConfigurationSameClientId = new DummyXsuaaServiceConfiguration("sb-test1!t1", "test1!t1");
+		serviceConfigurationOtherGrantedClientId = new DummyXsuaaServiceConfiguration("sb-test2!t1", "test2!t1");
+		serviceConfigurationUnGrantedClientId = new DummyXsuaaServiceConfiguration("sb-test3!t1", "test3!t1");
+
 		tokenWithAudience = JwtGenerator.createFromTemplate("/audience_1.txt");
-		tokenWithoutAudience= JwtGenerator.createFromTemplate("/audience_2.txt");
+		tokenWithoutAudience = JwtGenerator.createFromTemplate("/audience_2.txt");
+
+		claimsBuilder = new JWTClaimsSet.Builder().issueTime(new Date()).expirationTime(JwtGenerator.NO_EXPIRE);
 	}
+
 	@Test
-	public void testSameClientId()
-	{
-		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test1!t1","test1!t1")).validate(tokenWithAudience);
+	public void testSameClientId() {
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationSameClientId).validate(tokenWithAudience);
 		Assert.assertFalse(result.hasErrors());
 	}
 
 	@Test
-	public void testSameClientIdWithoutAudience()
-	{
-		OAuth2TokenValidatorResult result2 = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test1!t1","test1!t1")).validate(tokenWithoutAudience);
+	public void testSameClientIdWithoutAudience() {
+		OAuth2TokenValidatorResult result2 = new XsuaaAudienceValidator(serviceConfigurationSameClientId).validate(tokenWithoutAudience);
 		Assert.assertFalse(result2.hasErrors());
 	}
 
 	@Test
-	public void testOtherGrantedClientId()
-	{
-		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test2!t1","test2!t1")).validate(tokenWithAudience);
-		Assert.assertFalse(result.hasErrors());
-	}
-	@Test
-	public void testOtherGrantedClientIdWithoutAudience()
-	{
-		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test2!t1","test2!t1")).validate(tokenWithoutAudience);
+	public void testOtherGrantedClientIdWithoutAudience() {
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationOtherGrantedClientId).validate(tokenWithoutAudience);
 		Assert.assertFalse(result.hasErrors());
 	}
 
 	@Test
-	public void testOtherGrantedClientIdWithoutAudienceAndDot()
-	{
-		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test4!t1","test4!t1")).validate(tokenWithAudience);
+	public void testOtherGrantedClientIdWithoutAudienceAndDot() {
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test4!t1", "test4!t1")).validate(tokenWithAudience);
 		Assert.assertFalse(result.hasErrors());
 	}
 
 	@Test
-	public void testUnGrantedClientId()
-	{
-		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test3!t1","test3!t1")).validate(tokenWithAudience);
+	public void testOtherGrantedClientId() {
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationUnGrantedClientId).validate(tokenWithAudience);
 		Assert.assertTrue(result.hasErrors());
 	}
 
+	@Test
+	public void testUnGrantedClientId() {
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationUnGrantedClientId).validate(tokenWithAudience);
+		Assert.assertTrue(result.hasErrors());
+	}
 
-	class DummyXsuaaServiceConfiguration implements XsuaaServiceConfiguration
-	{
+	@Test
+	public void testOtherGrantedClientIdWithoutAudienceButScopes() throws Exception {
+		List<String> scopes = new ArrayList<String>();
+		scopes.add("test2!t1.Display");
+		claimsBuilder.claim(Token.CLAIM_SCOPES, scopes);
+
+		Jwt tokenWithoutAudienceButScopes = JwtGenerator.createFromClaims(claimsBuilder.build());
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationOtherGrantedClientId).validate(tokenWithoutAudienceButScopes);
+		Assert.assertFalse(result.hasErrors());
+	}
+
+	@Test
+	public void testOtherGrantedClientIdWithoutAudienceAndMatchingScopes() throws Exception {
+		List<String> scopes = new ArrayList<String>();
+		scopes.add("test3!t1.Display");
+		claimsBuilder.claim(Token.CLAIM_SCOPES, scopes);
+
+		Jwt tokenWithoutAudienceButScopes = JwtGenerator.createFromClaims(claimsBuilder.build());
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationOtherGrantedClientId).validate(tokenWithoutAudienceButScopes);
+		Assert.assertTrue(result.hasErrors());
+	}
+
+	@Test
+	public void testOtherGrantedClientIdWithoutAudienceAndScopes() throws Exception {
+		Jwt tokenWithoutAudienceAndScopes = JwtGenerator.createFromClaims(claimsBuilder.build());
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationOtherGrantedClientId).validate(tokenWithoutAudienceAndScopes);
+		Assert.assertTrue(result.hasErrors());
+	}
+
+	@Test
+	public void testOtherGrantedClientIdWithoutAudienceAndEmptyScopes() throws Exception {
+		claimsBuilder.claim(Token.CLAIM_SCOPES, "[]");
+		Jwt tokenWithoutAudienceAndScopes = JwtGenerator.createFromClaims(claimsBuilder.build());
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationOtherGrantedClientId).validate(tokenWithoutAudienceAndScopes);
+		Assert.assertTrue(result.hasErrors());
+	}
+
+	class DummyXsuaaServiceConfiguration implements XsuaaServiceConfiguration {
 
 		String clientId;
 		String xsAppId;
@@ -72,6 +118,7 @@ public class XsuaaAudienceValidatorTest {
 			this.clientId = clientId;
 			this.xsAppId = xsAppId;
 		}
+
 		@Override
 		public String getClientId() {
 			return clientId;
@@ -96,6 +143,7 @@ public class XsuaaAudienceValidatorTest {
 		public String getAppId() {
 			return xsAppId;
 		}
+
 		@Override
 		public String getUaaDomain() {
 			return null;


### PR DESCRIPTION
added further test cases to eliminate NullPointer exception and other issues, when the claim "scope" is null or empty as part of the JWT token.

fixes #22 