### PR TITLE
add null check to avoid NullPointerException when resource is reactive

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServicePropertySourceFactory.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServicePropertySourceFactory.java
@@ -47,7 +47,8 @@ public class XsuaaServicePropertySourceFactory implements PropertySourceFactory 
 	public PropertySource<?> createPropertySource(String name, EncodedResource resource) throws IOException {
 		XsuaaServicesParser vcapServicesParser = null;
 		if (configurationProperties == null) {
-			if (resource != null && resource.getResource().getFilename().length() > 0) {
+			if (resource != null && resource.getResource().getFilename() != null
+					&& !resource.getResource().getFilename().isEmpty()) {
 				vcapServicesParser = new XsuaaServicesParser(resource.getResource().getInputStream());
 			} else {
 				vcapServicesParser = new XsuaaServicesParser();


### PR DESCRIPTION
Aims to solve issue #77 

Simply adding a `null` check to avoid the `NullPointerException` as explained in the issue. Also changed the expression that checked if the filename was not empty to use the `isEmpty` method.