### PR TITLE
Remove xsd version, remove spring-aop

### DIFF
--- a/java-security/Migration_SpringSecurityProjects.md
+++ b/java-security/Migration_SpringSecurityProjects.md
@@ -32,11 +32,6 @@ First make sure you have the following dependencies defined in your pom.xml:
   <artifactId>spring-security-oauth2</artifactId>
   <version>2.4.1.RELEASE</version> <!-- chose the latest from maven repository -->
 </dependency>
-<dependency>
-  <groupId>org.springframework</groupId>
-  <artifactId>spring-aop</artifactId>
-  <version>4.3.27.RELEASE</version> <!-- chose the latest from maven repository -->
-</dependency>
 
 <!-- new java-security dependencies -->
 <dependency>
@@ -259,14 +254,14 @@ application locally make sure that it is still working and finally test the appl
 	```
 	Configuration problem: You cannot use a spring-security-4.0.xsd or spring-security-4.1.xsd schema with Spring Security 4.2. Please update your schema declarations to the 4.2 schema. Offending resource: ServletContext resource [/WEB-INF/spring-security.xml]
 	```  
-	You can fix this by updating the Spring versions as part of the schema declaration in the file `/WEB-INF/spring-security.xml` as suggested as part of the error log, e.g:
+	You can fix this by removing the Spring versions of the schema declaration in the file `/WEB-INF/spring-security.xml`. Without explicit versions set, the latest version will be used.
 	```
 	xsi:schemaLocation="http://www.springframework.org/schema/security/oauth2
-			    http://www.springframework.org/schema/security/spring-security-oauth2-2.0.xsd
+			    http://www.springframework.org/schema/security/spring-security-oauth2.xsd
 			    http://www.springframework.org/schema/security
-			    http://www.springframework.org/schema/security/spring-security-4.2.xsd
+			    http://www.springframework.org/schema/security/spring-security.xsd
 			    http://www.springframework.org/schema/beans
-			    http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+			    http://www.springframework.org/schema/beans/spring-beans.xsd
 	```
 	
 - org.springframework.beans.factory.xml.XmlBeanDefinitionStoreException  


### PR DESCRIPTION
Updated the Migration_SpringSecurityProjects file by removing non required dependency and removing the version of the xsd files in the spring-security.xml example.