### PR TITLE
Introduce Spring Boot Auto Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ See [spring-security-xsuaa-usage](samples/spring-security-xsuaa-usage) for an ex
 # Download and Installation
 Build results are published to maven central: https://search.maven.org/search?q=com.sap.cloud.security 
 
-To download and install the this project clone this repository via:
+To download and install this project clone this repository via:
 ```
 git clone https://github.com/SAP/cloud-security-xsuaa-integration
 cd cloud-security-xsuaa-integration
-mvn package
+mvn clean install
 ```
-*Note:* Use this is you want to enhance this xsuaa integration libraries. The buid results are also available on maven central. 
+*Note:* Use this if you want to enhance this xsuaa integration libraries. The build results are also available on maven central.
 
 # Limitations
 Libraries and information provided here is around the topic of integrating with the xsuaa service. General integration into other OAuth authorization servers is not the primary focus.

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<spring.core.version>5.1.1.RELEASE</spring.core.version>
+		<spring.boot.version>2.1.5.RELEASE</spring.boot.version>
 		<junit.version>4.12</junit.version>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/samples/spring-security-basic-auth/README.md
+++ b/samples/spring-security-basic-auth/README.md
@@ -20,7 +20,6 @@ Configure the OAuth resource server by:
 ```java
 @EnableWebSecurity
 @EnableCaching
-@PropertySource(factory = XsuaaServicePropertySourceFactory.class, value = { "" })
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
    @Autowired
@@ -52,15 +51,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         return converter;
    }
 
-   @Bean
-   JwtDecoder jwtDecoder() {
-        return new XsuaaJwtDecoderBuilder(xsuaaServiceConfiguration).build();
-   }
-
-   @Bean
-   XsuaaServiceConfigurationDefault xsuaaConfig() {
-        return new XsuaaServiceConfigurationDefault();
-   }
 }
 ```
 

--- a/samples/spring-security-basic-auth/src/main/java/sample/spring/xsuaa/SecurityConfiguration.java
+++ b/samples/spring-security-basic-auth/src/main/java/sample/spring/xsuaa/SecurityConfiguration.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -27,18 +26,14 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfigurationDefault;
-import com.sap.cloud.security.xsuaa.XsuaaServicePropertySourceFactory;
 import com.sap.cloud.security.xsuaa.extractor.AuthenticationMethod;
 import com.sap.cloud.security.xsuaa.extractor.TokenBrokerResolver;
 import com.sap.cloud.security.xsuaa.token.TokenAuthenticationConverter;
-import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
 
 @EnableWebSecurity
 @EnableCaching
-@PropertySource(factory = XsuaaServicePropertySourceFactory.class, value = { "" })
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Autowired
@@ -73,14 +68,4 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 		return converter;
 	}
 
-
-	@Bean
-	JwtDecoder jwtDecoder() {
-		return new XsuaaJwtDecoderBuilder(xsuaaServiceConfiguration).build();
-	}
-
-	@Bean
-	XsuaaServiceConfigurationDefault xsuaaConfig() {
-		return new XsuaaServiceConfigurationDefault();
-	}
 }

--- a/samples/spring-security-xsuaa-usage/README.md
+++ b/samples/spring-security-xsuaa-usage/README.md
@@ -14,7 +14,6 @@ Configure the OAuth resource server by:
 
 ```java
 @EnableWebSecurity
-@PropertySource(factory = XsuaaServicePropertySourceFactory.class, value = { "" })
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Autowired
@@ -41,16 +40,6 @@ XsuaaServiceConfigurationDefault xsuaaServiceConfiguration;
         TokenAuthenticationConverter converter = new TokenAuthenticationConverter(xsuaaServiceConfiguration);
         converter.setLocalScopeAsAuthorities(true);
         return converter;
-    }
-
-    @Bean
-    JwtDecoder jwtDecoder() {
-        return new XsuaaJwtDecoderBuilder(xsuaaServiceConfiguration).build();
-    }
-
-    @Bean
-    XsuaaServiceConfigurationDefault xsuaaConfig() {
-        return new XsuaaServiceConfigurationDefault();
     }
 }
 ```

--- a/samples/spring-security-xsuaa-usage/src/main/java/sample/spring/xsuaa/SecurityConfiguration.java
+++ b/samples/spring-security-xsuaa-usage/src/main/java/sample/spring/xsuaa/SecurityConfiguration.java
@@ -16,8 +16,6 @@
 package sample.spring.xsuaa;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -25,15 +23,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfigurationDefault;
-import com.sap.cloud.security.xsuaa.XsuaaServicePropertySourceFactory;
 import com.sap.cloud.security.xsuaa.token.TokenAuthenticationConverter;
-import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
 
 @EnableWebSecurity
-@PropertySource(factory = XsuaaServicePropertySourceFactory.class, value = { "" })
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
 	@Autowired
@@ -65,13 +59,4 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 		return converter;
 	}
 
-	@Bean
-	JwtDecoder jwtDecoder() {
-		return new XsuaaJwtDecoderBuilder(xsuaaServiceConfiguration).build();
-	}
-
-	@Bean
-	XsuaaServiceConfigurationDefault config() {
-		return new XsuaaServiceConfigurationDefault();
-	}
 }

