### PR TITLE
Remove base64 paddings in jwt tokens

### DIFF
--- a/java-security-test/src/main/java/com/sap/cloud/security/test/JwtGenerator.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/JwtGenerator.java
@@ -4,7 +4,6 @@ import static com.sap.cloud.security.token.TokenClaims.AUDIENCE;
 import static com.sap.cloud.security.token.TokenHeader.ALGORITHM;
 
 import com.sap.cloud.security.config.Service;
-import com.sap.cloud.security.json.DefaultJsonObject;
 import com.sap.cloud.security.json.JsonObject;
 import com.sap.cloud.security.json.JsonParsingException;
 import com.sap.cloud.security.token.IasToken;
@@ -21,7 +20,6 @@ import javax.annotation.Nonnull;
 import java.security.*;
 import java.time.Instant;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Jwt {@link Token} builder class to generate tokes for testing purposes.
@@ -250,8 +248,9 @@ public class JwtGenerator {
 	}
 
 	private String base64Encode(byte[] bytes) {
-		return Base64.getUrlEncoder().encodeToString(bytes);
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
 	}
+
 
 	interface SignatureCalculator {
 		byte[] calculateSignature(PrivateKey privateKey, JwtSignatureAlgorithm algorithm, byte[] dataToSign)


### PR DESCRIPTION
Because they are not standard compliant. The definition of the base64 encoding that is used to create JWT-Tokens is defined as follows in [rfc7515](https://tools.ietf.org/html/rfc7515):

> Base64 encoding using the URL- and filename-safe character set
      defined in Section 5 of RFC 4648 [RFC4648], with all trailing '='
      characters omitted (as permitted by Section 3.2) and without the
      inclusion of any line breaks, whitespace, or other additional
      characters.

The change is simple, we can just encode without the padding. The java base64 decoder automatically detects the presence (or absence) of base64 paddings. So we do not run into compatibility issues with newly generated tokens that lack paddings.
