### PR TITLE
Deprecated usage of java.util.Date, added java.time.Instant alternative

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/Token.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/Token.java
@@ -1,5 +1,7 @@
 package com.sap.cloud.security.xsuaa.token;
 
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Date;
 
@@ -164,10 +166,18 @@ public interface Token extends UserDetails {
 
 	/**
 	 * Returns date of when jwt token expires.
-	 *
+	 * @deprecated use {@link #getExpiration()}.
 	 * @return expiration date if present
 	 */
 	@Nullable
+	@Deprecated
 	Date getExpirationDate();
+
+	/**
+	 * Returns the moment in time when the token will be expired.
+	 * @return the expiration point in time if present.
+	 */
+	@Nullable
+	Instant getExpiration();
 
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/XsuaaToken.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/XsuaaToken.java
@@ -10,6 +10,9 @@ import static com.sap.cloud.security.xsuaa.token.TokenClaims.CLAIM_USER_NAME;
 import static com.sap.cloud.security.xsuaa.token.TokenClaims.CLAIM_ZDN;
 import static com.sap.cloud.security.xsuaa.token.TokenClaims.CLAIM_ZONE_ID;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -61,9 +64,15 @@ public class XsuaaToken extends Jwt implements Token {
 		return this.authorities;
 	}
 
+
 	@Override
 	public Date getExpirationDate() {
 		return getExpiresAt() != null ? Date.from(getExpiresAt()) : null;
+	}
+
+	@Override
+	public Instant getExpiration() {
+		return getExpiresAt();
 	}
 
 	@Override

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/XsuaaTokenTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/XsuaaTokenTest.java
@@ -74,6 +74,7 @@ public class XsuaaTokenTest {
 		assertThat(token.getAuthorities().size(), is(0));
 		assertThat(token.isEnabled(), is(false));
 		assertThat(token.getExpirationDate(), is(JwtGenerator.NO_EXPIRE_DATE));
+		assertThat(token.getExpiration(), is(JwtGenerator.NO_EXPIRE_DATE.toInstant()));
 		assertThat(token.getAdditionalAuthAttribute("any"), nullValue());
 	}
 

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenResponse.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenResponse.java
@@ -4,6 +4,7 @@ import com.sap.cloud.security.xsuaa.jwt.Base64JwtDecoder;
 import com.sap.cloud.security.xsuaa.jwt.DecodedJwt;
 
 import javax.annotation.Nullable;
+import java.time.Instant;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
@@ -42,9 +43,24 @@ public class OAuth2TokenResponse {
 		return new Base64JwtDecoder().decode(accessToken);
 	}
 
+	/**
+	 * Returns the moment in time when the token will be expired.
+	 * @return the expiration point in time if present.
+	 * @deprecated use {@link #getExpiredAt()}.
+	 */
+	@Deprecated
 	public Date getExpiredAtDate() {
 		return new Date(expiredTimeMillis);
 	}
+
+	/**
+	 * Returns the moment in time when the token will be expired.
+	 * @return the expiration point in time if present.
+	 */
+	public Instant getExpiredAt() {
+		return Instant.ofEpochMilli(expiredTimeMillis);
+	}
+
 
 	/**
 	 * An OAuth2 refresh token. Clients typically use the refresh token to obtain a

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenResponseTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenResponseTest.java
@@ -1,13 +1,14 @@
 package com.sap.cloud.security.xsuaa.client;
 
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.junit.Assert.assertThat;
+import org.hamcrest.number.OrderingComparison;
+import org.junit.Test;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import org.hamcrest.number.OrderingComparison;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.junit.Assert.assertThat;
 
 public class OAuth2TokenResponseTest {
 
@@ -20,6 +21,19 @@ public class OAuth2TokenResponseTest {
 		Date maxExpireDate = new Date(System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(expireInSeconds));
 
 		assertThat(accessToken.getExpiredAtDate(), allOf(OrderingComparison.greaterThanOrEqualTo(minExpireDate),
+				OrderingComparison.lessThanOrEqualTo(maxExpireDate)));
+	}
+
+	@Test
+	public void getExpiredFromAccessToken() {
+		long expireInSeconds = 47299;
+		Instant minExpireDate = Instant.now().plusSeconds(expireInSeconds);
+
+		OAuth2TokenResponse accessToken = new OAuth2TokenResponse(null, expireInSeconds, null);
+
+		Instant maxExpireDate = Instant.now().plusSeconds(expireInSeconds);
+
+		assertThat(accessToken.getExpiredAt(), allOf(OrderingComparison.greaterThanOrEqualTo(minExpireDate),
 				OrderingComparison.lessThanOrEqualTo(maxExpireDate)));
 	}
 }


### PR DESCRIPTION
I chose `Instant` in favour of `ZonedDateTime` (and `LocalDateTime`). Seemed to be the best fit. It is also used by spring in their OAuth2 Token implementation.