### PR TITLE
Logging

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,6 @@
 
 	<groupId>com.sap.cloud.security.xsuaa</groupId>
 	<artifactId>api</artifactId>
-	<version>2.5.1</version>
 
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>

--- a/etc/suppression.xml
+++ b/etc/suppression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2020-03-01Z">
+    <suppress until="2020-06-01Z">
         <notes><![CDATA[
         This suppresses CVE-2018-1258 which is necessary because of a bug in the dependency-check plugin itself
         and needs to be active until it is resolved: https://github.com/jeremylong/DependencyCheck/issues/1827

--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -16,11 +16,12 @@
 	<packaging>jar</packaging>
 
 	<dependencies>
-		<dependency> <!-- can be removed with slf4j-api 1.8 version -->
+		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>${slf4j.api.version}</version>
+			<artifactId>slf4j-api</artifactId>
+			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>
 			<artifactId>jsr305</artifactId>

--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -90,6 +90,11 @@
             <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
+		<dependency> <!-- check if it's still needed when slf4j-api 1.8 is available -->
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -55,7 +55,7 @@ A Java implementation of JSON Web Token (JWT) - [RFC 7519](https://tools.ietf.or
 ### Logging
 
 This library uses [slf4j](http://www.slf4j.org/) for logging. It only ships the [slf4j-api module](https://mvnrepository.com/artifact/org.slf4j/slf4j-api) and no actual logger implementation.
-For the loggin to work slf4j needs to find a valid logger implementation at runtime. 
+For the logging to work slf4j needs to find a valid logger implementation at runtime. 
 If your app is deployed via buildpack then you will have one available and logging should just work.
 
 If there is no valid logger binding at runtime you will see an error message like this:

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -52,6 +52,21 @@ A Java implementation of JSON Web Token (JWT) - [RFC 7519](https://tools.ietf.or
 </dependency>
 ```
 
+### Logging
+
+This library uses [slf4j](http://www.slf4j.org/) for logging. It only ships the [slf4j-api module](https://mvnrepository.com/artifact/org.slf4j/slf4j-api) and no actual logger implementation.
+For the loggin to work slf4j needs to find a valid logger implementation at runtime. 
+If your app is deployed via buildpack then you will have one available and logging should just work.
+
+If there is no valid logger binding at runtime you will see an error message like this:
+```log
+SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
+SLF4J: Defaulting to no-operation (NOP) logger implementation
+```
+In this case you need to add a logger implementation dependency to your application.
+See the slf4j [documentation](http://www.slf4j.org/codes.html#StaticLoggerBinder)
+for more information.
+
 ## Basic Usage
 
 ### Setup Step 1: Load the Service Configuration(s)

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -65,7 +65,8 @@ SLF4J: Defaulting to no-operation (NOP) logger implementation
 ```
 In this case you need to add a logger implementation dependency to your application.
 See the slf4j [documentation](http://www.slf4j.org/codes.html#StaticLoggerBinder)
-for more information.
+for more information and a [list](http://www.slf4j.org/manual.html#swapping) of available
+logger options.
 
 ## Basic Usage
 

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -85,6 +85,11 @@
 			<version>1.19.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency> <!-- check if it's still needed when slf4j-api 1.8 is available -->
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<spring.security.jwt.version>1.0.10.RELEASE</spring.security.jwt.version>
 		<reactor.version>3.2.8.RELEASE</reactor.version>
 		<log4j.version>2.11.2</log4j.version>
-		<slf4j.api.version>1.7.28</slf4j.api.version> <!--see also here http://www.slf4j.org/faq.html#changesInVersion18 -->
+		<slf4j.api.version>1.7.30</slf4j.api.version> <!--see also here http://www.slf4j.org/faq.html#changesInVersion18 -->
 		<org.json.version>20190722</org.json.version>
 		<google.jsr305.version>3.0.2</google.jsr305.version>
 		<apache.httpclient.version>4.5.9</apache.httpclient.version>
@@ -102,6 +102,11 @@
 			<dependency>
 				<groupId>${project.groupId}</groupId>
 				<artifactId>token-client</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>${project.groupId}</groupId>
+				<artifactId>java-api</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
@@ -202,6 +207,12 @@
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
 				<version>${slf4j.api.version}</version>
+			</dependency>
+			<dependency> <!-- only use in test scope -->
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-simple</artifactId>
+				<version>${slf4j.api.version}</version>
+				<scope>test</scope>
 			</dependency>
 			<!-- other -->
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>${project.groupId}</groupId>
+				<groupId>${parent-groupId}</groupId>
 				<artifactId>java-api</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -125,8 +125,8 @@
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>${project.groupId}</groupId>
-				<artifactId>core</artifactId>
+				<groupId>${parent-groupId}</groupId>
+				<artifactId>java-security</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<!-- spring -->

--- a/token-client/pom.xml
+++ b/token-client/pom.xml
@@ -72,7 +72,11 @@
 			<artifactId>spring-security-oauth2-jose</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency> <!-- check if it's still needed when slf4j-api 1.8 is available -->
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
This PR removes the dependency to the slf4j-simple implementation. The library now only ships the api so that the library user can decide which implementation to use. This is recommended by the slf4j manual http://www.slf4j.org/manual.html.

I have merged [this](https://github.com/SAP/cloud-security-xsuaa-integration/pull/237/commits/812be7c72302613725a2f6c4254419e366d1edb6) into this PR so that it builds (and can be merged into master).

For now I have only added the logging description to the java-security README, maybe this can be placed more prominently?