### PR TITLE
Use jku of token to retrieve keys

### DIFF
--- a/spring-xsuaa-it/src/main/java/testservice/api/basic/SecurityConfiguration.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/basic/SecurityConfiguration.java
@@ -77,13 +77,5 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 			return "mysecret-basic";
 		}
 
-		@Override
-		public String getUaaDomain() {
-			try {
-				return new URL(getUaaUrl()).getHost();
-			} catch (MalformedURLException e) {
-				return null;
-			}
-		}
 	}
 }

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/BasicAuthenticationValidationIT.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/BasicAuthenticationValidationIT.java
@@ -28,8 +28,7 @@ import testservice.api.basic.TestController;
 @SpringBootTest(properties = {
 		"xsuaa.xsappname=java-hello-world",
 		"xsuaa.clientid=sb-java-hello-world",
-		"xsuaa.url=${mockxsuaaserver.url}",
-		"xsuaa.uaadomain=localhost" }, classes = { XsuaaITApplication.class, SecurityConfiguration.class,
+		"xsuaa.url=${mockxsuaaserver.url}"}, classes = { XsuaaITApplication.class, SecurityConfiguration.class,
 				TestController.class })
 @AutoConfigureMockMvc
 @ActiveProfiles("test.api.basic")

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/BasicAuthenticationValidationIT.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/BasicAuthenticationValidationIT.java
@@ -28,7 +28,8 @@ import testservice.api.basic.TestController;
 @SpringBootTest(properties = {
 		"xsuaa.xsappname=java-hello-world",
 		"xsuaa.clientid=sb-java-hello-world",
-		"xsuaa.url=${mockxsuaaserver.url}" }, classes = { XsuaaITApplication.class, SecurityConfiguration.class,
+		"xsuaa.url=${mockxsuaaserver.url}",
+		"xsuaa.uaadomain=localhost" }, classes = { XsuaaITApplication.class, SecurityConfiguration.class,
 				TestController.class })
 @AutoConfigureMockMvc
 @ActiveProfiles("test.api.basic")

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/BasicAuthenticationValidationIT.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/BasicAuthenticationValidationIT.java
@@ -28,7 +28,7 @@ import testservice.api.basic.TestController;
 @SpringBootTest(properties = {
 		"xsuaa.xsappname=java-hello-world",
 		"xsuaa.clientid=sb-java-hello-world",
-		"xsuaa.url=${mockxsuaaserver.url}"}, classes = { XsuaaITApplication.class, SecurityConfiguration.class,
+		"xsuaa.url=${mockxsuaaserver.url}" }, classes = { XsuaaITApplication.class, SecurityConfiguration.class,
 				TestController.class })
 @AutoConfigureMockMvc
 @ActiveProfiles("test.api.basic")

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenValidationIT.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenValidationIT.java
@@ -28,7 +28,7 @@ import testservice.api.v1.TestController;
 @SpringBootTest(properties = {
 		"xsuaa.xsappname=java-hello-world",
 		"xsuaa.clientid=sb-java-hello-world",
-		"xsuaa.url=${mockxsuaaserver.url}"}, classes = { XsuaaITApplication.class,
+		"xsuaa.url=${mockxsuaaserver.url}" }, classes = { XsuaaITApplication.class,
 				testservice.api.v1.SecurityConfiguration.class, TestController.class })
 @AutoConfigureMockMvc
 @ActiveProfiles("test.api.v1")

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenValidationIT.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenValidationIT.java
@@ -28,7 +28,8 @@ import testservice.api.v1.TestController;
 @SpringBootTest(properties = {
 		"xsuaa.xsappname=java-hello-world",
 		"xsuaa.clientid=sb-java-hello-world",
-		"xsuaa.url=${mockxsuaaserver.url}" }, classes = { XsuaaITApplication.class,
+		"xsuaa.url=${mockxsuaaserver.url}",
+		"xsuaa.uaadomain=localhost" }, classes = { XsuaaITApplication.class,
 				testservice.api.v1.SecurityConfiguration.class, TestController.class })
 @AutoConfigureMockMvc
 @ActiveProfiles("test.api.v1")
