### PR TITLE
Add further testcase to webflux sample application

### DIFF
--- a/samples/spring-webflux-security-xsuaa-usage/pom.xml
+++ b/samples/spring-webflux-security-xsuaa-usage/pom.xml
@@ -49,6 +49,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.sap.cloud.security.xsuaa</groupId>
+			<artifactId>spring-xsuaa-mock</artifactId>
+			<version>1.5.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/samples/spring-webflux-security-xsuaa-usage/pom.xml
+++ b/samples/spring-webflux-security-xsuaa-usage/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>2.1.5.RELEASE</version>
-		<relativePath/>
+		<relativePath />
 	</parent>
 
 	<groupId>com.sap.cloud.security.samples</groupId>
@@ -40,16 +40,26 @@
 			<artifactId>spring-xsuaa</artifactId>
 			<version>1.5.0</version>
 		</dependency>
+
+		<dependency>
+			<groupId>com.sap.cloud.security.xsuaa</groupId>
+			<artifactId>spring-xsuaa-test</artifactId>
+			<version>1.5.0</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>

--- a/samples/spring-webflux-security-xsuaa-usage/src/main/java/sample/spring/webflux/xsuaa/TestController.java
+++ b/samples/spring-webflux-security-xsuaa-usage/src/main/java/sample/spring/webflux/xsuaa/TestController.java
@@ -13,16 +13,13 @@ import reactor.core.publisher.Mono;
 @RestController
 public class TestController {
 
-    @GetMapping("/v1/sayHello")
-    public Mono<ResponseEntity<String>> sayHello() {
-        ResponseEntity.BodyBuilder unAuthenticated = ResponseEntity.status(HttpStatus.UNAUTHORIZED);
+	@GetMapping("/v1/sayHello")
+	public Mono<ResponseEntity<String>> sayHello() {
+		ResponseEntity.BodyBuilder unAuthenticated = ResponseEntity.status(HttpStatus.UNAUTHORIZED);
 
-        return ReactiveSecurityContext.getToken()
-                .doOnError(throwable -> Mono.just(unAuthenticated))
-                .flatMap(token -> {
-                    return Mono.just(ResponseEntity.ok()
-                            .contentType(MediaType.TEXT_PLAIN)
-                            .body("Authorities: " + token.getAuthorities()));
-                });
-    }
+		return ReactiveSecurityContext.getToken()
+				.doOnError(throwable -> Mono.just(unAuthenticated))
+				.map(token -> ResponseEntity.ok().contentType(MediaType.TEXT_PLAIN)
+						.body("Authorities: " + token.getAuthorities()));
+	}
 }

--- a/samples/spring-webflux-security-xsuaa-usage/src/main/java/sample/spring/webflux/xsuaa/TestController.java
+++ b/samples/spring-webflux-security-xsuaa-usage/src/main/java/sample/spring/webflux/xsuaa/TestController.java
@@ -1,13 +1,13 @@
 package sample.spring.webflux.xsuaa;
 
-import com.sap.cloud.security.xsuaa.token.ReactiveSecurityContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.sap.cloud.security.xsuaa.token.ReactiveSecurityContext;
+
 import reactor.core.publisher.Mono;
 
 @RestController

--- a/samples/spring-webflux-security-xsuaa-usage/src/test/java/sample/spring/webflux/xsuaa/ApplicationTest.java
+++ b/samples/spring-webflux-security-xsuaa-usage/src/test/java/sample/spring/webflux/xsuaa/ApplicationTest.java
@@ -1,3 +1,4 @@
+package sample.spring.webflux.xsuaa;
 import com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaAutoConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/samples/spring-webflux-security-xsuaa-usage/src/test/java/sample/spring/webflux/xsuaa/TestControllerTest.java
+++ b/samples/spring-webflux-security-xsuaa-usage/src/test/java/sample/spring/webflux/xsuaa/TestControllerTest.java
@@ -1,0 +1,28 @@
+package sample.spring.webflux.xsuaa;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureWebTestClient
+public class TestControllerTest {
+
+	@Autowired
+	private WebTestClient webClient;
+
+	@Test
+	public void unauthorizedRequest() {
+		webClient.method(HttpMethod.GET).uri("/v1/sayHello").contentType(MediaType.APPLICATION_JSON_UTF8)
+				.header(HttpHeaders.AUTHORIZATION, "invalidToken").exchange().expectStatus().isUnauthorized();
+	}
+
+}

