### PR TITLE
Increase visibility of SecurityTestRule#addApplicationServletFilter

### DIFF
--- a/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTestRule.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTestRule.java
@@ -142,7 +142,15 @@ public class SecurityTestRule extends ExternalResource {
 		return this;
 	}
 
-	SecurityTestRule addApplicationServletFilter(Class<? extends Filter> filterClass) {
+	/**
+	 * Adds a filter to the servlet server. Only has an effect when used in
+	 * conjunction with {@link #useApplicationServer}.
+	 *
+	 * @param filterClass
+	 *            the filter class that should intercept with incoming requests.
+	 * @return the rule itself.
+	 */
+	public SecurityTestRule addApplicationServletFilter(Class<? extends Filter> filterClass) {
 		applicationServletFilters.add(new FilterHolder(filterClass));
 		return this;
 	}


### PR DESCRIPTION
I'm a developer of the [SAP Cloud SDK](https://community.sap.com/topics/cloud-sdk) and currently I'm creating a sample application and different test setups for best practices to show the integration of both libraries.

In order to enable the Cloud SDK within applications served by the internal Jetty container during tests, we would need the consumer to be able to attach our filter class.

Before:
```java
@ClassRule
public static SecurityTestRule rule =
  SecurityTestRule.getInstance(Service.XSUAA)
    .useApplicationServer()
    .addApplicationServlet(TestServlet.class, "/app");
```

After:
```java
@ClassRule
public static SecurityTestRule rule =
  SecurityTestRule.getInstance(Service.XSUAA)
    .useApplicationServer()
    .addApplicationServlet(TestServlet.class, "/app")
    .addApplicationServletFilter(com.sap.cloud.sdk.cloudplatform.servlet.RequestAccessorFilter.class);
```

I already tested by invoking the _package-private_ function via Java Reflection. As a workaround.