### PR TITLE
Initialization of Spring SecurityContext for non HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## 1.4.0
 * API method to query [token validity](https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/Token.java#L167)
 * Bugfix in basic authentication support: allow  usage of JWT token or basic authentication with one configuration
+* Allow applications to initialize of Spring SecurityContext for non HTTP requests. As documented [here](https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/spring-xsuaa/README.md)
+
 ## 1.3.1
 * Broker plan validation failed due to incorrect audience validation
 ## 1.3.0

--- a/spring-xsuaa-it/pom.xml
+++ b/spring-xsuaa-it/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.0.RELEASE</version>
+		<version>2.1.4.RELEASE</version>
 		<relativePath />
 	</parent>
 
@@ -18,7 +18,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Finchley.RELEASE</spring-cloud.version>
 	</properties>
 
 	<dependencies>
@@ -42,12 +41,12 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-oauth2-jose</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-config</artifactId>
+			<artifactId>spring-security-oauth2-jose</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
@@ -85,18 +84,6 @@
 			<version>1.0.9.RELEASE</version>
 		</dependency>
 	</dependencies>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/spring-xsuaa-it/src/main/java/testservice/api/basic/SecurityConfiguration.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/basic/SecurityConfiguration.java
@@ -73,7 +73,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 	}
 
 	@Bean
-	JwtDecoder jwtDecoder() throws MalformedURLException {
+	JwtDecoder jwtDecoder() {
 		return new XsuaaJwtDecoderBuilder(getXsuaaServiceConfiguration()).build();
 	}
 

--- a/spring-xsuaa-it/src/main/java/testservice/api/basic/SecurityConfiguration.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/basic/SecurityConfiguration.java
@@ -38,9 +38,9 @@ import com.sap.cloud.security.xsuaa.mock.MockXsuaaServiceConfiguration;
 import com.sap.cloud.security.xsuaa.token.TokenAuthenticationConverter;
 import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
 
-@Profile({ "test.api.basic" })
 @EnableWebSecurity
 @EnableCaching
+@Profile({ "test.api.basic" })
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	public static TokenBrokerResolver tokenBrokerResolver; // make static for tests
@@ -62,7 +62,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 		// @formatter:on
 	}
 
-	Converter<Jwt, AbstractAuthenticationToken> getJwtAuthenticationConverter() throws MalformedURLException {
+	Converter<Jwt, AbstractAuthenticationToken> getJwtAuthenticationConverter() {
 		TokenAuthenticationConverter converter = new TokenAuthenticationConverter(getXsuaaServiceConfiguration());
 		return converter;
 	}

--- a/spring-xsuaa-it/src/main/java/testservice/api/basic/TestController.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/basic/TestController.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -38,6 +39,7 @@ import com.sap.xs2.security.container.XSTokenRequestImpl;
 import com.sap.xsa.security.container.XSTokenRequest;
 
 @RestController
+@Profile({ "test.api.basic" })
 public class TestController {
 
 	@Value("${mockxsuaaserver.url}")

--- a/spring-xsuaa-it/src/main/java/testservice/api/nohttp/MyEventHandler.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/nohttp/MyEventHandler.java
@@ -1,4 +1,49 @@
 package testservice.api.nohttp;
 
+import java.util.Collection;
+
+import com.sap.xs2.security.container.SecurityContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile({ "test.api.nohttp" })
 public class MyEventHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MyEventHandler.class);
+
+    @Value("${xsuaa.xsappname}")
+    String xsappname;
+
+    @Autowired
+    JwtDecoder jwtDecoder;
+
+    public void onEvent(String myEncodedJwtToken) {
+        if(myEncodedJwtToken != null) {
+            Jwt jwtToken = jwtDecoder.decode(myEncodedJwtToken);
+            SecurityContext.init(xsappname, jwtToken, true);
+        }
+        try {
+            handleEvent();
+        } finally {
+            SecurityContext.clear();
+        }
+    }
+
+    void handleEvent() {
+        Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) SecurityContext.getToken()
+                .getAuthorities();
+        if (!authorities.contains(new SimpleGrantedAuthority("Display"))) {
+            throw new AccessDeniedException("Missing Authorization.");
+        }
+        LOGGER.info("Event handled properly");
+    }
 }

