### PR TITLE
Implemented JWT bearer token grant support

### DIFF
--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/AbstractOAuth2TokenService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/AbstractOAuth2TokenService.java
@@ -104,6 +104,26 @@ public abstract class AbstractOAuth2TokenService implements OAuth2TokenService {
 		return requestAccessToken(UriUtil.replaceSubdomain(tokenEndpoint, subdomain), headers, parameters);
 	}
 
+	@Override
+	public OAuth2TokenResponse retrieveAccessTokenViaJwtBearerTokenGrant(URI tokenEndpoint,
+			ClientCredentials clientCredentials, String assertion, @Nullable String subdomain,
+			@Nullable Map<String, String> optionalParameters) throws OAuth2ServiceException {
+		Assertions.assertNotNull(tokenEndpoint, "tokenEndpoint is required");
+		Assertions.assertNotNull(clientCredentials, "clientCredentials are required");
+		Assertions.assertNotNull(assertion, "assertion is required");
+
+		Map<String, String> parameters = new RequestParameterBuilder()
+				.withGrantType(GRANT_TYPE_JWT_BEARER)
+				.withClientCredentials(clientCredentials)
+				.withAssertion(assertion)
+				.withOptionalParameters(optionalParameters)
+				.buildAsMap();
+
+		HttpHeaders headers = httpHeadersFactory.createWithoutAuthorizationHeader();
+
+		return requestAccessToken(UriUtil.replaceSubdomain(tokenEndpoint, subdomain), headers, parameters);
+	}
+
 	/**
 	 *
 	 * @param tokenEndpointUri

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenService.java
@@ -104,4 +104,27 @@ public interface OAuth2TokenService {
 			String username, String password, @Nullable String subdomain,
 			@Nullable Map<String, String> optionalParameters) throws OAuth2ServiceException;
 
+
+	/**
+	 * @param tokenEndpointUri
+	 *            the token endpoint URI.
+	 * @param clientCredentials
+	 *            the client id and secret of the OAuth client, the recipient of the
+	 *            token.
+	 * @param assertion
+	 *            the JWT token identifying representing the user to be
+	 *            authenticated
+	 * @param subdomain
+	 *            optionally indicates what Identity Zone this request goes to by
+	 *            supplying a subdomain (tenant).
+	 * @param optionalParameters
+	 *            optional request parameters, can be null.
+	 * @return the OAuth2AccessToken
+	 * @throws OAuth2ServiceException
+	 *             in case of an error during the http request.
+	 */
+	OAuth2TokenResponse retrieveAccessTokenViaJwtBearerTokenGrant(URI tokenEndpointUri,
+			ClientCredentials clientCredentials, String assertion, @Nullable String subdomain,
+			@Nullable Map<String, String> optionalParameters) throws OAuth2ServiceException;
+
 }

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenServiceConstants.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenServiceConstants.java
@@ -13,12 +13,14 @@ public class OAuth2TokenServiceConstants {
 	public static final String CLIENT_SECRET = "client_secret";
 	public static final String USERNAME = "username";
 	public static final String PASSWORD = "password";
+	public static final String ASSERTION = "assertion";
 
 	public static final String GRANT_TYPE = "grant_type";
 	public static final String GRANT_TYPE_USER_TOKEN = "user_token";
 	public static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
 	public static final String GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials";
 	public static final String GRANT_TYPE_PASSWORD = "password";
+	public static final String GRANT_TYPE_JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
 
 	public static final String TOKEN_TYPE_OPAQUE = "opaque";
 

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/RequestParameterBuilder.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/RequestParameterBuilder.java
@@ -48,6 +48,11 @@ public class RequestParameterBuilder {
 		return this;
 	}
 
+	public RequestParameterBuilder withAssertion(String assertion) {
+		parameters.put(ASSERTION, assertion);
+		return this;
+	}
+
 	public Map<String, String> buildAsMap() {
 		return parameters;
 	}

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServiceJwtBearerTokenTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServiceJwtBearerTokenTest.java
@@ -1,0 +1,182 @@
+package com.sap.cloud.security.xsuaa.client;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.*;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestOperations;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class XsuaaOAuth2TokenServiceJwtBearerTokenTest {
+
+	private OAuth2TokenService cut;
+
+	private String assertion = "jwtToken";
+	private String subdomain = "subdomain";
+	private ClientCredentials clientCredentials = new ClientCredentials("theClientId", "test321");
+	private URI tokenEndpoint = URI.create("https://subdomain.myauth.server.com/oauth/token");
+	private Map<String, String> optionalParameters;
+	private Map<String, String> response;
+
+	@Mock
+	private RestOperations mockRestOperations;
+
+	@Before
+	public void setup() {
+		response = new HashMap<>();
+		response.putIfAbsent(ACCESS_TOKEN, "f529.dd6e30.d454677322aaabb0");
+		response.putIfAbsent(EXPIRES_IN, "43199");
+		when(mockRestOperations.postForEntity(any(), any(), any()))
+				.thenReturn(ResponseEntity.status(200).body(response));
+		optionalParameters = new HashMap<>();
+		cut = new XsuaaOAuth2TokenService(mockRestOperations);
+	}
+
+	@Test(expected = OAuth2ServiceException.class)
+	public void retrieveToken_httpStatusUnauthorized_throwsException() throws OAuth2ServiceException {
+		throwExceptionOnPost(HttpStatus.UNAUTHORIZED);
+
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientCredentials,
+				assertion, null, null);
+	}
+
+	@Test(expected = OAuth2ServiceException.class)
+	public void retrieveToken_httpStatusNotOk_throwsException() throws OAuth2ServiceException {
+		throwExceptionOnPost(HttpStatus.BAD_REQUEST);
+
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientCredentials,
+				assertion, null, null);
+	}
+
+	@Test
+	public void retrieveToken_requiredParametersMissing_throwsException() {
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaJwtBearerTokenGrant(null, clientCredentials,
+				assertion, subdomain, optionalParameters)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, null,
+				assertion, subdomain, optionalParameters)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientCredentials,
+				null, subdomain, optionalParameters)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void retrieveToken_callsTokenEndpoint() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientCredentials,
+				assertion, null, null);
+
+		Mockito.verify(mockRestOperations, times(1))
+				.postForEntity(eq(tokenEndpoint), any(), any());
+	}
+
+	@Test
+	public void retrieveToken_setsCorrectGrantType() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientCredentials,
+				assertion, null, null);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+
+		String actualGrantType = valueOfParameter(GRANT_TYPE, requestEntityCaptor);
+		assertThat(actualGrantType).isEqualTo(GRANT_TYPE_JWT_BEARER);
+	}
+
+	@Test
+	public void retrieveToken_setsAssertion() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientCredentials,
+				assertion, null, null);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+
+		assertThat(valueOfParameter(ASSERTION, requestEntityCaptor)).isEqualTo(assertion);
+	}
+
+	@Test
+	public void retrieveToken_setsClientCredentials() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientCredentials,
+				assertion, null, null);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+
+		assertThat(valueOfParameter(CLIENT_ID, requestEntityCaptor)).isEqualTo(clientCredentials.getId());
+		assertThat(valueOfParameter(CLIENT_SECRET, requestEntityCaptor)).isEqualTo(clientCredentials.getSecret());
+	}
+
+	@Test
+	public void retrieveToken_setsOptionalParameters() throws OAuth2ServiceException {
+		String tokenFormatParameterName = "token_format";
+		String tokenFormat = "opaque";
+		String responseTypeParameterName = "response_type";
+		String loginHint = "token";
+
+		optionalParameters.put(tokenFormatParameterName, tokenFormat);
+		optionalParameters.put(responseTypeParameterName, loginHint);
+
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientCredentials,
+				assertion, null, optionalParameters);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+		assertThat(valueOfParameter(tokenFormatParameterName, requestEntityCaptor)).isEqualTo(tokenFormat);
+		assertThat(valueOfParameter(responseTypeParameterName, requestEntityCaptor)).isEqualTo(loginHint);
+	}
+
+	@Test
+	public void retrieveToken_setsCorrectHeaders() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientCredentials,
+				assertion, null, optionalParameters);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+		HttpHeaders headers = requestEntityCaptor.getValue().getHeaders();
+
+		assertThat(headers.getAccept()).containsExactly(MediaType.APPLICATION_JSON);
+		assertThat(headers.getContentType()).isEqualTo(MediaType.APPLICATION_FORM_URLENCODED);
+	}
+
+	@Test
+	public void retrieveToken() throws OAuth2ServiceException {
+		OAuth2TokenResponse actualResponse = cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint,
+				clientCredentials,
+				assertion, null, null);
+
+		assertThat(actualResponse.getAccessToken()).isEqualTo(response.get(ACCESS_TOKEN));
+		assertThat(actualResponse.getExpiredAt()).isNotNull();
+	}
+
+	private ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> captureRequestEntity() {
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = ArgumentCaptor
+				.forClass(HttpEntity.class);
+		Mockito.verify(mockRestOperations, times(1))
+				.postForEntity(
+						eq(tokenEndpoint),
+						requestEntityCaptor.capture(),
+						eq(Map.class));
+		return requestEntityCaptor;
+	}
+
+	private String valueOfParameter(
+			String parameterKey, ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor) {
+		MultiValueMap<String, String> body = requestEntityCaptor.getValue().getBody();
+		return body.getFirst(parameterKey);
+	}
+
+	private void throwExceptionOnPost(HttpStatus unauthorized) {
+		when(mockRestOperations.postForEntity(any(), any(), any()))
+				.thenThrow(new HttpClientErrorException(unauthorized));
+	}
+
+}


### PR DESCRIPTION
In case a trust is created between IAS and XSUAA, then you can use this to replace an IAS OIDC token with an XSUAA Access Token.

Furthermore its possible to attach a Role Collection to this IAS Identity Provider in the cockpit to receive scopes as part of the returned access token.