--- a/spring-xsuaa-it/src/main/java/testservice/api/basic/SecurityConfiguration.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/basic/SecurityConfiguration.java
@@ -29,14 +29,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
 import com.sap.cloud.security.xsuaa.extractor.AuthenticationMethod;
 import com.sap.cloud.security.xsuaa.extractor.TokenBrokerResolver;
 import com.sap.cloud.security.xsuaa.mock.MockXsuaaServiceConfiguration;
 import com.sap.cloud.security.xsuaa.token.TokenAuthenticationConverter;
-import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
 
 @EnableWebSecurity
 @EnableCaching
@@ -70,11 +68,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Bean
 	XsuaaServiceConfiguration getXsuaaServiceConfiguration() {
 		return new MySecurityConfiguration();
-	}
-
-	@Bean
-	JwtDecoder jwtDecoder() {
-		return new XsuaaJwtDecoderBuilder(getXsuaaServiceConfiguration()).build();
 	}
 
 	private class MySecurityConfiguration extends MockXsuaaServiceConfiguration {

--- a/spring-xsuaa-it/src/main/java/testservice/api/nohttp/MyEventHandler.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/nohttp/MyEventHandler.java
@@ -2,7 +2,6 @@ package testservice.api.nohttp;
 
 import java.util.Collection;
 
-import com.sap.xs2.security.container.SecurityContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,35 +14,37 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.stereotype.Service;
 
+import com.sap.xs2.security.container.SecurityContext;
+
 @Service
 @Profile({ "test.api.nohttp" })
 public class MyEventHandler {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MyEventHandler.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(MyEventHandler.class);
 
-    @Value("${xsuaa.xsappname}")
-    String xsappname;
+	@Value("${xsuaa.xsappname}")
+	String xsappname;
 
-    @Autowired
-    JwtDecoder jwtDecoder;
+	@Autowired
+	JwtDecoder jwtDecoder;
 
-    public void onEvent(String myEncodedJwtToken) {
-        if(myEncodedJwtToken != null) {
-            Jwt jwtToken = jwtDecoder.decode(myEncodedJwtToken);
-            SecurityContext.init(xsappname, jwtToken, true);
-        }
-        try {
-            handleEvent();
-        } finally {
-            SecurityContext.clear();
-        }
-    }
+	public void onEvent(String myEncodedJwtToken) {
+		if (myEncodedJwtToken != null) {
+			Jwt jwtToken = jwtDecoder.decode(myEncodedJwtToken);
+			SecurityContext.init(xsappname, jwtToken, true);
+		}
+		try {
+			handleEvent();
+		} finally {
+			SecurityContext.clear();
+		}
+	}
 
-    void handleEvent() {
-        Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) SecurityContext.getToken()
-                .getAuthorities();
-        if (!authorities.contains(new SimpleGrantedAuthority("Display"))) {
-            throw new AccessDeniedException("Missing Authorization.");
-        }
-        LOGGER.info("Event handled properly");
-    }
+	void handleEvent() {
+		Collection<GrantedAuthority> authorities = (Collection<GrantedAuthority>) SecurityContext.getToken()
+				.getAuthorities();
+		if (!authorities.contains(new SimpleGrantedAuthority("Display"))) {
+			throw new AccessDeniedException("Missing Authorization.");
+		}
+		LOGGER.info("Event handled properly");
+	}
 }

--- a/spring-xsuaa-it/src/main/java/testservice/api/nohttp/SecurityConfiguration.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/nohttp/SecurityConfiguration.java
@@ -18,11 +18,9 @@ package testservice.api.nohttp;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
 import com.sap.cloud.security.xsuaa.mock.MockXsuaaServiceConfiguration;
-import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
 
 @Configuration
 // @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
@@ -33,10 +31,4 @@ public class SecurityConfiguration {
 	XsuaaServiceConfiguration getXsuaaServiceConfiguration() {
 		return new MockXsuaaServiceConfiguration();
 	}
-
-	@Bean
-	JwtDecoder jwtDecoder() {
-		return new XsuaaJwtDecoderBuilder(getXsuaaServiceConfiguration()).build();
-	}
-
 }

--- a/spring-xsuaa-it/src/main/java/testservice/api/v1/SecurityConfiguration.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/v1/SecurityConfiguration.java
@@ -23,12 +23,10 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
 import com.sap.cloud.security.xsuaa.mock.MockXsuaaServiceConfiguration;
 import com.sap.cloud.security.xsuaa.token.TokenAuthenticationConverter;
-import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
 
 @EnableWebSecurity
 @Profile({ "test.api.v1" })
@@ -55,11 +53,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 	@Bean
 	XsuaaServiceConfiguration getXsuaaServiceConfiguration() {
 		return new MockXsuaaServiceConfiguration();
-	}
-
-	@Bean
-	JwtDecoder jwtDecoder() {
-		return new XsuaaJwtDecoderBuilder(getXsuaaServiceConfiguration()).build();
 	}
 
 }

--- a/spring-xsuaa-it/src/test/java/testservice/api/InitializeSecurityContextTest.java
+++ b/spring-xsuaa-it/src/test/java/testservice/api/InitializeSecurityContextTest.java
@@ -13,6 +13,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaAutoConfiguration;
+import com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaResourceServerJwkAutoConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +39,8 @@ import testservice.api.nohttp.MyEventHandler;
 import testservice.api.nohttp.SecurityConfiguration;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = { SecurityConfiguration.class, MyEventHandler.class })