--- a/spring-xsuaa-it/src/main/java/testservice/api/nohttp/MyEventHandler.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/nohttp/MyEventHandler.java
@@ -1,0 +1,4 @@
+package testservice.api.nohttp;
+
+public class MyEventHandler {
+}

--- a/spring-xsuaa-it/src/main/java/testservice/api/nohttp/SecurityConfiguration.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/nohttp/SecurityConfiguration.java
@@ -17,14 +17,10 @@ package testservice.api.nohttp;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
 import com.sap.cloud.security.xsuaa.mock.MockXsuaaServiceConfiguration;
-import com.sap.cloud.security.xsuaa.token.TokenAuthenticationConverter;
 import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 @Profile({ "test.api.nohttp" })
@@ -39,12 +35,6 @@ public class SecurityConfiguration {
 	@Bean
 	JwtDecoder jwtDecoder() {
 		return new XsuaaJwtDecoderBuilder(getXsuaaServiceConfiguration()).build();
-	}
-
-	Converter<Jwt, AbstractAuthenticationToken> getJwtAuthenticationConverter() {
-		TokenAuthenticationConverter converter = new TokenAuthenticationConverter(getXsuaaServiceConfiguration());
-		converter.setLocalScopeAsAuthorities(true);
-		return converter;
 	}
 
 }

--- a/spring-xsuaa-it/src/main/java/testservice/api/nohttp/SecurityConfiguration.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/nohttp/SecurityConfiguration.java
@@ -15,16 +15,18 @@
  */
 package testservice.api.nohttp;
 
-import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
-import com.sap.cloud.security.xsuaa.mock.MockXsuaaServiceConfiguration;
-import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
-@Profile({ "test.api.nohttp" })
+import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
+import com.sap.cloud.security.xsuaa.mock.MockXsuaaServiceConfiguration;
+import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
+
 @Configuration
