### PR TITLE
Waiting for WireMock to shutdown 

### DIFF
--- a/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
@@ -333,13 +333,32 @@ public class SecurityTest {
      * to avoid unwanted side-effects.
      */
     public void tearDown() {
-        wireMockServer.shutdown();
+        shutdownWireMock();
         try {
             if (useApplicationServer) {
                 applicationServer.stop();
             }
         } catch (Exception e) {
             LOGGER.error("Failed to stop jetty server", e);
+        }
+    }
+
+    /**
+     * The {@code shutdown} method of WireMock does not block the main thread.
+     * This can cause issues if one static {@link SecurityTestRule}
+     * is reused in many test classes. Therefore we wait until the WireMock server
+     * has really been shutdown (or the maximum amount of tries has been reached).
+     */
+    private void shutdownWireMock() {
+        wireMockServer.shutdown();
+        int maxTries = 100;
+        for (int tries = 0; tries < maxTries && wireMockServer.isRunning(); tries++) {
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                LOGGER.warn("Got interrupted while waiting for WireMock to shutdown. Giving up!");
+                break;
+            }
         }
     }
 }

--- a/java-security-test/src/test/java/com/sap/cloud/security/test/SecurityTestTest.java
+++ b/java-security-test/src/test/java/com/sap/cloud/security/test/SecurityTestTest.java
@@ -1,0 +1,19 @@
+package com.sap.cloud.security.test;
+
+import com.sap.cloud.security.config.Service;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SecurityTestTest {
+
+	private SecurityTest cut = new SecurityTest(Service.XSUAA);
+
+	@Test
+	public void wireMockServerIsNotRunningAfterTearDown() throws Exception {
+		cut.setup();
+		cut.tearDown();
+		assertThat(cut.wireMockServer.isRunning()).isFalse();
+	}
+
+}


### PR DESCRIPTION
This prevents issues when the static SecurityTestRule is reused in many classes.
In my machine it took WireMock between 20ms and 100ms to shutdown. This code checks every 50ms if the server has been shutdown and sleeps otherwise. I also added a check so that this check is only done 100 times. This means that this will never block longer than 5 seconds.