+@SpringBootTest(classes = { SecurityConfiguration.class, MyEventHandler.class, XsuaaAutoConfiguration.class,
+		XsuaaResourceServerJwkAutoConfiguration.class })
 @ActiveProfiles({ "test.api.nohttp", "uaamock" })
 public class InitializeSecurityContextTest {
 	@Value("${xsuaa.clientid}")

--- a/spring-xsuaa-test/src/test/java/com/sap/cloud/security/xsuaa/test/JwtGeneratorTest.java
+++ b/spring-xsuaa-test/src/test/java/com/sap/cloud/security/xsuaa/test/JwtGeneratorTest.java
@@ -120,7 +120,8 @@ public class JwtGeneratorTest {
 	@Test
 	public void testTokenWithDerivedAudienceClaim() {
 
-		Jwt jwt = jwtGenerator.addScopes("openid", "app1.scope", "app2.sub.scope", "app2.scope", ".scopeWithoutAppId").deriveAudiences(true)
+		Jwt jwt = jwtGenerator.addScopes("openid", "app1.scope", "app2.sub.scope", "app2.scope", ".scopeWithoutAppId")
+				.deriveAudiences(true)
 				.getToken();
 
 		assertThat(jwt.getAudience().size(), equalTo(2));

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -34,6 +34,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<version>${spring.boot.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>
@@ -54,6 +60,12 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<version>${spring.boot.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServicePropertySourceFactory.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServicePropertySourceFactory.java
@@ -4,12 +4,15 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.util.Properties;
 
+import com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaAutoConfiguration;
 import org.springframework.core.env.PropertiesPropertySource;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.support.EncodedResource;
 import org.springframework.core.io.support.PropertySourceFactory;
 
 /**
+ * Part of Auto Configuration {@link XsuaaAutoConfiguration}
+ *
  * <h2>Example Usage</h2>
  * 
  * <pre class="code">
@@ -22,8 +25,6 @@ import org.springframework.core.io.support.PropertySourceFactory;
  * 
  * &#64;Value("${xsuaa.url:}")
  * </pre>
- * 
- *
  *
  */
 public class XsuaaServicePropertySourceFactory implements PropertySourceFactory {

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfiguration.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfiguration.java
@@ -1,0 +1,40 @@
+package com.sap.cloud.security.xsuaa.autoconfiguration;
+
+import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
+import com.sap.cloud.security.xsuaa.XsuaaServiceConfigurationDefault;
+import com.sap.cloud.security.xsuaa.XsuaaServicePropertySourceFactory;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for default beans used by the XSUAA client library.
+ * <p>
+ * Activates when there is a bean of type {@link Jwt} configured in the context.
+ *
+ * <p>
+ * can be disabled with @EnableAutoConfiguration(exclude={XsuaaAutoConfiguration.class}) or
+ * with property spring.xsuaa.auto = false
+ */
+@Configuration
+@ConditionalOnClass(Jwt.class)
+@ConditionalOnProperty(prefix = "spring.xsuaa", name = "auto", havingValue = "true", matchIfMissing = true)
+public class XsuaaAutoConfiguration {
+
+    @Configuration
+    @PropertySource(factory = XsuaaServicePropertySourceFactory.class, value = { "" })
+    @ConditionalOnProperty(prefix = "spring.xsuaa", name = "multiple-bindings", havingValue = "false", matchIfMissing = true)
+    public static class XsuaaServiceAutoConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean(XsuaaServiceConfiguration.class)
+        public XsuaaServiceConfiguration xsuaaServiceConfiguration() {
+            return new XsuaaServiceConfigurationDefault();
+        }
+    }
+}

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfiguration.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfiguration.java
@@ -13,28 +13,30 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 /**
- * {@link EnableAutoConfiguration Auto-configuration} for default beans used by the XSUAA client library.
+ * {@link EnableAutoConfiguration Auto-configuration} for default beans used by
+ * the XSUAA client library.
  * <p>
  * Activates when there is a bean of type {@link Jwt} configured in the context.
  *
  * <p>
- * can be disabled with @EnableAutoConfiguration(exclude={XsuaaAutoConfiguration.class}) or
- * with property spring.xsuaa.auto = false
+ * can be disabled
+ * with @EnableAutoConfiguration(exclude={XsuaaAutoConfiguration.class}) or with
+ * property spring.xsuaa.auto = false
  */
 @Configuration
 @ConditionalOnClass(Jwt.class)
 @ConditionalOnProperty(prefix = "spring.xsuaa", name = "auto", havingValue = "true", matchIfMissing = true)
 public class XsuaaAutoConfiguration {
 
-    @Configuration
-    @PropertySource(factory = XsuaaServicePropertySourceFactory.class, value = { "" })
-    @ConditionalOnProperty(prefix = "spring.xsuaa", name = "multiple-bindings", havingValue = "false", matchIfMissing = true)
-    public static class XsuaaServiceAutoConfiguration {
+	@Configuration
+	@PropertySource(factory = XsuaaServicePropertySourceFactory.class, value = { "" })
+	@ConditionalOnProperty(prefix = "spring.xsuaa", name = "multiple-bindings", havingValue = "false", matchIfMissing = true)
+	public static class XsuaaServiceAutoConfiguration {
 
-        @Bean
-        @ConditionalOnMissingBean(XsuaaServiceConfiguration.class)
-        public XsuaaServiceConfiguration xsuaaServiceConfiguration() {
-            return new XsuaaServiceConfigurationDefault();
-        }
-    }
+		@Bean
+		@ConditionalOnMissingBean(XsuaaServiceConfiguration.class)
+		public XsuaaServiceConfiguration xsuaaServiceConfiguration() {
+			return new XsuaaServiceConfigurationDefault();
+		}
+	}
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaResourceServerJwkAutoConfiguration.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaResourceServerJwkAutoConfiguration.java
@@ -1,0 +1,39 @@
+package com.sap.cloud.security.xsuaa.autoconfiguration;
+
+import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
+import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoderBuilder;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} that exposes a {@link JwtDecoder},
+ * which has the standard Spring Security Jwt validators as well as the XSUAA-specific validators.
+ *
+ * Activates when there is a bean of type {@link Jwt} configured in the context.
+ *
+ * <p>
+ * can be disabled with @EnableAutoConfiguration(exclude={XsuaaResourceServerJwkAutoConfiguration.class}) or
+ * with property spring.xsuaa.auto = false
+ */
+@Configuration
+@ConditionalOnClass(Jwt.class)
+@ConditionalOnProperty(prefix = "spring.xsuaa", name = "auto", havingValue = "true", matchIfMissing = true)
+@AutoConfigureBefore(OAuth2ResourceServerAutoConfiguration.class) // imports OAuth2ResourceServerJwtConfiguration which specifies JwtDecoder
+public class XsuaaResourceServerJwkAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(XsuaaServiceConfiguration.class)
+    @ConditionalOnMissingBean
+    public JwtDecoder xsuaaJwtDecoder(XsuaaServiceConfiguration xsuaaServiceConfiguration) {
+        return new XsuaaJwtDecoderBuilder(xsuaaServiceConfiguration).build();
+    }
+}

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaResourceServerJwkAutoConfiguration.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaResourceServerJwkAutoConfiguration.java
@@ -15,25 +15,28 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 /**
- * {@link EnableAutoConfiguration Auto-configuration} that exposes a {@link JwtDecoder},
- * which has the standard Spring Security Jwt validators as well as the XSUAA-specific validators.
+ * {@link EnableAutoConfiguration Auto-configuration} that exposes a
+ * {@link JwtDecoder}, which has the standard Spring Security Jwt validators as
+ * well as the XSUAA-specific validators.
  *
  * Activates when there is a bean of type {@link Jwt} configured in the context.
  *
  * <p>
- * can be disabled with @EnableAutoConfiguration(exclude={XsuaaResourceServerJwkAutoConfiguration.class}) or
- * with property spring.xsuaa.auto = false
+ * can be disabled
+ * with @EnableAutoConfiguration(exclude={XsuaaResourceServerJwkAutoConfiguration.class})
+ * or with property spring.xsuaa.auto = false
  */
 @Configuration
 @ConditionalOnClass(Jwt.class)
 @ConditionalOnProperty(prefix = "spring.xsuaa", name = "auto", havingValue = "true", matchIfMissing = true)
-@AutoConfigureBefore(OAuth2ResourceServerAutoConfiguration.class) // imports OAuth2ResourceServerJwtConfiguration which specifies JwtDecoder
+@AutoConfigureBefore(OAuth2ResourceServerAutoConfiguration.class) // imports OAuth2ResourceServerJwtConfiguration which
+																	// specifies JwtDecoder
 public class XsuaaResourceServerJwkAutoConfiguration {
 
-    @Bean
-    @ConditionalOnBean(XsuaaServiceConfiguration.class)
-    @ConditionalOnMissingBean
-    public JwtDecoder xsuaaJwtDecoder(XsuaaServiceConfiguration xsuaaServiceConfiguration) {
-        return new XsuaaJwtDecoderBuilder(xsuaaServiceConfiguration).build();
-    }
+	@Bean
+	@ConditionalOnBean(XsuaaServiceConfiguration.class)
+	@ConditionalOnMissingBean
+	public JwtDecoder xsuaaJwtDecoder(XsuaaServiceConfiguration xsuaaServiceConfiguration) {
+		return new XsuaaJwtDecoderBuilder(xsuaaServiceConfiguration).build();
+	}
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderBuilder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderBuilder.java
@@ -1,6 +1,5 @@
 package com.sap.cloud.security.xsuaa.token.authentication;
 
-
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
@@ -36,7 +35,8 @@ public class XsuaaJwtDecoderBuilder {
 	 * @return JwtDecoder
 	 */
 	public JwtDecoder build() {
-		DelegatingOAuth2TokenValidator<Jwt> combinedTokenValidators = new DelegatingOAuth2TokenValidator<>(defaultTokenValidators,
+		DelegatingOAuth2TokenValidator<Jwt> combinedTokenValidators = new DelegatingOAuth2TokenValidator<>(
+				defaultTokenValidators,
 				xsuaaTokenValidators);
 		return new XsuaaJwtDecoder(configuration, decoderCacheValidity, decoderCacheSize, combinedTokenValidators);
 	}

--- a/spring-xsuaa/src/main/resources/META-INF/spring.factories
+++ b/spring-xsuaa/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaAutoConfiguration

--- a/spring-xsuaa/src/main/resources/META-INF/spring.factories
+++ b/spring-xsuaa/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaAutoConfiguration
+com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaAutoConfiguration,\
+com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaResourceServerJwkAutoConfiguration

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfigurationTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfigurationTest.java
@@ -25,101 +25,108 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest(classes = XsuaaAutoConfiguration.class)
 public class XsuaaAutoConfigurationTest {
 
-    // create an ApplicationContextRunner that will create a context with the configuration under test.
-    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withConfiguration(AutoConfigurations.of(XsuaaAutoConfiguration.class));
+	// create an ApplicationContextRunner that will create a context with the
+	// configuration under test.
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(XsuaaAutoConfiguration.class));
 
-    @Autowired
-    private ApplicationContext context;
+	@Autowired
+	private ApplicationContext context;
 
-    @Test
-    public final void autoConfigurationActive() {
-        contextRunner.run((context) -> {
-            assertThat(context.containsBean("xsuaaServiceConfiguration"), is(true));
-            assertThat(context.getBean("xsuaaServiceConfiguration"),
-                    instanceOf(XsuaaServiceConfigurationDefault.class));
-            assertThat(context.getBean(XsuaaServiceConfiguration.class), is(not(nullValue())));
-        });
-    }
+	@Test
+	public final void autoConfigurationActive() {
+		contextRunner.run((context) -> {
+			assertThat(context.containsBean("xsuaaServiceConfiguration"), is(true));
+			assertThat(context.getBean("xsuaaServiceConfiguration"),
+					instanceOf(XsuaaServiceConfigurationDefault.class));
+			assertThat(context.getBean(XsuaaServiceConfiguration.class), is(not(nullValue())));
+		});
+	}
 
-    @Test
-    public final void autoConfigurationActiveInclProperties() {
-        contextRunner
-                .withPropertyValues("spring.xsuaa.auto:true")
-                .withPropertyValues("spring.xsuaa.multiple-bindings:false").run((context) -> {
-            assertThat(context.containsBean("xsuaaServiceConfiguration"), is(true));
-            assertThat(context.getBean("xsuaaServiceConfiguration"),
-                    instanceOf(XsuaaServiceConfigurationDefault.class));
-            assertThat(context.getBean(XsuaaServiceConfiguration.class), is(not(nullValue())));
-        });
-    }
+	@Test
+	public final void autoConfigurationActiveInclProperties() {
+		contextRunner
+				.withPropertyValues("spring.xsuaa.auto:true")
+				.withPropertyValues("spring.xsuaa.multiple-bindings:false").run((context) -> {
+					assertThat(context.containsBean("xsuaaServiceConfiguration"), is(true));
+					assertThat(context.getBean("xsuaaServiceConfiguration"),
+							instanceOf(XsuaaServiceConfigurationDefault.class));
+					assertThat(context.getBean(XsuaaServiceConfiguration.class), is(not(nullValue())));
+				});
+	}
 
-    @Test
-    public void autoConfigurationDisabledByProperty() {
-        contextRunner.withPropertyValues("spring.xsuaa.auto:false").run((context) -> {
-            assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
-        });
-    }
+	@Test
+	public void autoConfigurationDisabledByProperty() {
+		contextRunner.withPropertyValues("spring.xsuaa.auto:false").run((context) -> {
+			assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
+		});
+	}
 
-    @Test
-    public void serviceConfigurationDisabledByProperty() {
-        contextRunner.withPropertyValues("spring.xsuaa.multiple-bindings:true").run((context) -> {
-            assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
-        });
-    }
+	@Test
+	public void serviceConfigurationDisabledByProperty() {
+		contextRunner.withPropertyValues("spring.xsuaa.multiple-bindings:true").run((context) -> {
+			assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
+		});
+	}
 
-    @Test
-    public final void autoConfigurationWithoutJwtOnClasspathInactive() {
-        contextRunner.withClassLoader(new FilteredClassLoader(Jwt.class)) // removes Jwt.class from classpath
-                .run((context) -> {
-                    assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
-                });
-    }
+	@Test
+	public final void autoConfigurationWithoutJwtOnClasspathInactive() {
+		contextRunner.withClassLoader(new FilteredClassLoader(Jwt.class)) // removes Jwt.class from classpath
+				.run((context) -> {
+					assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
+				});
+	}
 
-    @Test
-    public final void userConfigurationCanOverrideDefaultBeans() {
-        contextRunner.withUserConfiguration(UserConfiguration.class)
-                .run((context) -> {
-                    assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
-                    assertThat(context.containsBean("customServiceConfiguration"), is(true));
-                    assertThat(context.getBean("customServiceConfiguration"),
-                            instanceOf(CustomXsuaaConfiguration.class));
-                });
-    }
+	@Test
+	public final void userConfigurationCanOverrideDefaultBeans() {
+		contextRunner.withUserConfiguration(UserConfiguration.class)
+				.run((context) -> {
+					assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
+					assertThat(context.containsBean("customServiceConfiguration"), is(true));
+					assertThat(context.getBean("customServiceConfiguration"),
+							instanceOf(CustomXsuaaConfiguration.class));
+				});
+	}
 
-    @Configuration
-    public static class UserConfiguration {
+	@Configuration
+	public static class UserConfiguration {
 
-        @Bean
-        public XsuaaServiceConfiguration customServiceConfiguration() {
-            return new CustomXsuaaConfiguration();
-        }
-    }
+		@Bean
+		public XsuaaServiceConfiguration customServiceConfiguration() {
+			return new CustomXsuaaConfiguration();
+		}
+	}
 
-    static class CustomXsuaaConfiguration implements XsuaaServiceConfiguration {
+	static class CustomXsuaaConfiguration implements XsuaaServiceConfiguration {
 
-        @Override public String getClientId() {
-            return null;
-        }
+		@Override
+		public String getClientId() {
+			return null;
+		}
 
-        @Override public String getClientSecret() {
-            return null;
-        }
+		@Override
+		public String getClientSecret() {
+			return null;
+		}
 
-        @Override public String getUaaUrl() {
-            return null;
-        }
+		@Override
+		public String getUaaUrl() {
+			return null;
+		}
 
-        @Override public String getTokenKeyUrl(String zid, String subdomain) {
-            return null;
-        }
+		@Override
+		public String getTokenKeyUrl(String zid, String subdomain) {
+			return null;
+		}
 
-        @Override public String getAppId() {
-            return null;
-        }
+		@Override
+		public String getAppId() {
+			return null;
+		}
 
-        @Override public String getUaaDomain() {
-            return null;
-        }
-    }
+		@Override
+		public String getUaaDomain() {
+			return null;
+		}
+	}
 }

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfigurationTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfigurationTest.java
@@ -70,8 +70,7 @@ public class XsuaaAutoConfigurationTest {
 
     @Test
     public final void autoConfigurationWithoutJwtOnClasspathInactive() {
-        contextRunner.withClassLoader(new FilteredClassLoader(
-                Jwt.class)) // make sure XsuaaServiceConfiguration.class is not on the classpath.
+        contextRunner.withClassLoader(new FilteredClassLoader(Jwt.class)) // removes Jwt.class from classpath
                 .run((context) -> {
                     assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
                 });

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfigurationTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfigurationTest.java
@@ -1,0 +1,126 @@
+package com.sap.cloud.security.xsuaa.autoconfiguration;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
+import com.sap.cloud.security.xsuaa.XsuaaServiceConfigurationDefault;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = XsuaaAutoConfiguration.class)
+public class XsuaaAutoConfigurationTest {
+
+    // create an ApplicationContextRunner that will create a context with the configuration under test.
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(XsuaaAutoConfiguration.class));
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public final void autoConfigurationActive() {
+        contextRunner.run((context) -> {
+            assertThat(context.containsBean("xsuaaServiceConfiguration"), is(true));
+            assertThat(context.getBean("xsuaaServiceConfiguration"),
+                    instanceOf(XsuaaServiceConfigurationDefault.class));
+            assertThat(context.getBean(XsuaaServiceConfiguration.class), is(not(nullValue())));
+        });
+    }
+
+    @Test
+    public final void autoConfigurationActiveInclProperties() {
+        contextRunner
+                .withPropertyValues("spring.xsuaa.auto:true")
+                .withPropertyValues("spring.xsuaa.multiple-bindings:false").run((context) -> {
+            assertThat(context.containsBean("xsuaaServiceConfiguration"), is(true));
+            assertThat(context.getBean("xsuaaServiceConfiguration"),
+                    instanceOf(XsuaaServiceConfigurationDefault.class));
+            assertThat(context.getBean(XsuaaServiceConfiguration.class), is(not(nullValue())));
+        });
+    }
+
+    @Test
+    public void autoConfigurationDisabledByProperty() {
+        contextRunner.withPropertyValues("spring.xsuaa.auto:false").run((context) -> {
+            assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
+        });
+    }
+
+    @Test
+    public void serviceConfigurationDisabledByProperty() {
+        contextRunner.withPropertyValues("spring.xsuaa.multiple-bindings:true").run((context) -> {
+            assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
+        });
+    }
+
+    @Test
+    public final void autoConfigurationWithoutJwtOnClasspathInactive() {
+        contextRunner.withClassLoader(new FilteredClassLoader(
+                Jwt.class)) // make sure XsuaaServiceConfiguration.class is not on the classpath.
+                .run((context) -> {
+                    assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
+                });
+    }
+
+    @Test
+    public final void userConfigurationCanOverrideDefaultBeans() {
+        contextRunner.withUserConfiguration(UserConfiguration.class)
+                .run((context) -> {
+                    assertThat(context.containsBean("xsuaaServiceConfiguration"), is(false));
+                    assertThat(context.containsBean("customServiceConfiguration"), is(true));
+                    assertThat(context.getBean("customServiceConfiguration"),
+                            instanceOf(CustomXsuaaConfiguration.class));
+                });
+    }
+
+    @Configuration
+    public static class UserConfiguration {
+
+        @Bean
+        public XsuaaServiceConfiguration customServiceConfiguration() {
+            return new CustomXsuaaConfiguration();
+        }
+    }
+
+    static class CustomXsuaaConfiguration implements XsuaaServiceConfiguration {
+
+        @Override public String getClientId() {
+            return null;
+        }
+
+        @Override public String getClientSecret() {
+            return null;
+        }
+
+        @Override public String getUaaUrl() {
+            return null;
+        }
+
+        @Override public String getTokenKeyUrl(String zid, String subdomain) {
+            return null;
+        }
+
+        @Override public String getAppId() {
+            return null;
+        }
+
+        @Override public String getUaaDomain() {
+            return null;
+        }
+    }
+}

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaResourceServerJwkAutoConfigurationTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaResourceServerJwkAutoConfigurationTest.java
@@ -1,0 +1,92 @@
+package com.sap.cloud.security.xsuaa.autoconfiguration;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { XsuaaResourceServerJwkAutoConfiguration.class, XsuaaAutoConfiguration.class })
+public class XsuaaResourceServerJwkAutoConfigurationTest {
+
+    // create an ApplicationContextRunner that will create a context with the configuration under test.
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(
+                    AutoConfigurations.of(XsuaaResourceServerJwkAutoConfiguration.class, XsuaaAutoConfiguration.class));
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public final void autoConfigurationActive() {
+        contextRunner.run((context) -> {
+            assertThat(context.containsBean("xsuaaJwtDecoder"), is(true));
+            assertThat(context.getBean("xsuaaJwtDecoder"), instanceOf(XsuaaJwtDecoder.class));
+            assertThat(context.getBean(JwtDecoder.class), is(not(nullValue())));
+            assertThat(context.getBean(JwtDecoder.class), instanceOf(XsuaaJwtDecoder.class));
+        });
+    }
+
+    @Test
+    public final void autoConfigurationActiveInclProperties() {
+        contextRunner
+                .withPropertyValues("spring.xsuaa.auto:true").run((context) -> {
+            assertThat(context.containsBean("xsuaaJwtDecoder"), is(true));
+            assertThat(context.getBean("xsuaaJwtDecoder"), instanceOf(XsuaaJwtDecoder.class));
+            assertThat(context.getBean(JwtDecoder.class), is(not(nullValue())));
+        });
+    }
+
+    @Test
+    public void autoConfigurationDisabledByProperty() {
+        contextRunner.withPropertyValues("spring.xsuaa.auto:false").run((context) -> {
+            assertThat(context.containsBean("xsuaaJwtDecoder"), is(false));
+        });
+    }
+
+    @Test
+    public final void autoConfigurationWithoutXsuaaServiceConfigurationOnClasspathInactive() {
+        contextRunner.withClassLoader(
+                new FilteredClassLoader(Jwt.class)) // make sure XsuaaServiceConfiguration.class is not on the classpath
+                .run((context) -> {
+                    assertThat(context.containsBean("xsuaaJwtDecoder"), is(false));
+                });
+    }
+
+    @Test
+    public final void userConfigurationCanOverrideDefaultBeans() {
+        contextRunner.withUserConfiguration(UserConfiguration.class)
+                .run((context) -> {
+                    assertThat(context.containsBean("xsuaaJwtDecoder"), is(false));
+                    assertThat(context.containsBean("customJwtDecoder"), is(true));
+                    assertThat(context.getBean("customJwtDecoder"),
+                            instanceOf(NimbusJwtDecoderJwkSupport.class));
+                });
+    }
+
+    @Configuration
+    public static class UserConfiguration {
+
+        @Bean
+        public JwtDecoder customJwtDecoder() {
+            return new NimbusJwtDecoderJwkSupport("http://localhost:8080/uaa/oauth/token_keys");
+        }
+    }
+}

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaResourceServerJwkAutoConfigurationTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaResourceServerJwkAutoConfigurationTest.java
@@ -26,67 +26,68 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest(classes = { XsuaaResourceServerJwkAutoConfiguration.class, XsuaaAutoConfiguration.class })
 public class XsuaaResourceServerJwkAutoConfigurationTest {
 
-    // create an ApplicationContextRunner that will create a context with the configuration under test.
-    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withConfiguration(
-                    AutoConfigurations.of(XsuaaResourceServerJwkAutoConfiguration.class, XsuaaAutoConfiguration.class));
+	// create an ApplicationContextRunner that will create a context with the
+	// configuration under test.
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(
+					AutoConfigurations.of(XsuaaResourceServerJwkAutoConfiguration.class, XsuaaAutoConfiguration.class));
 
-    @Autowired
-    private ApplicationContext context;
+	@Autowired
+	private ApplicationContext context;
 
-    @Test
-    public final void autoConfigurationActive() {
-        contextRunner.run((context) -> {
-            assertThat(context.containsBean("xsuaaJwtDecoder"), is(true));
-            assertThat(context.getBean("xsuaaJwtDecoder"), instanceOf(XsuaaJwtDecoder.class));
-            assertThat(context.getBean(JwtDecoder.class), is(not(nullValue())));
-            assertThat(context.getBean(JwtDecoder.class), instanceOf(XsuaaJwtDecoder.class));
-        });
-    }
+	@Test
+	public final void autoConfigurationActive() {
+		contextRunner.run((context) -> {
+			assertThat(context.containsBean("xsuaaJwtDecoder"), is(true));
+			assertThat(context.getBean("xsuaaJwtDecoder"), instanceOf(XsuaaJwtDecoder.class));
+			assertThat(context.getBean(JwtDecoder.class), is(not(nullValue())));
+			assertThat(context.getBean(JwtDecoder.class), instanceOf(XsuaaJwtDecoder.class));
+		});
+	}
 
-    @Test
-    public final void autoConfigurationActiveInclProperties() {
-        contextRunner
-                .withPropertyValues("spring.xsuaa.auto:true").run((context) -> {
-            assertThat(context.containsBean("xsuaaJwtDecoder"), is(true));
-            assertThat(context.getBean("xsuaaJwtDecoder"), instanceOf(XsuaaJwtDecoder.class));
-            assertThat(context.getBean(JwtDecoder.class), is(not(nullValue())));
-        });
-    }
+	@Test
+	public final void autoConfigurationActiveInclProperties() {
+		contextRunner
+				.withPropertyValues("spring.xsuaa.auto:true").run((context) -> {
+					assertThat(context.containsBean("xsuaaJwtDecoder"), is(true));
+					assertThat(context.getBean("xsuaaJwtDecoder"), instanceOf(XsuaaJwtDecoder.class));
+					assertThat(context.getBean(JwtDecoder.class), is(not(nullValue())));
+				});
+	}
 
-    @Test
-    public void autoConfigurationDisabledByProperty() {
-        contextRunner.withPropertyValues("spring.xsuaa.auto:false").run((context) -> {
-            assertThat(context.containsBean("xsuaaJwtDecoder"), is(false));
-        });
-    }
+	@Test
+	public void autoConfigurationDisabledByProperty() {
+		contextRunner.withPropertyValues("spring.xsuaa.auto:false").run((context) -> {
+			assertThat(context.containsBean("xsuaaJwtDecoder"), is(false));
+		});
+	}
 
-    @Test
-    public final void autoConfigurationWithoutXsuaaServiceConfigurationOnClasspathInactive() {
-        contextRunner.withClassLoader(
-                new FilteredClassLoader(Jwt.class)) // make sure XsuaaServiceConfiguration.class is not on the classpath
-                .run((context) -> {
-                    assertThat(context.containsBean("xsuaaJwtDecoder"), is(false));
-                });
-    }
+	@Test
+	public final void autoConfigurationWithoutXsuaaServiceConfigurationOnClasspathInactive() {
+		contextRunner.withClassLoader(
+				new FilteredClassLoader(Jwt.class)) // make sure XsuaaServiceConfiguration.class is not on the classpath
+				.run((context) -> {
+					assertThat(context.containsBean("xsuaaJwtDecoder"), is(false));
+				});
+	}
 
-    @Test
-    public final void userConfigurationCanOverrideDefaultBeans() {
-        contextRunner.withUserConfiguration(UserConfiguration.class)
-                .run((context) -> {
-                    assertThat(context.containsBean("xsuaaJwtDecoder"), is(false));
-                    assertThat(context.containsBean("customJwtDecoder"), is(true));
-                    assertThat(context.getBean("customJwtDecoder"),
-                            instanceOf(NimbusJwtDecoderJwkSupport.class));
-                });
-    }
+	@Test
+	public final void userConfigurationCanOverrideDefaultBeans() {
+		contextRunner.withUserConfiguration(UserConfiguration.class)
+				.run((context) -> {
+					assertThat(context.containsBean("xsuaaJwtDecoder"), is(false));
+					assertThat(context.containsBean("customJwtDecoder"), is(true));
+					assertThat(context.getBean("customJwtDecoder"),
+							instanceOf(NimbusJwtDecoderJwkSupport.class));
+				});
+	}
 
-    @Configuration
-    public static class UserConfiguration {
+	@Configuration
+	public static class UserConfiguration {
 
-        @Bean
-        public JwtDecoder customJwtDecoder() {
-            return new NimbusJwtDecoderJwkSupport("http://localhost:8080/uaa/oauth/token_keys");
-        }
-    }
+		@Bean
+		public JwtDecoder customJwtDecoder() {
+			return new NimbusJwtDecoderJwkSupport("http://localhost:8080/uaa/oauth/token_keys");
+		}
+	}
 }


### PR DESCRIPTION
### Changes 
- introduces basic autoconfig for `XsuaaServiceConfiguration`
- introduces autoconfig for `JwtDecoder`
- `XsuaaJwtDecoderBuilder` can be configured with default validators 
https://github.com/SAP/cloud-security-xsuaa-integration/blob/a31768d497d65de0551d35d0491ef1549b6f2134/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderBuilder.java#L81
- uses default validators from spring-security Oauth2 https://github.com/SAP/cloud-security-xsuaa-integration/blob/a31768d497d65de0551d35d0491ef1549b6f2134/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderBuilder.java#L27

### Open Todos / follow ups
- [x] update documentation
- [x] update integration tests and samples
- [x] apply code formatting rules
- [ ] enhance changelog and increase version
- [x] some further tests with existing sample applications
- [x] issue #86