### PR TITLE
Added refresh token flow test

### DIFF
--- a/samples/spring-security-xsuaa-usage/src/main/java/sample/spring/xsuaa/SecurityConfiguration.java
+++ b/samples/spring-security-xsuaa-usage/src/main/java/sample/spring/xsuaa/SecurityConfiguration.java
@@ -49,6 +49,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				.antMatchers("/v1/*").authenticated()
 				.antMatchers("/v2/*").hasAuthority("Read")
 				.antMatchers("/v3/*").hasAuthority("Read")
+				.antMatchers("/v3/requestRefreshToken/*").hasAuthority("Read")
 				.anyRequest().denyAll()
 			.and()
 				.oauth2ResourceServer()


### PR DESCRIPTION
Also the security configuration needed another `antMatchers`. Without this line the `requestRefreshToken` will always be denied (403).