@@ -62,8 +63,7 @@ public class XsuaaTokenValidationIT {
 
 	@Test
 	public void test_requesttoken() throws Exception {
-		String fqHost = new URL(mockServerUrl).getHost();
-		String hostname = fqHost.substring(0, fqHost.indexOf("."));
+		String hostname = new URL(mockServerUrl).getHost();
 
 		this.mvc.perform(
 				get("/requesttoken").with(bearerToken(JWTUtil.createJWT("/saml.txt", hostname, "legacy-token-key"))))

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenValidationIT.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenValidationIT.java
@@ -62,10 +62,8 @@ public class XsuaaTokenValidationIT {
 
 	@Test
 	public void test_requesttoken() throws Exception {
-		String hostname = new URL(mockServerUrl).getHost();
-
 		this.mvc.perform(
-				get("/requesttoken").with(bearerToken(JWTUtil.createJWT("/saml.txt", hostname, "legacy-token-key"))))
+				get("/requesttoken").with(bearerToken(JWTUtil.createJWT("/saml.txt", "uaa", "legacy-token-key"))))
 				.andExpect(status().isOk()).andExpect(content().string("cc_token"));
 	}
 

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenValidationIT.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenValidationIT.java
@@ -28,8 +28,7 @@ import testservice.api.v1.TestController;
 @SpringBootTest(properties = {
 		"xsuaa.xsappname=java-hello-world",
 		"xsuaa.clientid=sb-java-hello-world",
-		"xsuaa.url=${mockxsuaaserver.url}",
-		"xsuaa.uaadomain=localhost" }, classes = { XsuaaITApplication.class,
+		"xsuaa.url=${mockxsuaaserver.url}"}, classes = { XsuaaITApplication.class,
 				testservice.api.v1.SecurityConfiguration.class, TestController.class })
 @AutoConfigureMockMvc
 @ActiveProfiles("test.api.v1")

--- a/spring-xsuaa-it/src/test/java/testservice/api/InitializeSecurityContextTest.java
+++ b/spring-xsuaa-it/src/test/java/testservice/api/InitializeSecurityContextTest.java
@@ -13,8 +13,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaAutoConfiguration;
-import com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaResourceServerJwkAutoConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,10 +25,14 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaAutoConfiguration;
+import com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaResourceServerJwkAutoConfiguration;
+import com.sap.cloud.security.xsuaa.mock.XsuaaRequestDispatcher;
 import com.sap.cloud.security.xsuaa.test.JwtGenerator;
 import com.sap.cloud.security.xsuaa.token.Token;
 import com.sap.xs2.security.container.SecurityContext;
@@ -39,8 +41,10 @@ import testservice.api.nohttp.MyEventHandler;
 import testservice.api.nohttp.SecurityConfiguration;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = { SecurityConfiguration.class, MyEventHandler.class, XsuaaAutoConfiguration.class,
-		XsuaaResourceServerJwkAutoConfiguration.class })
+@SpringBootTest(properties = {
+		"xsuaa.uaadomain=localhost" }, classes = { SecurityConfiguration.class, MyEventHandler.class,
+				XsuaaAutoConfiguration.class,
+				XsuaaResourceServerJwkAutoConfiguration.class })
 @ActiveProfiles({ "test.api.nohttp", "uaamock" })
 public class InitializeSecurityContextTest {
 	@Value("${xsuaa.clientid}")
@@ -90,6 +94,26 @@ public class InitializeSecurityContextTest {
 		SecurityContext.clear();
 
 		assertThat(SecurityContextHolder.getContext().getAuthentication(), is(nullValue()));
+	}
+
+	@Test
+	public void cacheHit() {
+		String jwt = new JwtGenerator(clientId, "subdomain").deriveAudiences(true)
+				.setJwtHeaderKeyId("legacy-token-key").getToken().getTokenValue();
+
+		jwtDecoder.decode(jwt);
+		int callCountAfterFirstCall = XsuaaRequestDispatcher.getCallCount();
+
+		jwtDecoder.decode(jwt);
+		Assert.assertEquals(callCountAfterFirstCall, XsuaaRequestDispatcher.getCallCount());
+	}
+
+	@Test(expected = JwtException.class)
+	public void missingJkuFails() {
+		String jwt = new JwtGenerator(clientId, "subdomain").deriveAudiences(true)
+				.setJwtHeaderKeyId("legacy-token-key").setJku(null).getToken().getTokenValue();
+
+		jwtDecoder.decode(jwt);
 	}
 
 	@Test(expected = JwtValidationException.class)

--- a/spring-xsuaa-it/src/test/java/testservice/api/InitializeSecurityContextTest.java
+++ b/spring-xsuaa-it/src/test/java/testservice/api/InitializeSecurityContextTest.java
@@ -42,8 +42,8 @@ import testservice.api.nohttp.SecurityConfiguration;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { SecurityConfiguration.class, MyEventHandler.class,
-				XsuaaAutoConfiguration.class,
-				XsuaaResourceServerJwkAutoConfiguration.class })
+		XsuaaAutoConfiguration.class,
+		XsuaaResourceServerJwkAutoConfiguration.class })
 @ActiveProfiles({ "test.api.nohttp", "uaamock" })
 public class InitializeSecurityContextTest {
 	@Value("${xsuaa.clientid}")

--- a/spring-xsuaa-it/src/test/java/testservice/api/InitializeSecurityContextTest.java
+++ b/spring-xsuaa-it/src/test/java/testservice/api/InitializeSecurityContextTest.java
@@ -41,8 +41,7 @@ import testservice.api.nohttp.MyEventHandler;
 import testservice.api.nohttp.SecurityConfiguration;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(properties = {
-		"xsuaa.uaadomain=localhost" }, classes = { SecurityConfiguration.class, MyEventHandler.class,
+@SpringBootTest(classes = { SecurityConfiguration.class, MyEventHandler.class,
 				XsuaaAutoConfiguration.class,
 				XsuaaResourceServerJwkAutoConfiguration.class })
 @ActiveProfiles({ "test.api.nohttp", "uaamock" })

--- a/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/MockXsuaaServiceConfiguration.java
+++ b/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/MockXsuaaServiceConfiguration.java
@@ -10,16 +10,11 @@ public class MockXsuaaServiceConfiguration extends XsuaaServiceConfigurationDefa
 	private String mockXsuaaServerUrl;
 
 	@Override
-	public String getTokenKeyUrl(String zid, String subdomain) {
-		if (!mockXsuaaServerUrl.isEmpty() && mockXsuaaServerUrl == getUaaUrl()) {
-			return getUaaUrl() + "/" + subdomain + "/token_keys";
-		}
-		return super.getTokenKeyUrl(zid, subdomain);
-	}
-
-	@Override
 	public String getUaaDomain() {
-		return "localhost";
+		if (!mockXsuaaServerUrl.isEmpty() && mockXsuaaServerUrl == getUaaUrl()) {
+			return "localhost";
+		}
+		return super.getUaaDomain();
 	}
 
 }

--- a/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/MockXsuaaServiceConfiguration.java
+++ b/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/MockXsuaaServiceConfiguration.java
@@ -16,4 +16,10 @@ public class MockXsuaaServiceConfiguration extends XsuaaServiceConfigurationDefa
 		}
 		return super.getTokenKeyUrl(zid, subdomain);
 	}
