### PR TITLE
extractToken should support oauth and/or client credentials

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/extractor/TokenBrokerResolver.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/extractor/TokenBrokerResolver.java
@@ -17,6 +17,7 @@ import org.springframework.cache.Cache;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
+import org.springframework.util.StringUtils;
 
 /**
  * Analyse authentication header and obtain token from UAA
@@ -105,7 +106,10 @@ public class TokenBrokerResolver implements BearerTokenResolver {
 		for (AuthenticationMethod credentialType : authenticationMethods) {
 			Enumeration<String> headers = request.getHeaders(AUTHORIZATION_HEADER);
 			String token = getBrokerToken(credentialType, headers, oauthTokenUrl);
-			return token;
+			// TODO add test case in BasicCredentialExtractorTest
+			if (!StringUtils.isEmpty(token)) {
+				return token;
+			}
 		}
 		return null;
 	}

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/extractor/TokenBrokerResolver.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/extractor/TokenBrokerResolver.java
@@ -106,7 +106,6 @@ public class TokenBrokerResolver implements BearerTokenResolver {
 		for (AuthenticationMethod credentialType : authenticationMethods) {
 			Enumeration<String> headers = request.getHeaders(AUTHORIZATION_HEADER);
 			String token = getBrokerToken(credentialType, headers, oauthTokenUrl);
-			// TODO add test case in BasicCredentialExtractorTest
 			if (!StringUtils.isEmpty(token)) {
 				return token;
 			}


### PR DESCRIPTION
With this change two kind of tokens are supported: Oauth and basic/client-credentials.

E.g. in case the "Authorization" header is not provided, and basic or client-credentials is supported it tries to return the password or client-credentials token.