### PR TITLE
Deprecates SecurityContext to avoid issues with Security Container lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ All notable changes to this project will be documented in this file.
 * Supports reactive ServerHttpSecurity (Spring webflux). Have a look at the (webflux sample application)[samples/spring-webflux-security-xsuaa-usage/README.md]
 * Some enhancements for XSUAA integration
 * To make sure that the Spring SecurityContext is always initialized with a validated token use `SpringSecurityContext.init()` method as documented [here](spring-xsuaa/README.md)
+* Use `SpringSecurityContext` instead of `SecurityContext`, which gets deprecated in this version. With version `2.0.0` we want to get rid of package `com.sap.xs2.security.container` in order to avoid Class Loader issues, when an application makes use of SAP-libraries using the SAP-internal container lib.
 
 ### Incompatible changes
-* As of version `1.6.0` you need to make use of XSUAA Spring Boot Starter in order to leverage auto-configuration (see Troubleshoot section [here](spring-xsuaa/README.md))
-* To avoid issues, when an application makes use of SAP-libraries using the SAP-internal container lib, use `SpringSecurityContext` instead of `SecurityContext`.
+* As of version `1.6.0` you need to make use of XSUAA Spring Boot Starter in order to leverage auto-configuration (see "Troubleshoot" section [here](spring-xsuaa/README.md#troubleshoot))
+
 
 ## 1.5.0
 * Supports `jku` URI which is provided as part of the JSON Web Signature (JWS). The `jku` of the Jwt token header references the public key URI of the Xsuaa OAuth Authorization Server, and needs to match to the `xsuaa.uaadomain`.

--- a/spring-xsuaa-it/src/main/java/testservice/api/nohttp/MyEventHandler.java
+++ b/spring-xsuaa-it/src/main/java/testservice/api/nohttp/MyEventHandler.java
@@ -29,6 +29,7 @@ public class MyEventHandler {
 	@Autowired
 	JwtDecoder jwtDecoder;
 
+	@Deprecated
 	public void onEvent_deprecated(String myEncodedJwtToken) {
 		if (myEncodedJwtToken != null) {
 			Jwt jwtToken = jwtDecoder.decode(myEncodedJwtToken);

--- a/spring-xsuaa/src/main/java/com/sap/xs2/security/container/SecurityContext.java
+++ b/spring-xsuaa/src/main/java/com/sap/xs2/security/container/SecurityContext.java
@@ -11,6 +11,13 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
+/**
+ * As part of this Spring xsuaa library, we need to get rid of {@code com.sap.xs2.security.container} package.
+ * It will be removed with version {@code 2.0.0}
+ *
+ * @deprecated use {@link SpringSecurityContext} class instead.
+ */
+@Deprecated
 public class SecurityContext {
 	/**
 	 * Obtain the UserInfo object from the Spring Security Context
@@ -20,7 +27,6 @@ public class SecurityContext {
 	 *             in case of error
 	 * @deprecated use {@link #getToken()} instead.
 	 */
-	@Deprecated
 	static public UserInfo getUserInfo() throws UserInfoException {
 		if (SecurityContextHolder.getContext().getAuthentication() != null) {
 			if (SecurityContextHolder.getContext().getAuthentication().getPrincipal() instanceof UserInfo) {
@@ -43,7 +49,6 @@ public class SecurityContext {
 	 *             Note: This method is introduced with xsuaa spring client lib.
 	 * @deprecated method is moved to {@link SpringSecurityContext#getToken()}
 	 */
-	@Deprecated
 	static public Token getToken() {
 		return SpringSecurityContext.getToken();
 	}
@@ -64,7 +69,6 @@ public class SecurityContext {
 	 *             {@link SpringSecurityContext#init(String, JwtDecoder, AuthoritiesExtractor)}
 	 *             instead
 	 */
-	@Deprecated
 	static public void init(String appId, Jwt token, boolean extractLocalScopesOnly) {
 		TokenAuthenticationConverter authenticationConverter = new TokenAuthenticationConverter(
 				new LocalAuthoritiesExtractor(appId));
@@ -80,7 +84,6 @@ public class SecurityContext {
 	 *
 	 * @deprecated method is moved to {@link SpringSecurityContext#clear()}
 	 */
-	@Deprecated
 	static public void clear() {
 		SpringSecurityContext.clear();
 	}


### PR DESCRIPTION
- preparation for 2.0.0

Considers this issue:
- https://github.com/SAP/cloud-security-xsuaa-integration/issues/119