### PR TITLE
Jwt decoder refactoring

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/DefaultJwtDecoderFactory.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/DefaultJwtDecoderFactory.java
@@ -1,0 +1,16 @@
+package com.sap.cloud.security.xsuaa.token.authentication;
+
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoderJwkSupport;
+
+public class DefaultJwtDecoderFactory implements JwtDecoderFactory {
+
+	@Override
+	public JwtDecoder create(String jku, OAuth2TokenValidator<Jwt> tokenValidator) {
+		NimbusJwtDecoderJwkSupport decoder = new NimbusJwtDecoderJwkSupport(jku);
+		decoder.setJwtValidator(tokenValidator);
+		return decoder;
+	}
+}

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/DefaultReactiveJwtDecoderFactory.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/DefaultReactiveJwtDecoderFactory.java
@@ -1,0 +1,17 @@
+package com.sap.cloud.security.xsuaa.token.authentication;
+
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+
+public class DefaultReactiveJwtDecoderFactory implements ReactiveJwtDecoderFactory {
+
+	@Override
+	public ReactiveJwtDecoder create(String jku, OAuth2TokenValidator<Jwt> tokenValidator) {
+		NimbusReactiveJwtDecoder decoder = new NimbusReactiveJwtDecoder(jku);
+		decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(tokenValidator));
+		return decoder;
+	}
+}

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/JwtDecoderFactory.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/JwtDecoderFactory.java
@@ -1,0 +1,10 @@
+package com.sap.cloud.security.xsuaa.token.authentication;
+
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+public interface JwtDecoderFactory  {
+
+	JwtDecoder create(String jku, OAuth2TokenValidator<Jwt> tokenValidator);
+}

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/JwtDecoderFactory.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/JwtDecoderFactory.java
@@ -4,7 +4,20 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
-public interface JwtDecoderFactory  {
+import javax.annotation.Nonnull;
 
-	JwtDecoder create(String jku, OAuth2TokenValidator<Jwt> tokenValidator);
+public interface JwtDecoderFactory {
+
+	/**
+	 * Factory interface that is used by {@code XsuaaJwtDecoderBuilder} to create
+	 * the actual decoder instance.
+	 *
+	 * @param jku
+	 *            the public key URL of the authorization server.
+	 * @param tokenValidator
+	 *            is used to validate the token. To combine several validators use
+	 *            {@code DelegatingOAuth2TokenValidator}.
+	 * @return the {@code JwtDecoder}.
+	 */
+	JwtDecoder create(@Nonnull String jku, @Nonnull OAuth2TokenValidator<Jwt> tokenValidator);
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/ReactiveJwtDecoderFactory.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/ReactiveJwtDecoderFactory.java
@@ -1,0 +1,9 @@
+package com.sap.cloud.security.xsuaa.token.authentication;
+
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+
+public interface ReactiveJwtDecoderFactory {
+	ReactiveJwtDecoder create(String jku, OAuth2TokenValidator<Jwt> tokenValidator);
+}

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/ReactiveJwtDecoderFactory.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/ReactiveJwtDecoderFactory.java
@@ -4,6 +4,20 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
 
+import javax.annotation.Nonnull;
+
 public interface ReactiveJwtDecoderFactory {
-	ReactiveJwtDecoder create(String jku, OAuth2TokenValidator<Jwt> tokenValidator);
+
+	/**
+	 * Factory interface that is used by {@code XsuaaJwtDecoderBuilder} to create
+	 * the actual reactive decoder instance.
+	 *
+	 * @param jku
+	 *            the public key URL of the authorization server.
+	 * @param tokenValidator
+	 *            is used to validate the token. To combine several validators use
+	 *            {@code DelegatingOAuth2TokenValidator}
+	 * @return the {@code ReactiveJwtDecoder}.
+	 */
+	ReactiveJwtDecoder create(@Nonnull String jku, @Nonnull OAuth2TokenValidator<Jwt> tokenValidator);
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/ReactiveXsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/ReactiveXsuaaJwtDecoder.java
@@ -12,9 +12,7 @@ import reactor.core.publisher.Mono;
 
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class ReactiveXsuaaJwtDecoder implements ReactiveJwtDecoder {

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/ReactiveXsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/ReactiveXsuaaJwtDecoder.java
@@ -45,25 +45,10 @@ public class ReactiveXsuaaJwtDecoder implements ReactiveJwtDecoder {
 		cache = Caffeine.newBuilder().expireAfterWrite(cacheValidityInSeconds, TimeUnit.SECONDS).maximumSize(cacheSize)
 				.build();
 
-		this.tokenInfoExtractor = new TokenInfoExtractor() {
-			@Override
-			public String getJku(JWT jwt) {
-				return (String) jwt.getHeader().toJSONObject().getOrDefault(CLAIM_JKU, null);
-			}
-
-			@Override
-			public String getKid(JWT jwt) {
-				return (String) jwt.getHeader().toJSONObject().getOrDefault(CLAIM_KID, null);
-			}
-
-			@Override
-			public String getUaaDomain(JWT jwt) {
-				return xsuaaServiceConfiguration.getUaaDomain();
-			}
-		};
+		this.tokenInfoExtractor = new XsuaaTokenInfoExtractor(xsuaaServiceConfiguration.getUaaDomain());
 
 		this.tokenValidators.addAll(Arrays.asList(tokenValidators));
-		this.postValidationActions = postValidationActions != null ? postValidationActions : Collections.EMPTY_LIST;
+		this.postValidationActions = postValidationActions != null ? postValidationActions : new ArrayList<>();
 	}
 
 	@Override

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/TokenInfoExtractor.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/TokenInfoExtractor.java
@@ -8,9 +8,21 @@ import com.nimbusds.jwt.JWT;
  */
 public interface TokenInfoExtractor {
 
+	/**
+	 * @param jwt the token.
+	 * @return the public key URL of the authorization server.
+	 */
 	String getJku(JWT jwt);
 
+	/**
+	 * @param jwt the token.
+	 * @return the extracted kid claim.
+	 */
 	String getKid(JWT jwt);
 
+	/**
+	 * @param jwt the token.
+	 * @return the extracted UAA domain.
+	 */
 	String getUaaDomain(JWT jwt);
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
@@ -1,14 +1,10 @@
 package com.sap.cloud.security.xsuaa.token.authentication;
 
-import static com.sap.cloud.security.xsuaa.token.TokenClaims.CLAIM_JKU;
-import static com.sap.cloud.security.xsuaa.token.TokenClaims.CLAIM_KID;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -44,24 +40,9 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 				.build();
 		this.tokenValidators = tokenValidators;
 
-		this.tokenInfoExtractor = new TokenInfoExtractor() {
-			@Override
-			public String getJku(JWT jwt) {
-				return (String) jwt.getHeader().toJSONObject().getOrDefault(CLAIM_JKU, null);
-			}
+		this.tokenInfoExtractor = new XsuaaTokenInfoExtractor(xsuaaServiceConfiguration.getUaaDomain());
 
-			@Override
-			public String getKid(JWT jwt) {
-				return (String) jwt.getHeader().toJSONObject().getOrDefault(CLAIM_KID, null);
-			}
-
-			@Override
-			public String getUaaDomain(JWT jwt) {
-				return xsuaaServiceConfiguration.getUaaDomain();
-			}
-		};
-
-		this.postValidationActions = postValidationActions != null ? postValidationActions : Collections.EMPTY_LIST;
+		this.postValidationActions = postValidationActions != null ? postValidationActions : new ArrayList<>();
 	}
 
 	@Override

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
@@ -43,7 +43,6 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 		this.postValidationActions = postValidationActions != null ? postValidationActions : new ArrayList<>();
 	}
 
-
 	@Override
 	public Jwt decode(String token) throws JwtException {
 		Assert.notNull(token, "token is required");

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderBuilder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderBuilder.java
@@ -68,8 +68,6 @@ public class XsuaaJwtDecoderBuilder {
 				reactiveJwtDecoderFactory, combinedTokenValidators, postValidationActions);
 	}
 
-
-
 	/**
 	 * Decoders cache the signing keys. Overwrite the cache time (default: 900
 	 * seconds).

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenInfoExtractor.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenInfoExtractor.java
@@ -5,7 +5,7 @@ import com.nimbusds.jwt.JWT;
 import static com.sap.cloud.security.xsuaa.token.TokenClaims.CLAIM_JKU;
 import static com.sap.cloud.security.xsuaa.token.TokenClaims.CLAIM_KID;
 
-class XsuaaTokenInfoExtractor implements  TokenInfoExtractor {
+class XsuaaTokenInfoExtractor implements TokenInfoExtractor {
 
 	private final String uaaDomain;
 

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenInfoExtractor.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenInfoExtractor.java
@@ -1,0 +1,34 @@
+package com.sap.cloud.security.xsuaa.token.authentication;
+
+import com.nimbusds.jwt.JWT;
+
+import static com.sap.cloud.security.xsuaa.token.TokenClaims.CLAIM_JKU;
+import static com.sap.cloud.security.xsuaa.token.TokenClaims.CLAIM_KID;
+
+class XsuaaTokenInfoExtractor implements  TokenInfoExtractor {
+
+	private final String uaaDomain;
+
+	XsuaaTokenInfoExtractor(String uaaDomain) {
+		this.uaaDomain = uaaDomain;
+	}
+
+	@Override
+	public String getJku(JWT jwt) {
+		return headerValueOrNull(jwt, CLAIM_JKU);
+	}
+
+	@Override
+	public String getKid(JWT jwt) {
+		return headerValueOrNull(jwt, CLAIM_KID);
+	}
+
+	@Override
+	public String getUaaDomain(JWT jwt) {
+		return uaaDomain;
+	}
+
+	private String headerValueOrNull(JWT jwt, String key) {
+		return (String) jwt.getHeader().toJSONObject().getOrDefault(key, null);
+	}
+}

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenInfoExtractorTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaTokenInfoExtractorTest.java
@@ -1,0 +1,53 @@
+package com.sap.cloud.security.xsuaa.token.authentication;
+
+import com.nimbusds.jwt.SignedJWT;
+import com.sap.cloud.security.xsuaa.test.JwtGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.ParseException;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class XsuaaTokenInfoExtractorTest {
+
+	private static final String UAA_DOMAIN = "theUaaDomain";
+
+	private XsuaaTokenInfoExtractor cut;
+	private JwtGenerator jwtGenerator;
+
+	@Before
+	public void setUp() throws Exception {
+		cut = new XsuaaTokenInfoExtractor(UAA_DOMAIN);
+		jwtGenerator = new JwtGenerator();
+	}
+
+	@Test
+	public void getJku() throws ParseException {
+		String jku = "theJku";
+		jwtGenerator.setJku(jku);
+
+		SignedJWT jwt = createJWT();
+
+		assertThat(cut.getJku(jwt)).isEqualTo(jku);
+	}
+
+	@Test
+	public void getKid() throws ParseException {
+		String keyId = "theKeyId";
+		jwtGenerator.setJwtHeaderKeyId(keyId);
+
+		SignedJWT jwt = createJWT();
+
+		assertThat(cut.getKid(jwt)).isEqualTo(keyId);
+	}
+
+	@Test
+	public void getUaaDomain() {
+		assertThat(cut.getUaaDomain(null)).isEqualTo(UAA_DOMAIN);
+	}
+
+	private SignedJWT createJWT() throws ParseException {
+		return SignedJWT.parse(jwtGenerator.getToken().getTokenValue());
+	}
+}


### PR DESCRIPTION
I have started refactoring the JwtDecoder part in spring-xsuaa. It is not finished yet but I just wanted to make sure that I am heading in the right direction. 

The main change is that `ReactiveXsuaaJwtDecoder/XsuaaJwtDecoder` now do not themselves create the NimbusJwtDecoder instances but receive a factory that is creating those decoders for them.
The `XsuaaJwtDecoderBuilder` uses default factories that deliver the decoder instances that were previously created inside `ReactiveXsuaaJwtDecoder/XsuaaJwtDecoder`. The main benefit with the approach is that a library user can create her own implementation of those factories. This makes the Decoder implementation interchangeable. 