--- a/samples/spring-webflux-security-xsuaa-usage/src/test/java/sample/spring/webflux/xsuaa/TestControllerTest.java
+++ b/samples/spring-webflux-security-xsuaa-usage/src/test/java/sample/spring/webflux/xsuaa/TestControllerTest.java
@@ -11,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+import com.sap.cloud.security.xsuaa.test.JwtGenerator;
+
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureWebTestClient
@@ -21,8 +23,11 @@ public class TestControllerTest {
 
 	@Test
 	public void unauthorizedRequest() {
+		JwtGenerator jwtGenerator = new JwtGenerator();
+
 		webClient.method(HttpMethod.GET).uri("/v1/sayHello").contentType(MediaType.APPLICATION_JSON_UTF8)
-				.header(HttpHeaders.AUTHORIZATION, "invalidToken").exchange().expectStatus().isUnauthorized();
+				.header(HttpHeaders.AUTHORIZATION, jwtGenerator.getTokenForAuthorizationHeader()).exchange()
+				.expectStatus().isUnauthorized();
 	}
 
 }

--- a/samples/spring-webflux-security-xsuaa-usage/src/test/java/sample/spring/webflux/xsuaa/mock/XsuaaMockPostProcessor.java
+++ b/samples/spring-webflux-security-xsuaa-usage/src/test/java/sample/spring/webflux/xsuaa/mock/XsuaaMockPostProcessor.java
@@ -1,0 +1,26 @@
+package sample.spring.webflux.xsuaa.mock;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Profiles;
+
+import com.sap.cloud.security.xsuaa.mock.XsuaaMockWebServer;
+
+public class XsuaaMockPostProcessor implements EnvironmentPostProcessor, DisposableBean {
+
+	private final XsuaaMockWebServer mockAuthorizationServer = new XsuaaMockWebServer();
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		if (environment.acceptsProfiles(Profiles.of("uaamock"))) {
+			environment.getPropertySources().addFirst(this.mockAuthorizationServer);
+		}
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		this.mockAuthorizationServer.destroy();
+	}
+}

--- a/samples/spring-webflux-security-xsuaa-usage/src/test/resources/META-INF/spring.factories
+++ b/samples/spring-webflux-security-xsuaa-usage/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.env.EnvironmentPostProcessor=sample.spring.webflux.xsuaa.mock.XsuaaMockPostProcessor

--- a/samples/spring-webflux-security-xsuaa-usage/src/test/resources/application.properties
+++ b/samples/spring-webflux-security-xsuaa-usage/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=uaamock

--- a/samples/spring-webflux-security-xsuaa-usage/src/test/resources/application.properties
+++ b/samples/spring-webflux-security-xsuaa-usage/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 spring.profiles.active=uaamock
+xsuaa.clientid=sb-xsapplication!t895

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationDefault.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationDefault.java
@@ -41,7 +41,7 @@ public class XsuaaServiceConfigurationDefault implements XsuaaServiceConfigurati
 	public String getTokenKeyUrl(String zid, String subdomain) {
 		// Please note this method is deprecated and will be deleted with version 2.0
 		if ("uaa".equals(zid)) {
-			return uaaUrl + "/token_keys";
+			return getUaaUrl() + "/token_keys";
 		} else {
 			return String.format("https://%s.%s/token_keys", subdomain, uaadomain);
 		}


### PR DESCRIPTION
* Adding `spring-xsuaa-test` and `spring-xsuaa-mock` to webflux sample project.
* reduce verbosity of `TestController`
* Added authorized and unauthorized tests to `TestController` 

p.s. the `XsuaaServiceConfigurationDefault` wasn't building correctly the url from the `getTokenKeyUrl`. I wasn't setting the `uaaUrl` as I was expecting the mock to inject it.  Therefore, changed it to get the value from the method instead of accessing directly the attribute.