+// @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
+@Profile({ "test.api.nohttp" })
 public class SecurityConfiguration {
 
 	@Bean

--- a/spring-xsuaa-it/src/main/java/testservice/api/nohttp/SecurityConfiguration.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/nohttp/SecurityConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testservice.api.nohttp;
+
+import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
+import com.sap.cloud.security.xsuaa.mock.MockXsuaaServiceConfiguration;
+import com.sap.cloud.security.xsuaa.token.TokenAuthenticationConverter;
+import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+@Profile({ "test.api.nohttp" })
+@Configuration
+public class SecurityConfiguration {
+
+	@Bean
+	XsuaaServiceConfiguration getXsuaaServiceConfiguration() {
+		return new MockXsuaaServiceConfiguration();
+	}
+
+	@Bean
+	JwtDecoder jwtDecoder() {
+		return new XsuaaJwtDecoderBuilder(getXsuaaServiceConfiguration()).build();
+	}
+
+	Converter<Jwt, AbstractAuthenticationToken> getJwtAuthenticationConverter() {
+		TokenAuthenticationConverter converter = new TokenAuthenticationConverter(getXsuaaServiceConfiguration());
+		converter.setLocalScopeAsAuthorities(true);
+		return converter;
+	}
+
+}

--- a/spring-xsuaa-it/src/main/java/testservice/api/v1/SecurityConfiguration.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/v1/SecurityConfiguration.java
@@ -30,8 +30,8 @@ import com.sap.cloud.security.xsuaa.mock.MockXsuaaServiceConfiguration;
 import com.sap.cloud.security.xsuaa.token.TokenAuthenticationConverter;
 import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
 
-@Profile({ "test.api.v1" })
 @EnableWebSecurity
+@Profile({ "test.api.v1" })
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Override

--- a/spring-xsuaa-it/src/main/java/testservice/api/v1/TestController.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/v1/TestController.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -22,6 +23,7 @@ import com.sap.xs2.security.container.XSTokenRequestImpl;
 import com.sap.xsa.security.container.XSTokenRequest;
 
 @RestController
+@Profile({ "test.api.v1" })
 public class TestController {
 
 	@Value("${mockxsuaaserver.url}")

--- a/spring-xsuaa-it/src/main/resources/application-uaamock.yml
+++ b/spring-xsuaa-it/src/main/resources/application-uaamock.yml
@@ -1,0 +1,3 @@
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri: ${mockxsuaaserver.url}/token_keys
+xsuaa:
+  url: '${mockxsuaaserver.url}'

--- a/spring-xsuaa-it/src/main/resources/application.yml
+++ b/spring-xsuaa-it/src/main/resources/application.yml
@@ -1,2 +1,5 @@
 server:
   port: 9999
+xsuaa:
+  xsappname: 'java-hello-world'
+  clientid: 'sb-java-hello-world'

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/BasicCredentialExtractorTest.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/BasicCredentialExtractorTest.java
@@ -11,10 +11,7 @@ import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/InitializeSecurityContextTest.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/InitializeSecurityContextTest.java
@@ -1,0 +1,95 @@
+package com.sap.cloud.security.xsuaa.token.authentication;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.sap.cloud.security.xsuaa.test.JwtGenerator;
+import com.sap.cloud.security.xsuaa.token.Token;
+import com.sap.xs2.security.container.SecurityContext;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import testservice.api.nohttp.SecurityConfiguration;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = {
+		"xsuaa.xsappname=" + InitializeSecurityContextTest.XSAPPNAME,
+		"xsuaa.clientid=" + InitializeSecurityContextTest.CLIENT_ID,
+		"xsuaa.url=${mockxsuaaserver.url}" }, classes = { SecurityConfiguration.class})
+@ActiveProfiles("test.api.nohttp")
+public class InitializeSecurityContextTest {
+
+	static final String XSAPPNAME = "java-hello-world";
+	static final String CLIENT_ID = "sb-" + XSAPPNAME;
+
+	@Autowired
+	JwtDecoder jwtDecoder;
+
+	@Test
+	public void initializeSecurityContext_succeeds() {
+		String jwt = new JwtGenerator(CLIENT_ID, "subdomain")
+				.addScopes("openid", XSAPPNAME + ".Display", "otherXSAPP.Display")
+				.deriveAudiences(true).getToken().getTokenValue();
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication(), is(nullValue()));
+
+		SecurityContext.init(XSAPPNAME, jwtDecoder.decode(jwt), true);
+
+		// test authentication - isAuthenticated()
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		assertThat(authentication, is(notNullValue()));
+		assertThat(authentication.isAuthenticated(), is(true));
+
+		// test authorities
+		Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) authentication.getAuthorities();
+		Assert.assertThat(authorities.size(), is(1));
+		Assert.assertThat(authorities, hasItem(new SimpleGrantedAuthority("Display")));
+		Assert.assertThat(authorities, not(hasItem(new SimpleGrantedAuthority("Other"))));
+
+		// test principal (Token)
+		Token token = (Token)authentication.getPrincipal();
+		assertThat(token.getAuthorities(), is(authorities));
+		assertThat(token.getClientId(), is(CLIENT_ID));
+	}
+
+	@Test
+	public void clearSecurityContext_succeeds() {
+		String jwt = new JwtGenerator(CLIENT_ID, "subdomain").deriveAudiences(true).getToken().getTokenValue();
+
+		SecurityContext.init(XSAPPNAME, jwtDecoder.decode(jwt), true);
+		SecurityContext.clear();
+
+		assertThat(SecurityContextHolder.getContext().getAuthentication(), is(nullValue()));
+	}
+
+	@Test(expected = JwtValidationException.class) // An error occurred while attempting to decode the Jwt: Jwt expired at ...
+	public void decodeExpiredToken_raisesValidationException() {
+		Map customClaims = new HashMap<String, Object>();
+		Instant justOutdated = new Date().toInstant().minusSeconds(3600);
+		customClaims.put("exp", Date.from(justOutdated)); // token should be expired
+		customClaims.put("iat", Date.from(justOutdated.minusSeconds(1000))); // issuedAt must be before expiredAt
+		String jwt = new JwtGenerator(CLIENT_ID, "subdomain").addCustomClaims(customClaims).deriveAudiences(true).getToken().getTokenValue();
+
+		jwtDecoder.decode(jwt);
+	}
+}

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/InitializeSecurityContextTest.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/InitializeSecurityContextTest.java
@@ -67,7 +67,7 @@ public class InitializeSecurityContextTest {
 		Assert.assertThat(authorities, not(hasItem(new SimpleGrantedAuthority("Other"))));
 
 		// test principal (Token)
-		Token token = (Token)authentication.getPrincipal();
+		Token token = (Token)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		assertThat(token.getAuthorities(), is(authorities));
 		assertThat(token.getClientId(), is(CLIENT_ID));
 	}

