### PR TITLE
Excluded vulnerable jackson library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,24 @@
 				<groupId>org.springframework.security.oauth</groupId>
 				<artifactId>spring-security-oauth2</artifactId>
 				<version>${spring.security.oauth2.version}</version>
+				<exclusions>
+					<exclusion>
+					<groupId>org.codehaus.jackson</groupId>
+					<artifactId>jackson-core-asl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.codehaus.jackson</groupId>
+					<artifactId>jackson-mapper-asl</artifactId>
+				</exclusion>
+				<exclusion>
+					<artifactId>spring-beans</artifactId>
+					<groupId>org.springframework</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>spring-context</artifactId>
+					<groupId>org.springframework</groupId>
+				</exclusion>
+			</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.security</groupId>

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -65,16 +65,6 @@
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
 			<scope>compile</scope>
-			<exclusions>
-				<exclusion>
-					<artifactId>spring-beans</artifactId>
-					<groupId>org.springframework</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>spring-context</artifactId>
-					<groupId>org.springframework</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
I have moved the exclusion rule for spring-security-oauth2 to the parent pom and added exclusions for vulnerable jackson libraries (CVE-2019-10202) that we don't actually use. I have successfully tested this with all the samples. 

relates to NGPBUG-98555