### PR TITLE
Introduce mvn formatter goal and other fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,17 +132,6 @@
 								</execution>
 							</executions>
 						</plugin>
-						<!--<plugins>-->
-						<!--<plugin>-->
-						<!--<groupId>org.apache.maven.plugins</groupId>-->
-						<!--<artifactId>maven-compiler-plugin</artifactId>-->
-						<!--<version>3.7.0</version>-->
-						<!--<configuration>-->
-						<!--<source>1.8</source>-->
-						<!--<target>1.8</target>-->
-						<!--</configuration>-->
-						<!--</plugin>-->
-						<!--</plugins>-->
 					</plugins>
 				</pluginManagement>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,9 @@
 	</distributionManagement>
 
 	<properties>
+		<project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<spring.core.version>5.1.1.RELEASE</spring.core.version>
 		<junit.version>4.12</junit.version>
 		<maven.compiler.target>1.8</maven.compiler.target>
@@ -84,19 +86,65 @@
 							<artifactId>maven-javadoc-plugin</artifactId>
 							<version>3.0.1</version>
 						</plugin>
+
+						<plugin>
+							<groupId>net.revelc.code.formatter</groupId>
+							<artifactId>formatter-maven-plugin</artifactId>
+							<version>2.8.1</version>
+							<configuration>
+								<encoding>${project.build.sourceEncoding}</encoding>
+								<lineEnding>LF</lineEnding>
+								<directories>
+									<directory>${project.basedir}/src/main/java</directory>
+									<directory>${project.basedir}/src/test/java</directory>
+								</directories>
+								<configFile>${project.basedir}/../etc/eclipse_settings.xml</configFile>
+							</configuration>
+							<executions>
+								<execution>
+									<phase>process-sources</phase>
+									<goals>
+										<goal>format</goal>
+									</goals>
+								</execution>
+							</executions>
+						</plugin>
+
+						<plugin>
+							<groupId>net.revelc.code</groupId>
+							<artifactId>impsort-maven-plugin</artifactId>
+							<version>1.2.0</version>
+							<configuration>
+								<groups>java.,javax.,org.,com.</groups>
+								<staticGroups>java,*</staticGroups>
+								<staticAfter>false</staticAfter>
+								<removeUnused>true</removeUnused>
+								<excludes>
+									<exclude>**/test/resources/**</exclude>
+								</excludes>
+							</configuration>
+							<executions>
+								<execution>
+									<id>sort-imports</id>
+									<goals>
+										<goal>sort</goal>
+									</goals>
+								</execution>
+							</executions>
+						</plugin>
+						<!--<plugins>-->
+						<!--<plugin>-->
+						<!--<groupId>org.apache.maven.plugins</groupId>-->
+						<!--<artifactId>maven-compiler-plugin</artifactId>-->
+						<!--<version>3.7.0</version>-->
+						<!--<configuration>-->
+						<!--<source>1.8</source>-->
+						<!--<target>1.8</target>-->
+						<!--</configuration>-->
+						<!--</plugin>-->
+						<!--</plugins>-->
 					</plugins>
 				</pluginManagement>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.7.0</version>
-						<configuration>
-							<source>1.8</source>
-							<target>1.8</target>
-						</configuration>
-					</plugin>
-				</plugins>
 			</build>
 		</profile>
 		<profile>

--- a/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/XsuaaMockWebServer.java
+++ b/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/XsuaaMockWebServer.java
@@ -25,8 +25,10 @@ public class XsuaaMockWebServer extends PropertySource<MockWebServer> implements
 	}
 
 	/**
-	 * Overwrites the dispatcher used to match incoming requests to mock responses. The default dispatcher simply serves a fixed sequence of responses
-	 * from a queue; custom dispatchers can vary the response based on timing or the content of the request.
+	 * Overwrites the dispatcher used to match incoming requests to mock responses.
+	 * The default dispatcher simply serves a fixed sequence of responses from a
+	 * queue; custom dispatchers can vary the response based on timing or the
+	 * content of the request.
 	 *
 	 * @param dispatcher
 	 *            the dispatcher to be used
@@ -69,7 +71,8 @@ public class XsuaaMockWebServer extends PropertySource<MockWebServer> implements
 		try {
 			mockWebServer.start();
 			this.started = true;
-			logger.warn(">>>>>>>>>>>Started Xsuaa mock Server that provides public keys for offline JWT Token validation. NEVER run in productive environment!<<<<<<");
+			logger.warn(
+					">>>>>>>>>>>Started Xsuaa mock Server that provides public keys for offline JWT Token validation. NEVER run in productive environment!<<<<<<");
 		} catch (IOException e) {
 			throw new RuntimeException("Could not start XSUAA mock webserver" + mockWebServer, e);
 		}

--- a/spring-xsuaa-mock/src/test/java/com/sap/cloud/security/xsuaa/mock/ApplicationTest.java
+++ b/spring-xsuaa-mock/src/test/java/com/sap/cloud/security/xsuaa/mock/ApplicationTest.java
@@ -6,7 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(properties = { "xsuaa.url=${mockxsuaaserver.url}", "xsuaa.identityzoneid= uaa" }, classes = { XsuaaMockWebServer.class, XsuaaRequestDispatcher.class })
+@SpringBootTest(properties = { "xsuaa.url=${mockxsuaaserver.url}", "xsuaa.identityzoneid= uaa" }, classes = {
+		XsuaaMockWebServer.class, XsuaaRequestDispatcher.class })
 public class ApplicationTest {
 
 	@Test

--- a/spring-xsuaa-mock/src/test/java/com/sap/cloud/security/xsuaa/mock/XsuaaMockWebServerSpringBootTest.java
+++ b/spring-xsuaa-mock/src/test/java/com/sap/cloud/security/xsuaa/mock/XsuaaMockWebServerSpringBootTest.java
@@ -31,15 +31,18 @@ public class XsuaaMockWebServerSpringBootTest {
 
 	@Test
 	public void xsuaaMockStarted() throws URISyntaxException {
-		ResponseEntity<String> response = restTemplate.getForEntity(new URI(xsuaaMockServerUrl + "/token_keys"), String.class);
+		ResponseEntity<String> response = restTemplate.getForEntity(new URI(xsuaaMockServerUrl + "/token_keys"),
+				String.class);
 		Assert.assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
 		Assert.assertThat(response.getBody(), notNullValue());
 	}
 
 	@Test
 	public void xsuaaMockReturnsTestDomainTokenKeys() throws Exception {
-		ResponseEntity<String> response = restTemplate.getForEntity(new URI(xsuaaMockServerUrl + "/testdomain/token_keys"), String.class);
-		String testdomainTokenKeys = IOUtils.resourceToString("/mock/testdomain_token_keys.json", StandardCharsets.UTF_8);
+		ResponseEntity<String> response = restTemplate
+				.getForEntity(new URI(xsuaaMockServerUrl + "/testdomain/token_keys"), String.class);
+		String testdomainTokenKeys = IOUtils.resourceToString("/mock/testdomain_token_keys.json",
+				StandardCharsets.UTF_8);
 		Assert.assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
 		Assert.assertThat(response.getBody(), containsString("keys"));
 		Assert.assertThat(response.getBody(), containsString("legacy-token-key-testdomain"));
@@ -48,12 +51,14 @@ public class XsuaaMockWebServerSpringBootTest {
 
 	@Test(expected = HttpClientErrorException.class)
 	public void xsuaaMockReturnsNotFound() throws URISyntaxException {
-		ResponseEntity<String> response = restTemplate.getForEntity(new URI(xsuaaMockServerUrl + "/anyNotSupportedPath"), String.class);
+		ResponseEntity<String> response = restTemplate
+				.getForEntity(new URI(xsuaaMockServerUrl + "/anyNotSupportedPath"), String.class);
 	}
 
 	@Test
 	public void xsuaaMockReturnsCustomResponse() throws URISyntaxException {
-		ResponseEntity<String> response = restTemplate.getForEntity(new URI(xsuaaMockServerUrl + "/customdomain/token_keys"), String.class);
+		ResponseEntity<String> response = restTemplate
+				.getForEntity(new URI(xsuaaMockServerUrl + "/customdomain/token_keys"), String.class);
 		Assert.assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
 		Assert.assertThat(response.getBody(), containsString("legacy-token-key-customdomain"));
 	}

--- a/spring-xsuaa-test/README.md
+++ b/spring-xsuaa-test/README.md
@@ -12,7 +12,7 @@ This includes for example a `JwtGenerator` that generates JSON Web Tokens (JWT) 
 
  All of them are returned as [`Jwt`](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/oauth2/jwt/Jwt.html), which offers you a `getTokenValue()` method that returns the encoded and signed Jwt token. You need to prefix this one with `Bearer ` in case you like to provide it via `Authorization` header to your application.
 
- > In most cases the Jwt gets Base64 encoded and signed with this [private key](/src/main/resources/privateKey.txt).
+ > In most cases the Jwt gets Base64 encoded and signed with this [private key](src/main/resources/privateKey.txt).
 
 
 ## Requirements
@@ -43,3 +43,12 @@ This includes for example a `JwtGenerator` that generates JSON Web Tokens (JWT) 
 
 ## Usage
 Find examples on how to use the `JwtGenerator` [here](src/test/java/com/sap/cloud/security/xsuaa/test/JwtGeneratorTest.java).
+
+### Troubleshoot
+
+#### Jwt validation fails because of missing audience
+```
+DEBUG .o.s.r.w.BearerTokenAuthenticationFilter : Authentication request for failed: org.springframework.security.oauth2.core.OAuth2AuthenticationException: An error occurred while attempting to decode the Jwt: Missing audience
+```
+
+This can have different causes. The first one is obvious, your JWT token lacks of `aud` claim which contains the application names of the scopes. Make sure, that you've configured the `JwtGenerator` appropriately. Secondly make sure, that the xs application name, your scopes are prefixed with, is provided either via `VCAP_SERVICES` system environment variable or via properties e.g. `xsuaa.xsappname=xsapplication!t895`

--- a/spring-xsuaa-test/README.md
+++ b/spring-xsuaa-test/README.md
@@ -22,12 +22,22 @@ This includes for example a `JwtGenerator` that generates JSON Web Tokens (JWT) 
 
 ## Configuration
 
-### Maven Dependency
+### Maven Dependencies
 ```xml
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa-test</artifactId>
     <version>1.2.0</version>
+</dependency>
+<dependency>
+    <groupId>commons-io</groupId>
+    <artifactId>commons-io</artifactId>
+    <version>2.6</version>
+</dependency>
+<dependency>
+    <groupId>org.springframework.security</groupId>
+    <artifactId>spring-security-oauth2-jose</artifactId>
+    <version>5.1.1.RELEASE</version>
 </dependency>
 ```
 

--- a/spring-xsuaa-test/src/main/java/com/sap/cloud/security/xsuaa/test/JwtGenerator.java
+++ b/spring-xsuaa-test/src/main/java/com/sap/cloud/security/xsuaa/test/JwtGenerator.java
@@ -22,7 +22,7 @@ import com.nimbusds.jwt.JWTParser;
  */
 public class JwtGenerator {
 
-	public static final Date NO_EXPIRE_DATE = new Date(Long.MAX_VALUE);
+	public static final Date NO_EXPIRE_DATE = new GregorianCalendar(2190, 12, 31).getTime();
 	public static final int NO_EXPIRE = Integer.MAX_VALUE;
 	public static final String CLIENT_ID = "sb-xsapplication!t895";
 	public static final String IDENTITY_ZONE_ID = "uaa"; // must be 'uaa' to make use of mockserver (see


### PR DESCRIPTION
### About

This change relates to @sawoz  proposal of making use of these two maven plugins:
- [Maven `code.revelc.net-formatter` plugin](https://code.revelc.net/formatter-maven-plugin/usage.html)  that considers [our formatting settings](https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/etc/eclipse_settings.xml) 
- [Maven `code.revelc.net-impSort` plugin](https://code.revelc.net/impsort-maven-plugin/index.html) to ensure import ordering and removal of unused imports

I've applied the formatting only on "my" modules `spring-xsuaa-test` and  `spring-xsuaa-mock`. There is no difference now from applying it as part of my Ide.

### Usage
use on the command line on top level or as part of sub module:
```
mvn formatter:format
```

### Issues related / fixed
fixes #44 
refers to #42
fixes #54  

### TODOs
- [x] discuss final solution
- [ ] apply this to all remaining sub modules
- [ ] specify Contributions