--- a/spring-xsuaa-it/src/test/java/testservice/api/InitializeSecurityContextTest.java
+++ b/spring-xsuaa-it/src/test/java/testservice/api/InitializeSecurityContextTest.java
@@ -1,4 +1,4 @@
-package com.sap.cloud.security.xsuaa.token.authentication;
+package testservice.api;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -13,14 +13,13 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.sap.cloud.security.xsuaa.test.JwtGenerator;
-import com.sap.cloud.security.xsuaa.token.Token;
-import com.sap.xs2.security.container.SecurityContext;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -29,31 +28,39 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import com.sap.cloud.security.xsuaa.test.JwtGenerator;
+import com.sap.cloud.security.xsuaa.token.Token;
+import com.sap.xs2.security.container.SecurityContext;
+
+import testservice.api.nohttp.MyEventHandler;
 import testservice.api.nohttp.SecurityConfiguration;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(properties = {
-		"xsuaa.xsappname=" + InitializeSecurityContextTest.XSAPPNAME,
-		"xsuaa.clientid=" + InitializeSecurityContextTest.CLIENT_ID,
-		"xsuaa.url=${mockxsuaaserver.url}" }, classes = { SecurityConfiguration.class})
-@ActiveProfiles("test.api.nohttp")
+@SpringBootTest(classes = { SecurityConfiguration.class, MyEventHandler.class })
+@ActiveProfiles({ "test.api.nohttp", "uaamock" })
 public class InitializeSecurityContextTest {
+	@Value("${xsuaa.clientid}")
+	String clientId;
 
-	static final String XSAPPNAME = "java-hello-world";
-	static final String CLIENT_ID = "sb-" + XSAPPNAME;
+	@Value("${xsuaa.xsappname}")
+	String xsappname;
 
 	@Autowired
 	JwtDecoder jwtDecoder;
 
+	@Autowired
+	MyEventHandler eventHandler;
+
 	@Test
 	public void initializeSecurityContext_succeeds() {
-		String jwt = new JwtGenerator(CLIENT_ID, "subdomain")
-				.addScopes("openid", XSAPPNAME + ".Display", "otherXSAPP.Display")
+		String jwt = new JwtGenerator(clientId, "subdomain")
+				.addScopes("openid", xsappname + ".Display", "otherXSAPP.Display")
 				.deriveAudiences(true).getToken().getTokenValue();
 
 		assertThat(SecurityContextHolder.getContext().getAuthentication(), is(nullValue()));
 
-		SecurityContext.init(XSAPPNAME, jwtDecoder.decode(jwt), true);
+		SecurityContext.init(xsappname, jwtDecoder.decode(jwt), true);
 
 		// test authentication - isAuthenticated()
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -67,29 +74,54 @@ public class InitializeSecurityContextTest {
 		Assert.assertThat(authorities, not(hasItem(new SimpleGrantedAuthority("Other"))));
 
 		// test principal (Token)
-		Token token = (Token)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+		Token token = (Token) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		assertThat(token.getAuthorities(), is(authorities));
-		assertThat(token.getClientId(), is(CLIENT_ID));
+		assertThat(token.getClientId(), is(clientId));
 	}
 
 	@Test
 	public void clearSecurityContext_succeeds() {
-		String jwt = new JwtGenerator(CLIENT_ID, "subdomain").deriveAudiences(true).getToken().getTokenValue();
+		String jwt = new JwtGenerator(clientId, "subdomain").deriveAudiences(true).getToken().getTokenValue();
 
-		SecurityContext.init(XSAPPNAME, jwtDecoder.decode(jwt), true);
+		SecurityContext.init(xsappname, jwtDecoder.decode(jwt), true);
 		SecurityContext.clear();
 
 		assertThat(SecurityContextHolder.getContext().getAuthentication(), is(nullValue()));
 	}
 
-	@Test(expected = JwtValidationException.class) // An error occurred while attempting to decode the Jwt: Jwt expired at ...
+	@Test(expected = JwtValidationException.class)
+	// An error occurred while attempting to decode the Jwt: Jwt expired at ...
 	public void decodeExpiredToken_raisesValidationException() {
 		Map customClaims = new HashMap<String, Object>();
 		Instant justOutdated = new Date().toInstant().minusSeconds(3600);
 		customClaims.put("exp", Date.from(justOutdated)); // token should be expired
 		customClaims.put("iat", Date.from(justOutdated.minusSeconds(1000))); // issuedAt must be before expiredAt
-		String jwt = new JwtGenerator(CLIENT_ID, "subdomain").addCustomClaims(customClaims).deriveAudiences(true).getToken().getTokenValue();
+		String jwt = new JwtGenerator(clientId, "subdomain").addCustomClaims(customClaims).deriveAudiences(true)
+				.getToken().getTokenValue();
 
 		jwtDecoder.decode(jwt);
 	}
+
+	@Test
+	public void callEventWithSufficientAuthorization_succeeds() {
+		String jwt = new JwtGenerator(clientId, "subdomain")
+				.addScopes("openid", xsappname + ".Display")
+				.deriveAudiences(true).getToken().getTokenValue();
+
+		eventHandler.onEvent(jwt);
+	}
+
+	@Test(expected = AccessDeniedException.class)
+	public void callEventWithInsufficientAuthorization_raisesAccessDeniedException() {
+		String jwt = new JwtGenerator(clientId, "subdomain")
+				.deriveAudiences(true).getToken().getTokenValue();
+
+		eventHandler.onEvent(jwt);
+	}
+
+	@Test(expected = AccessDeniedException.class)
+	public void callEventWithNoJwtToken_raisesAccessDeniedException() {
+		eventHandler.onEvent(null);
+	}
+
 }

--- a/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/MockXsuaaServiceConfiguration.java
+++ b/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/MockXsuaaServiceConfiguration.java
@@ -3,9 +3,6 @@ package com.sap.cloud.security.xsuaa.mock;
 import org.springframework.beans.factory.annotation.Value;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfigurationDefault;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Profile;
 
 public class MockXsuaaServiceConfiguration extends XsuaaServiceConfigurationDefault {
 

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
@@ -18,6 +18,7 @@ import com.nimbusds.jwt.JWTParser;
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
 
 import net.minidev.json.JSONObject;
+import org.springframework.util.Assert;
 
 public class XsuaaJwtDecoder implements JwtDecoder {
 
@@ -31,6 +32,7 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 
 	@Override
 	public Jwt decode(String token) throws JwtException {
+		Assert.notNull(token, "token is required");
 		try {
 			JWT jwt = JWTParser.parse(token);
 			String subdomain = getSubdomain(jwt);
@@ -39,7 +41,7 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 			JwtDecoder decoder = cache.get(subdomain, k -> this.getDecoder(zid, subdomain));
 			return decoder.decode(token);
 		} catch (ParseException ex) {
-			throw new JwtException("Error initializing JWT  decoder:" + ex.getMessage());
+			throw new JwtException("Error initializing JWT decoder:" + ex.getMessage());
 		}
 	}
 

--- a/spring-xsuaa/src/main/java/com/sap/xs2/security/container/SecurityContext.java
+++ b/spring-xsuaa/src/main/java/com/sap/xs2/security/container/SecurityContext.java
@@ -1,7 +1,11 @@
 package com.sap.xs2.security.container;
 
+import com.sap.cloud.security.xsuaa.token.AuthenticationToken;
+import com.sap.cloud.security.xsuaa.token.TokenAuthenticationConverter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.util.Assert;
 
 import com.sap.cloud.security.xsuaa.token.Token;
@@ -44,4 +48,16 @@ public class SecurityContext {
 		return (Token) principal;
 	}
 
+	static public void init(String appId , Jwt token, boolean extractLocalScopesOnly) {
+		TokenAuthenticationConverter authenticationConverter = new TokenAuthenticationConverter(appId);
+		authenticationConverter.setLocalScopeAsAuthorities(extractLocalScopesOnly);
+		Authentication authentication = authenticationConverter.convert(token);
+
+		SecurityContextHolder.createEmptyContext();
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+
+	static public void clear() {
+		SecurityContextHolder.clearContext();
+	}
 }

--- a/spring-xsuaa/src/main/java/com/sap/xs2/security/container/SecurityContext.java
+++ b/spring-xsuaa/src/main/java/com/sap/xs2/security/container/SecurityContext.java
@@ -2,6 +2,7 @@ package com.sap.xs2.security.container;
 
 import com.sap.cloud.security.xsuaa.token.AuthenticationToken;
 import com.sap.cloud.security.xsuaa.token.TokenAuthenticationConverter;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,10 +37,14 @@ public class SecurityContext {
 	 * Obtain the Token object from the Spring SecurityContext
 	 *
 	 * @return Token object
+	 * @throws AccessDeniedException  in case there is no token, user is not authenticated
 	 */
 	static public Token getToken() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		Assert.state(authentication != null, "Access forbidden: not authenticated");
+
+		if(authentication == null) {
+			throw new AccessDeniedException("Access forbidden: not authenticated");
+		}
 
 		Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		Assert.state(principal != null, "Principal must not be null");


### PR DESCRIPTION
In case of non-HTTP requests, you may need to initialize the Spring SecurityContext with a JWT token you've received from a message or you've requested from XSUAA directly.

**Prerequisite**:   
You need to initialize a `JwtDecoder` bean, as explained [here](https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/samples/spring-security-xsuaa-usage/src/main/java/sample/spring/xsuaa/SecurityConfiguration.java), using the `XsuaaJwtDecoderBuilder` class.

**Then, initialize Security Context**:
```
@Autowired
JwtDecoder jwtDecoder;

public void initializeSecurityContext() {
    Jwt jwtToken = jwtDecoder.decode(<your encoded jwt token String>);
    SecurityContext.init(XSAPPNAME, jwtToken, true);
}
```

By default the SecurityContext is initialized for your current Thread. I.e. you can access the Token from everywhere in your code, that runs in the same Thread:
```
Token token = (Token)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
```

**Finally, clear Security Context**:
Note that `SecurityContextHolder` stores the information in `ThreadLocal`s. That means you should remove current thread's value at the end:
```
SecurityContext.clear();
```