+
+	@Override
+	public String getUaaDomain() {
+		return "localhost";
+	}
+
 }

--- a/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/XsuaaMockWebServer.java
+++ b/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/XsuaaMockWebServer.java
@@ -14,11 +14,13 @@ import okhttp3.mockwebserver.MockWebServer;
 public class XsuaaMockWebServer extends PropertySource<MockWebServer> implements DisposableBean {
 
 	public static final String MOCK_XSUAA_PROPERTY_SOURCE_NAME = "mockxsuaaserver";
-	private static final String MOCK_XSUAA_URL = "mockxsuaaserver.url";
+	public static final String MOCK_XSUAA_URL = "mockxsuaaserver.url";
+	// must match the port defined in JwtGenerator
+	private static final int MOCK_XSUAA_PORT = 33195;
 
 	private static final Log logger = LogFactory.getLog(XsuaaMockWebServer.class);
 
-	private boolean started;
+	private static boolean started;
 
 	public XsuaaMockWebServer() {
 		super(MOCK_XSUAA_PROPERTY_SOURCE_NAME, createMockWebServer(new XsuaaRequestDispatcher()));
@@ -69,7 +71,7 @@ public class XsuaaMockWebServer extends PropertySource<MockWebServer> implements
 
 	private void intializeMockXsuaa(MockWebServer mockWebServer) {
 		try {
-			mockWebServer.start();
+			mockWebServer.start(MOCK_XSUAA_PORT);
 			this.started = true;
 			logger.warn(
 					">>>>>>>>>>>Started Xsuaa mock Server that provides public keys for offline JWT Token validation. NEVER run in productive environment!<<<<<<");

--- a/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/XsuaaMockWebServer.java
+++ b/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/XsuaaMockWebServer.java
@@ -66,7 +66,7 @@ public class XsuaaMockWebServer extends PropertySource<MockWebServer> implements
 
 	private String getUrl(MockWebServer mockWebServer) {
 		String url = mockWebServer.url("").url().toExternalForm();
-		return url.substring(0, url.length() - 1);
+		return url.substring(0, url.length() - 1).replace("127.0.0.1", "localhost");
 	}
 
 	private void intializeMockXsuaa(MockWebServer mockWebServer) {

--- a/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/XsuaaRequestDispatcher.java
+++ b/spring-xsuaa-mock/src/main/java/com/sap/cloud/security/xsuaa/mock/XsuaaRequestDispatcher.java
@@ -21,9 +21,11 @@ public class XsuaaRequestDispatcher extends Dispatcher {
 	protected static final String PATH_TOKEN_KEYS_TEMPLATE = "/mock/token_keys_template.json";
 	protected static final String PATH_PUBLIC_KEY = "/mock/publicKey.txt";
 	protected final Log logger = LogFactory.getLog(XsuaaRequestDispatcher.class);
+	private static int callCount = 0;
 
 	@Override
 	public MockResponse dispatch(RecordedRequest request) {
+		callCount++;
 		if ("/testdomain/token_keys".equals(request.getPath())) {
 			String subdomain = "testdomain";
 			return getTokenKeyForKeyId(PATH_TOKEN_KEYS_TEMPLATE, "legacy-token-key-" + subdomain);
@@ -71,4 +73,7 @@ public class XsuaaRequestDispatcher extends Dispatcher {
 		return getResponse(RESPONSE_500 + ": " + message, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
+	public static int getCallCount() {
+		return callCount;
+	}
 }

--- a/spring-xsuaa-mock/src/test/java/com/sap/cloud/security/xsuaa/mock/XsuaaMockWebServerTest.java
+++ b/spring-xsuaa-mock/src/test/java/com/sap/cloud/security/xsuaa/mock/XsuaaMockWebServerTest.java
@@ -22,7 +22,6 @@ public class XsuaaMockWebServerTest {
 		InetAddress address = InetAddress.getLocalHost();
 		String url = (String) xsuaaMockServer.getProperty(XsuaaMockWebServer.MOCK_XSUAA_PROPERTY_SOURCE_NAME);
 		url = url.toLowerCase();
-		url = url.replace("127.0.0.1", "localhost");
 		url = url.replace(address.getCanonicalHostName().toLowerCase(), "localhost");
 		Assert.assertThat(url, startsWith("http://localhost"));
 	}

--- a/spring-xsuaa-test/src/main/java/com/sap/cloud/security/xsuaa/test/JwtGenerator.java
+++ b/spring-xsuaa-test/src/main/java/com/sap/cloud/security/xsuaa/test/JwtGenerator.java
@@ -43,6 +43,9 @@ public class JwtGenerator {
 		static final String CLAIM_EXTERNAL_ATTR = "ext_attr";
 	}
 
+	// must match the port defined in XsuaaMockWebServer
+	private static final int MOCK_XSUAA_PORT = 33195;
+
 	public static final Date NO_EXPIRE_DATE = new GregorianCalendar(2190, 11, 31).getTime();
 	public static final int NO_EXPIRE = Integer.MAX_VALUE;
 	public static final String CLIENT_ID = "sb-xsapplication!t895";
@@ -50,14 +53,13 @@ public class JwtGenerator {
 	private static final String PRIVATE_KEY_FILE = "/privateKey.txt";
 	private final String clientId;
 	private String identityZoneId;
-	String subdomain = "";
-	/*
-	* see TokenImpl.GRANTTYPE_SAML2BEARER
-	 */
+	private String subdomain = "";
+	private String jku;
+	// see TokenImpl.GRANTTYPE_SAML2BEARER
 	private static final String GRANT_TYPE = "urn:ietf:params:oauth:grant-type:saml2-bearer";
 	private String[] scopes;
 	private String userName = "testuser";
-	private String jwtHeaderKeyId;
+	private String jwtHeaderKeyId = "legacy-token-key";
 	public Map<String, List<String>> attributes = new HashMap<>();
 	private Map<String, Object> customClaims = new LinkedHashMap();
 	private boolean deriveAudiences = false;
@@ -74,6 +76,7 @@ public class JwtGenerator {
 	public JwtGenerator(String clientId) {
 		this.clientId = clientId;
 		this.identityZoneId = DEFAULT_IDENTITY_ZONE_ID;
+		this.jku = createJku(null);
 	}
 
 	/**
@@ -93,6 +96,7 @@ public class JwtGenerator {
 		this.clientId = clientId;
 		this.subdomain = subdomain;
 		this.identityZoneId = subdomain + "-id";
+		this.jku = createJku(subdomain);
 	}
 
 	public JwtGenerator() {
@@ -191,6 +195,18 @@ public class JwtGenerator {
 	}
 
 	/**
+	 * Sets the url which is used to retrieve the verification keys
+	 *
+	 * @param jku
+	 *            the url to retrieve the keys
+	 * @return the JwtGenerator itself
+	 */
+	public JwtGenerator setJku(String jku) {
+		this.jku = jku;
+		return this;
+	}
+
+	/**
 	 * Builds a basic Jwt with the given clientId, userName, scopes, user attributes
 	 * claims and the keyId header.
 	 *
@@ -211,8 +227,12 @@ public class JwtGenerator {
 		for (Map.Entry<String, Object> customClaim : customClaims.entrySet()) {
 			claimsSetBuilder.claim(customClaim.getKey(), customClaim.getValue());
 		}
+		return createFromClaims(claimsSetBuilder.build().toString(), jwtHeaderKeyId, jku);
+	}
 
-		return createFromClaims(claimsSetBuilder.build().toString(), jwtHeaderKeyId);
+	private static String createJku(String subdomain) {
+		String subdomainPart =  subdomain != null && !subdomain.equals("") ? "/" + subdomain : "";
+		return "http://localhost:" + MOCK_XSUAA_PORT + subdomainPart + "/token_keys";
 	}
 
 	private List<String> deriveAudiencesFromScopes(String[] scopes) {
@@ -255,7 +275,7 @@ public class JwtGenerator {
 	public Jwt createFromTemplate(String pathToTemplate) throws IOException {
 		String claimsFromTemplate = IOUtils.resourceToString(pathToTemplate, StandardCharsets.UTF_8);
 		String claimsWithReplacements = replacePlaceholders(claimsFromTemplate);
-		return createFromClaims(claimsWithReplacements, jwtHeaderKeyId);
+		return createFromClaims(claimsWithReplacements, jwtHeaderKeyId, jku);
 	}
 
 	/**
@@ -279,7 +299,7 @@ public class JwtGenerator {
 	 * @return a jwt
 	 */
 	public static Jwt createFromClaims(JWTClaimsSet claimsSet) {
-		return createFromClaims(claimsSet.toString(), null);
+		return createFromClaims(claimsSet.toString(), null, null);
 	}
 
 	/**
@@ -301,8 +321,8 @@ public class JwtGenerator {
 				.claim(TokenClaims.CLAIM_GRANT_TYPE, GRANT_TYPE);
 	}
 
-	private static Jwt createFromClaims(String claims, String jwtHeaderKeyId) {
-		String token = signAndEncodeToken(claims, jwtHeaderKeyId);
+	private static Jwt createFromClaims(String claims, String jwtHeaderKeyId, String jku) {
+		String token = signAndEncodeToken(claims, jwtHeaderKeyId, jku);
 		return convertTokenToOAuthJwt(token);
 	}
 
@@ -316,13 +336,15 @@ public class JwtGenerator {
 		return claims;
 	}
 
-	private static String signAndEncodeToken(String claims, String keyId) {
+	private static String signAndEncodeToken(String claims, String keyId, String jku) {
 		RsaSigner signer = new RsaSigner(readPrivateKeyFromFile());
 
-		Map<String, String> headers = Collections.emptyMap();
+		Map<String, String> headers = new HashMap<>();
 		if (keyId != null) {
-			headers = new HashMap<>();
 			headers.put("kid", keyId);
+		}
+		if (jku != null) {
+			headers.put("jku", jku);
 		}
 
 		org.springframework.security.jwt.Jwt jwt = JwtHelper.encode(claims, signer, headers);

--- a/spring-xsuaa-test/src/main/java/com/sap/cloud/security/xsuaa/test/JwtGenerator.java
+++ b/spring-xsuaa-test/src/main/java/com/sap/cloud/security/xsuaa/test/JwtGenerator.java
@@ -23,8 +23,8 @@ import com.nimbusds.jwt.JWTParser;
 public class JwtGenerator {
 
 	/**
-	 * Do not want to introduce circular reference to spring-xsuaa.
-	 * duplicate of com.sap.cloud.security.xsuaa.token.TokenClaims
+	 * Do not want to introduce circular reference to spring-xsuaa. duplicate of
+	 * com.sap.cloud.security.xsuaa.token.TokenClaims
 	 */
 	public final class TokenClaims {
 		private TokenClaims() {
@@ -231,7 +231,7 @@ public class JwtGenerator {
 	}
 
 	private static String createJku(String subdomain) {
-		String subdomainPart =  subdomain != null && !subdomain.equals("") ? "/" + subdomain : "";
+		String subdomainPart = subdomain != null && !subdomain.equals("") ? "/" + subdomain : "";
 		return "http://localhost:" + MOCK_XSUAA_PORT + subdomainPart + "/token_keys";
 	}
 

--- a/spring-xsuaa-test/src/test/java/com/sap/cloud/security/xsuaa/test/JwtGeneratorTest.java
+++ b/spring-xsuaa-test/src/test/java/com/sap/cloud/security/xsuaa/test/JwtGeneratorTest.java
@@ -100,6 +100,7 @@ public class JwtGeneratorTest {
 
 	@Test
 	public void testTokenFromFile() throws IOException {
+		jwtGenerator.setJku(null).setJwtHeaderKeyId(null);
 		Jwt jwtFromTemplate = jwtGenerator.createFromTemplate("/claims_template.txt");
 		String jwtTokenFromTemplate = jwtFromTemplate.getTokenValue();
 		Jwt jwtFromFile = JwtGenerator.createFromFile("/token_cc.txt");

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfiguration.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfiguration.java
@@ -31,6 +31,8 @@ public interface XsuaaServiceConfiguration {
 	 * @param subdomain
 	 *            of the subaccount
 	 * @return token key endpoint
+	 *
+	 * @deprecated Xsuaa version 2.8.0 provides jwt token key url (jku) as part of the JWT. This method gets deleted with version 2.0.0.
 	 */
 	String getTokenKeyUrl(String zid, String subdomain);
 

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfiguration.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfiguration.java
@@ -32,7 +32,8 @@ public interface XsuaaServiceConfiguration {
 	 *            of the subaccount
 	 * @return token key endpoint
 	 *
-	 * @deprecated Xsuaa version 2.8.0 provides jwt token key url (jku) as part of the JWT. This method gets deleted with version 2.0.0.
+	 * @deprecated Xsuaa version 2.8.0 provides jwt token key url (jku) as part of
+	 *             the JWT. This method gets deleted with version 2.0.0.
 	 */
 	String getTokenKeyUrl(String zid, String subdomain);
 

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationDefault.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationDefault.java
@@ -18,7 +18,7 @@ public class XsuaaServiceConfigurationDefault implements XsuaaServiceConfigurati
 	@Value("${xsuaa.url:}")
 	private String uaaUrl;
 
-	@Value("${xsuaa.uaadomain:}")
+	@Value("${xsuaa.uaadomain:#{null}}")
 	private String uaadomain;
 
 	@Value("${xsuaa.identityzoneid:}")

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationDefault.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationDefault.java
@@ -39,6 +39,7 @@ public class XsuaaServiceConfigurationDefault implements XsuaaServiceConfigurati
 
 	@Override
 	public String getTokenKeyUrl(String zid, String subdomain) {
+		// Please note this method is deprecated and will be deleted with version 2.0
 		if ("uaa".equals(zid)) {
 			return uaaUrl + "/token_keys";
 		} else {

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/AuthenticationToken.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/AuthenticationToken.java
@@ -7,8 +7,8 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 /**
- * Internal class used to expose the {@link Token} implementation as the standard Principal for Spring
- * Security Jwt handling.
+ * Internal class used to expose the {@link Token} implementation as the
+ * standard Principal for Spring Security Jwt handling.
  *
  * @see TokenAuthenticationConverter
  * @see TokenImpl

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/Token.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/Token.java
@@ -11,7 +11,7 @@ import java.util.Date;
 
 public interface Token extends UserDetails {
 	/*
-	* @deprecated use instead {@link TokenClaims.CLAIM_XS_USER_ATTRIBUTES}
+	 * @deprecated use instead {@link TokenClaims.CLAIM_XS_USER_ATTRIBUTES}
 	 */
 	String CLAIM_XS_USER_ATTRIBUTES = "xs.user.attributes";
 	/*

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/TokenClaims.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/TokenClaims.java
@@ -4,19 +4,19 @@ package com.sap.cloud.security.xsuaa.token;
  * Class with public constants denoting custom XSUAA Jwt claims.
  */
 public final class TokenClaims {
-    private TokenClaims() {
-        throw new IllegalStateException("Utility class");
-    }
+	private TokenClaims() {
+		throw new IllegalStateException("Utility class");
+	}
 
-    public static final String CLAIM_XS_USER_ATTRIBUTES = "xs.user.attributes";
-    public static final String CLAIM_SCOPES = "scope";
-    public static final String CLAIM_CLIENT_ID = "cid";
-    public static final String CLAIM_USER_NAME = "user_name";
-    public static final String CLAIM_GIVEN_NAME = "given_name";
-    public static final String CLAIM_FAMILY_NAME = "family_name";
-    public static final String CLAIM_EMAIL = "email";
-    public static final String CLAIM_ORIGIN = "origin";
-    public static final String CLAIM_GRANT_TYPE = "grant_type";
-    public static final String CLAIM_ZDN = "zdn";
-    public static final String CLAIM_ZONE_ID = "zid";
+	public static final String CLAIM_XS_USER_ATTRIBUTES = "xs.user.attributes";
+	public static final String CLAIM_SCOPES = "scope";
+	public static final String CLAIM_CLIENT_ID = "cid";
+	public static final String CLAIM_USER_NAME = "user_name";
+	public static final String CLAIM_GIVEN_NAME = "given_name";
+	public static final String CLAIM_FAMILY_NAME = "family_name";
+	public static final String CLAIM_EMAIL = "email";
+	public static final String CLAIM_ORIGIN = "origin";
+	public static final String CLAIM_GRANT_TYPE = "grant_type";
+	public static final String CLAIM_ZDN = "zdn";
+	public static final String CLAIM_ZONE_ID = "zid";
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/TokenImpl.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/TokenImpl.java
@@ -40,7 +40,6 @@ public class TokenImpl extends Jwt implements Token {
 	static final String UNIQUE_USER_NAME_FORMAT = "user/%s/%s"; // user/<origin>/<logonName>
 	static final String UNIQUE_CLIENT_NAME_FORMAT = "client/%s"; // client/<clientid>
 
-
 	static final String CLAIM_SERVICEINSTANCEID = "serviceinstanceid";
 	static final String CLAIM_ADDITIONAL_AZ_ATTR = "az_attr";
 	static final String CLAIM_EXTERNAL_ATTR = "ext_attr";

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
@@ -1,22 +1,30 @@
 package com.sap.cloud.security.xsuaa.token.authentication;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
+import org.springframework.util.Assert;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTParser;
 import com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration;
-import net.minidev.json.JSONObject;
-import org.springframework.security.oauth2.core.OAuth2TokenValidator;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtException;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
-import org.springframework.util.Assert;
 
 public class XsuaaJwtDecoder implements JwtDecoder {
+	private final Log logger = LogFactory.getLog(XsuaaJwtDecoder.class);
 
 	Cache<String, JwtDecoder> cache;
 	private XsuaaServiceConfiguration xsuaaServiceConfiguration;
@@ -33,32 +41,70 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 	@Override
 	public Jwt decode(String token) throws JwtException {
 		Assert.notNull(token, "token is required");
-		try {
-			JWT jwt = JWTParser.parse(token);
-			String subdomain = getSubdomain(jwt);
+		JWT jwt;
 
-			String zid = jwt.getJWTClaimsSet().getStringClaim("zid");
-			JwtDecoder decoder = cache.get(subdomain, k -> this.getDecoder(zid, subdomain));
-			return decoder.decode(token);
+		try {
+			jwt = JWTParser.parse(token);
 		} catch (ParseException ex) {
 			throw new JwtException("Error initializing JWT decoder:" + ex.getMessage());
 		}
+
+		String jku = (String) jwt.getHeader().toJSONObject().getOrDefault("jku", null);
+		String kid = (String) jwt.getHeader().toJSONObject().getOrDefault("kid", null);
+		String uaadomain = xsuaaServiceConfiguration.getUaaDomain();
+
+		try {
+			canVerifyWithOnlineKey(jku, kid, uaadomain);
+			validateJKU(jku, uaadomain);
+			return verifyWithOnlineKey(token, jku, kid);
+		} catch (JwtValidationException ex) {
+			throw ex;
+		} catch (JwtException ex) {
+			throw new JwtException("JWT verification failed:" + ex.getMessage());
+		}
 	}
 
-	protected JwtDecoder getDecoder(String zid, String subdomain) {
-		String url = xsuaaServiceConfiguration.getTokenKeyUrl(zid, subdomain);
-		NimbusJwtDecoderJwkSupport decoder = new NimbusJwtDecoderJwkSupport(url);
+	private void canVerifyWithOnlineKey(String jku, String kid, String uaadomain) {
+		if (jku != null && kid != null && uaadomain != null) {
+			return;
+		}
+
+		List<String> nullParams = new ArrayList<>();
+		if (jku == null)
+			nullParams.add("jku");
+		if (kid == null)
+			nullParams.add("kid");
+		if (uaadomain == null)
+			nullParams.add("uaadomain");
+
+		throw new JwtException(String.format("Cannot verify with online key, %s is null",
+				String.join(", ", nullParams)));
+	}
+
+	private void validateJKU(String jku, String uaadomain) {
+		try {
+			URI jkuUri = new URI(jku);
+			if (jkuUri.getHost() == null) {
+				throw new JwtException("JKU of token is not valid");
+			} else if (!jkuUri.getHost().endsWith(uaadomain)) {
+				logger.warn(String.format("Error: Do not trust jku '%s' because it does not match uaa domain '%s'",
+						jku, uaadomain));
+				throw new JwtException("JKU of token is not trusted");
+			}
+		} catch (URISyntaxException e) {
+			throw new JwtException("JKU of token is not valid");
+		}
+	}
+
+	private Jwt verifyWithOnlineKey(String token, String jku, String kid) {
+		String cacheKey = jku + kid;
+		JwtDecoder decoder = cache.get(cacheKey, k -> this.getDecoder(jku));
+		return decoder.decode(token);
+	}
+
+	private JwtDecoder getDecoder(String jku) {
+		NimbusJwtDecoderJwkSupport decoder = new NimbusJwtDecoderJwkSupport(jku);
 		decoder.setJwtValidator(tokenValidators);
 		return decoder;
 	}
-
-	protected String getSubdomain(JWT jwt) throws ParseException {
-		String subdomain = "";
-		JSONObject extAttr = jwt.getJWTClaimsSet().getJSONObjectClaim("ext_attr");
-		if (extAttr != null && extAttr.getAsString("zdn") != null) {
-			subdomain = extAttr.getAsString("zdn");
-		}
-		return subdomain;
-	}
-
 }


### PR DESCRIPTION
Use jku of token to retrieve token keys instead of building
url.

Keep JWTGenerator compatible by setting JKU in token in transparent way.
Assumption: Mock xsuaa url is 'http://localhost:33195'