### PR TITLE
Ease enhancability of token converter

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/TokenAuthenticationConverter.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/TokenAuthenticationConverter.java
@@ -1,42 +1,58 @@
+/**
+ * Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
+ * This file is licensed under the Apache Software License,
+ * v. 2 except as noted otherwise in the LICENSE file
+ * https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/LICENSE
+ */
 package com.sap.cloud.security.xsuaa.token;
 
-import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
 
+/**
+ * Converter for xsuaa jwt token that stores authorization data like scopes inside the token.
+ */
 public class TokenAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
-    private String appId;
+	protected String appId;
 
-    public TokenAuthenticationConverter(String appId) {
-        this.appId = appId;
-    }
+	public TokenAuthenticationConverter(String appId) {
+		this.appId = appId;
+	}
 
-    public TokenAuthenticationConverter(XsuaaServiceConfiguration xsuaaServiceConfiguration) {
-        this.appId = xsuaaServiceConfiguration.getAppId();
-    }
+	public TokenAuthenticationConverter(XsuaaServiceConfiguration xsuaaServiceConfiguration) {
+		this.appId = xsuaaServiceConfiguration.getAppId();
+	}
 
-
-    public final AbstractAuthenticationToken convert(Jwt jwt) {
-        Collection<GrantedAuthority> authorities = extractAuthorities(jwt);
-        return new AuthenticationToken(appId, jwt, authorities);
-    }
+	public final AbstractAuthenticationToken convert(Jwt jwt) {
+		return new AuthenticationToken(appId, jwt, extractAuthorities(jwt));
+	}
 
     protected Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
-        Collection<String> scopes = this.getScopes(jwt);
-        return scopes.stream().map(authority -> authority).map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+        Collection<String> scopeAuthorities = getScopes(jwt);
+        Collection<String> otherAuthorities = extractAuthorities(new TokenImpl(jwt, appId));
+
+        Stream<String> authorities = Stream.of(scopeAuthorities, otherAuthorities).flatMap(Collection::stream);
+        return authorities.map(authority -> authority).map(SimpleGrantedAuthority::new).collect(Collectors.toList());
     }
 
-    private Collection<String> getScopes(Jwt jwt) {
-        List<String> scopesList = jwt.getClaimAsStringList(Token.CLAIM_SCOPES);
-        return scopesList != null ? scopesList : Collections.emptyList();
-    }
+	protected Collection<String> extractAuthorities(Token token) {
+        return Collections.emptyList();
+	}
+
+	protected Collection<String> getScopes(Jwt jwt) {
+		List<String> scopesList = jwt.getClaimAsStringList(Token.CLAIM_SCOPES);
+		return scopesList != null ? scopesList : Collections.emptyList();
+	}
 }

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/TokenAuthenticationConverterTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/TokenAuthenticationConverterTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
+ * This file is licensed under the Apache Software License,
+ * v. 2 except as noted otherwise in the LICENSE file
+ * https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/LICENSE
+ */
+package com.sap.cloud.security.xsuaa.token;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+
+public class TokenAuthenticationConverterTest {
+	private JWTClaimsSet.Builder claimsSetBuilder = null;
+	private String xsAppName = "my-app-name!400";
+	private TokenAuthenticationConverter tokenConverter;
+	String scopeAdmin = xsAppName + "." + "Admin";
+	String scopeRead = xsAppName + "." + "Read";
+    private Jwt jwtSamlWithXsUserAttributes;
+
+	@Before
+	public void setup() throws Exception {
+		claimsSetBuilder = new JWTClaimsSet.Builder().issueTime(new Date()).expirationTime(JwtGenerator.NO_EXPIRE);
+		tokenConverter = new TokenAuthenticationConverter(xsAppName);
+        jwtSamlWithXsUserAttributes = JwtGenerator.createFromTemplate("/saml.txt");
+	}
+
+	@Test
+	public void extractAuthoritiesWithoutScopes() throws Exception {
+		Jwt jwt = JwtGenerator.createFromClaims(claimsSetBuilder.build());
+
+		AbstractAuthenticationToken authenticationToken = tokenConverter.convert(jwt);
+		assertThat(authenticationToken.getAuthorities().size(), is(0));
+	}
+
+	@Test
+	public void extractAuthoritiesWithScopes() throws Exception {
+		List<String> scopesList = new ArrayList<>();
+		scopesList.add(scopeAdmin);
+		scopesList.add(scopeRead);
+		claimsSetBuilder.claim(Token.CLAIM_SCOPES, scopesList);
+		Jwt jwt = JwtGenerator.createFromClaims(claimsSetBuilder.build());
+
+		AbstractAuthenticationToken authenticationToken = tokenConverter.convert(jwt);
+		assertThat(authenticationToken.getAuthorities().size(), is(2));
+		assertThat(authenticationToken.getAuthorities(), hasItem(new SimpleGrantedAuthority(scopeRead)));
+		assertThat(authenticationToken.getAuthorities(), hasItem(new SimpleGrantedAuthority(scopeAdmin)));
+	}
+
+	@Test
+	public void extractCustomAuthoritiesWithScopes() throws Exception {
+        tokenConverter = new MyTokenAuthenticationConverter(xsAppName, "cost-center", "country");
+
+		AbstractAuthenticationToken authenticationToken = tokenConverter.convert(jwtSamlWithXsUserAttributes);
+		assertThat(authenticationToken.getAuthorities().size(), is(7));
+		assertThat(authenticationToken.getAuthorities(), hasItem(new SimpleGrantedAuthority("ATTR:COST-CENTER=0815")));
+		assertThat(authenticationToken.getAuthorities(), hasItem(new SimpleGrantedAuthority("ATTR:COST-CENTER=4711")));
+		assertThat(authenticationToken.getAuthorities(), hasItem(new SimpleGrantedAuthority("ATTR:COUNTRY=Germany")));
+        assertThat(authenticationToken.getAuthorities(), hasItem(new SimpleGrantedAuthority("java-hello-world.Delete")));
+	}
+
+	private static class MyTokenAuthenticationConverter extends TokenAuthenticationConverter {
+
+		protected String[] xsUserAttributes;
+
+		public MyTokenAuthenticationConverter(String appId, String... xsUserAttributes) {
+			super(appId);
+			this.xsUserAttributes = xsUserAttributes;
+		}
+
+		@Override
+		protected Collection<String> extractAuthorities(Token token) {
+			Set<String> newAuthorities = new HashSet<>();
+			for (String attribute : xsUserAttributes) {
+				String[] xsUserAttributeValues = token.getXSUserAttribute(attribute);
+				if (xsUserAttributeValues != null) {
+					for (String xsUserAttributeValue : xsUserAttributeValues) {
+						newAuthorities.add(getSidForAttributeValue(attribute, xsUserAttributeValue));
+					}
+				}
+			}
+			return newAuthorities;
+		}
+
+		public static String getSidForAttributeValue(String attributeName, String attributeValue) {
+			return "ATTR:" + attributeName.toUpperCase() + "=" + attributeValue;
+		}
+	}
+}

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidatorTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidatorTest.java
@@ -1,69 +1,115 @@
 package com.sap.cloud.security.xsuaa.token.authentication;
 
