### PR TITLE
Better InterruptedException handling

### DIFF
--- a/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
@@ -355,7 +355,8 @@ public class SecurityTest {
 				Thread.sleep(50);
 			} catch (InterruptedException e) {
 				LOGGER.warn("Got interrupted while waiting for WireMock to shutdown. Giving up!");
-				break;
+				Thread.currentThread().interrupt(); // restore the interrupted status
+				break; // stop blocking
 			}
 		}
 	}


### PR DESCRIPTION
Catching an `InterruptedException` resets the current thread's interrupted state. It is best practice to either re-throw the exception or at least exit and set the thread's interrupted state and not 'swallow' the exception. This is described [here](https://www.ibm.com/developerworks/java/library/j-jtp05236/index.html?ca=drs-#2.1).