### PR TITLE
Exented suppression rule because bug is still not fixed

### DIFF
--- a/etc/suppression.xml
+++ b/etc/suppression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2020-03-01Z">
+    <suppress until="2020-06-01Z">
         <notes><![CDATA[
         This suppresses CVE-2018-1258 which is necessary because of a bug in the dependency-check plugin itself
         and needs to be active until it is resolved: https://github.com/jeremylong/DependencyCheck/issues/1827


### PR DESCRIPTION
Extended suppression rule for 3 more months because https://github.com/jeremylong/DependencyCheck/issues/1827 is not fixed yet.