-import com.sap.cloud.security.xsuaa.token.JwtGenerator;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jwt.Jwt;
 
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
-
+import com.sap.cloud.security.xsuaa.token.JwtGenerator;
+import com.sap.cloud.security.xsuaa.token.Token;
 
 public class XsuaaAudienceValidatorTest {
 
-	private Jwt tokenWithAudience = null;
-	private Jwt tokenWithoutAudience = null;
+	private Jwt tokenWithAudience;
+	private Jwt tokenWithoutAudience;
+	private XsuaaServiceConfiguration serviceConfigurationSameClientId;
+	private XsuaaServiceConfiguration serviceConfigurationOtherGrantedClientId;
+	private XsuaaServiceConfiguration serviceConfigurationUnGrantedClientId;
+	private JWTClaimsSet.Builder claimsBuilder;
 
 	@Before
 	public void setup() throws Exception {
+		serviceConfigurationSameClientId = new DummyXsuaaServiceConfiguration("sb-test1!t1", "test1!t1");
+		serviceConfigurationOtherGrantedClientId = new DummyXsuaaServiceConfiguration("sb-test2!t1", "test2!t1");
+		serviceConfigurationUnGrantedClientId = new DummyXsuaaServiceConfiguration("sb-test3!t1", "test3!t1");
+
 		tokenWithAudience = JwtGenerator.createFromTemplate("/audience_1.txt");
-		tokenWithoutAudience= JwtGenerator.createFromTemplate("/audience_2.txt");
+		tokenWithoutAudience = JwtGenerator.createFromTemplate("/audience_2.txt");
+
+		claimsBuilder = new JWTClaimsSet.Builder().issueTime(new Date()).expirationTime(JwtGenerator.NO_EXPIRE);
 	}
+
 	@Test
-	public void testSameClientId()
-	{
-		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test1!t1","test1!t1")).validate(tokenWithAudience);
+	public void testSameClientId() {
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationSameClientId).validate(tokenWithAudience);
 		Assert.assertFalse(result.hasErrors());
 	}
 
 	@Test
-	public void testSameClientIdWithoutAudience()
-	{
-		OAuth2TokenValidatorResult result2 = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test1!t1","test1!t1")).validate(tokenWithoutAudience);
+	public void testSameClientIdWithoutAudience() {
+		OAuth2TokenValidatorResult result2 = new XsuaaAudienceValidator(serviceConfigurationSameClientId).validate(tokenWithoutAudience);
 		Assert.assertFalse(result2.hasErrors());
 	}
 
 	@Test
-	public void testOtherGrantedClientId()
-	{
-		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test2!t1","test2!t1")).validate(tokenWithAudience);
-		Assert.assertFalse(result.hasErrors());
-	}
-	@Test
-	public void testOtherGrantedClientIdWithoutAudience()
-	{
-		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test2!t1","test2!t1")).validate(tokenWithoutAudience);
+	public void testOtherGrantedClientIdWithoutAudience() {
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationOtherGrantedClientId).validate(tokenWithoutAudience);
 		Assert.assertFalse(result.hasErrors());
 	}
 
 	@Test
-	public void testOtherGrantedClientIdWithoutAudienceAndDot()
-	{
-		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test4!t1","test4!t1")).validate(tokenWithAudience);
+	public void testOtherGrantedClientIdWithoutAudienceAndDot() {
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test4!t1", "test4!t1")).validate(tokenWithAudience);
 		Assert.assertFalse(result.hasErrors());
 	}
 
 	@Test
-	public void testUnGrantedClientId()
-	{
-		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(new DummyXsuaaServiceConfiguration("sb-test3!t1","test3!t1")).validate(tokenWithAudience);
+	public void testOtherGrantedClientId() {
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationUnGrantedClientId).validate(tokenWithAudience);
 		Assert.assertTrue(result.hasErrors());
 	}
 
+	@Test
+	public void testUnGrantedClientId() {
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationUnGrantedClientId).validate(tokenWithAudience);
+		Assert.assertTrue(result.hasErrors());
+	}
 
-	class DummyXsuaaServiceConfiguration implements XsuaaServiceConfiguration
-	{
+	@Test
+	public void testOtherGrantedClientIdWithoutAudienceButScopes() throws Exception {
+		List<String> scopes = new ArrayList<String>();
+		scopes.add("test2!t1.Display");
+		claimsBuilder.claim(Token.CLAIM_SCOPES, scopes);
+
+		Jwt tokenWithoutAudienceButScopes = JwtGenerator.createFromClaims(claimsBuilder.build());
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationOtherGrantedClientId).validate(tokenWithoutAudienceButScopes);
+		Assert.assertFalse(result.hasErrors());
+	}
+
+	@Test
+	public void testOtherGrantedClientIdWithoutAudienceAndMatchingScopes() throws Exception {
+		List<String> scopes = new ArrayList<String>();
+		scopes.add("test3!t1.Display");
+		claimsBuilder.claim(Token.CLAIM_SCOPES, scopes);
+
+		Jwt tokenWithoutAudienceButScopes = JwtGenerator.createFromClaims(claimsBuilder.build());
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationOtherGrantedClientId).validate(tokenWithoutAudienceButScopes);
+		Assert.assertTrue(result.hasErrors());
+	}
+
+	@Test
+	public void testOtherGrantedClientIdWithoutAudienceAndScopes() throws Exception {
+		Jwt tokenWithoutAudienceAndScopes = JwtGenerator.createFromClaims(claimsBuilder.build());
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationOtherGrantedClientId).validate(tokenWithoutAudienceAndScopes);
+		Assert.assertTrue(result.hasErrors());
+	}
+
+	@Test
+	public void testOtherGrantedClientIdWithoutAudienceAndEmptyScopes() throws Exception {
+		claimsBuilder.claim(Token.CLAIM_SCOPES, "[]");
+		Jwt tokenWithoutAudienceAndScopes = JwtGenerator.createFromClaims(claimsBuilder.build());
+		OAuth2TokenValidatorResult result = new XsuaaAudienceValidator(serviceConfigurationOtherGrantedClientId).validate(tokenWithoutAudienceAndScopes);
+		Assert.assertTrue(result.hasErrors());
+	}
+
+	class DummyXsuaaServiceConfiguration implements XsuaaServiceConfiguration {
 
 		String clientId;
 		String xsAppId;
@@ -72,6 +118,7 @@ public class XsuaaAudienceValidatorTest {
 			this.clientId = clientId;
 			this.xsAppId = xsAppId;
 		}
+
 		@Override
 		public String getClientId() {
 			return clientId;
@@ -96,6 +143,7 @@ public class XsuaaAudienceValidatorTest {
 		public String getAppId() {
 			return xsAppId;
 		}
+
 		@Override
 		public String getUaaDomain() {
 			return null;


### PR DESCRIPTION
Right now, it is a hard job to enhance the `TokenAuthenticationConverter` so that it also extracts other things from the jwt token, such as `xs.user.attributes`....

fixes #23 