### PR TITLE
Disable default property source

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfiguration.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfiguration.java
@@ -3,10 +3,12 @@ package com.sap.cloud.security.xsuaa.autoconfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -37,7 +39,7 @@ public class XsuaaAutoConfiguration {
 
 	@Configuration
 	@PropertySource(factory = XsuaaServicePropertySourceFactory.class, value = { "" })
-	@ConditionalOnProperty(prefix = "spring.xsuaa", name = "multiple-bindings", havingValue = "false", matchIfMissing = true)
+	@Conditional(PropertyConditions.class)
 	public static class XsuaaServiceAutoConfiguration {
 
 		@Bean
@@ -46,6 +48,20 @@ public class XsuaaAutoConfiguration {
 			logger.info("auto-configures XsuaaServiceConfigurationDefault");
 			return new XsuaaServiceConfigurationDefault();
 		}
+	}
+
+	public static class PropertyConditions extends AllNestedConditions {
+
+		public PropertyConditions() {
+			super(ConfigurationPhase.PARSE_CONFIGURATION);
+		}
+
+		@ConditionalOnProperty(prefix = "spring.xsuaa", name = "multiple-bindings", havingValue = "false", matchIfMissing = true)
+		static class MultipleBindingsCondition { }
+
+		@ConditionalOnProperty(prefix = "spring.xsuaa", name = "disable-default-property-source", havingValue = "false", matchIfMissing = true)
+		static class DisableDefaultPropertySourceCondition { }
+
 	}
 
 	/**
@@ -60,5 +76,6 @@ public class XsuaaAutoConfiguration {
 		logger.info("auto-configures RestOperations for xsuaa requests)");
 		return new RestTemplate();
 	}
+
 
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfiguration.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfiguration.java
@@ -50,7 +50,7 @@ public class XsuaaAutoConfiguration {
 		}
 	}
 
-	public static class PropertyConditions extends AllNestedConditions {
+	private static class PropertyConditions extends AllNestedConditions {
 
 		public PropertyConditions() {
 			super(ConfigurationPhase.PARSE_CONFIGURATION);

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfigurationTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/autoconfiguration/XsuaaAutoConfigurationTest.java
@@ -57,6 +57,7 @@ public class XsuaaAutoConfigurationTest {
 	public void configures_xsuaaServiceConfiguration_withProperties() {
 		contextRunner
 				.withPropertyValues("spring.xsuaa.auto:true")
+				.withPropertyValues("spring.xsuaa.disable-default-property-source:false")
 				.withPropertyValues("spring.xsuaa.multiple-bindings:false").run((context) -> {
 					assertThat(context.containsBean("xsuaaServiceConfiguration"), is(true));
 					assertThat(context.getBean("xsuaaServiceConfiguration"),
@@ -76,12 +77,19 @@ public class XsuaaAutoConfigurationTest {
 	}
 
 	@Test
-	public void serviceConfigurationDisabledByProperty() {
+	public void serviceConfigurationDisabledByMultipleBindingsProperty() {
 		contextRunner.withPropertyValues("spring.xsuaa.multiple-bindings:true").run((context) -> {
 			assertThat(context).doesNotHaveBean("xsuaaServiceConfiguration");
 		});
 	}
 
+	@Test
+	public void serviceConfigurationDisabledByDisableDefaultPropertySourceProperty() {
+		contextRunner.withPropertyValues("spring.xsuaa.disable-default-property-source:true").run((context) -> {
+			assertThat(context).doesNotHaveBean("xsuaaServiceConfiguration");
+		});
+	}
+	
 	@Test
 	public void autoConfigurationInactive_if_noJwtOnClasspath() {
 		contextRunner.withClassLoader(new FilteredClassLoader(Jwt.class)) // removes Jwt.class from classpath


### PR DESCRIPTION
The default property source can now be disabled by setting the property `disable-default-property-source` to `true`.

SECAUTH-524