### PR TITLE
Support scope parameter in token-client

### DIFF
--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenServiceConstants.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/OAuth2TokenServiceConstants.java
@@ -14,6 +14,8 @@ public class OAuth2TokenServiceConstants {
 	public static final String USERNAME = "username";
 	public static final String PASSWORD = "password"; // NOSONAR
 	public static final String ASSERTION = "assertion";
+	public static final String AUTHORITIES = "authorities";
+	public static final String SCOPE = "scope";
 
 	public static final String GRANT_TYPE = "grant_type";
 	public static final String GRANT_TYPE_USER_TOKEN = "user_token";

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/ClientCredentialsTokenFlow.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/ClientCredentialsTokenFlow.java
@@ -1,11 +1,14 @@
 package com.sap.cloud.security.xsuaa.tokenflows;
 
 import static com.sap.cloud.security.xsuaa.Assertions.assertNotNull;
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.AUTHORITIES;
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.SCOPE;
 import static com.sap.cloud.security.xsuaa.tokenflows.XsuaaTokenFlowsUtils.buildAuthorities;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
+import com.sap.cloud.security.xsuaa.Assertions;
 import com.sap.cloud.security.xsuaa.client.ClientCredentials;
 import com.sap.cloud.security.xsuaa.client.OAuth2TokenResponse;
 import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
@@ -13,6 +16,7 @@ import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
 import com.sap.cloud.security.xsuaa.client.OAuth2TokenService;
 import com.sap.xsa.security.container.XSTokenRequest;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -22,11 +26,11 @@ import javax.annotation.Nullable;
  */
 public class ClientCredentialsTokenFlow {
 
-	private static final String AUTHORITIES = "authorities";
 
 	private XsuaaTokenFlowRequest request;
 	private OAuth2TokenService tokenService;
 	private boolean disableCache = false;
+	private List<String> scopes = new ArrayList<>();
 
 	/**
 	 * Creates a new instance.
@@ -74,6 +78,24 @@ public class ClientCredentialsTokenFlow {
 	 */
 	public ClientCredentialsTokenFlow subdomain(String subdomain) {
 		request.setSubdomain(subdomain);
+		return this;
+	}
+
+	/**
+	 * Sets the scope attribute for the token request. This will restrict the scope
+	 * of the created token to the scopes provided. By default the scope is not
+	 * restricted and the created token contains all granted scopes.
+	 *
+	 * If you specify a scope that is not authorized for the client, the token
+	 * request will fail.
+	 *
+	 * @param scopes
+	 *            - one or many scopes as string.
+	 * @return this builder.
+	 */
+	public ClientCredentialsTokenFlow scopes(@Nonnull String... scopes) {
+		Assertions.assertNotNull(scopes, "Scopes must not be null!");
+		this.scopes = Arrays.asList(scopes);
 		return this;
 	}
 
@@ -133,14 +155,16 @@ public class ClientCredentialsTokenFlow {
 	 */
 	@Nullable
 	private OAuth2TokenResponse requestTechnicalUserToken(XsuaaTokenFlowRequest request) throws TokenFlowException {
-		Map requestParameter = null;
+		Map<String, String> requestParameter = new HashMap();
 		String authorities = buildAuthorities(request);
 
 		if (authorities != null) {
-			requestParameter = new HashMap();
 			requestParameter.put(AUTHORITIES, authorities); // places JSON inside the URI
 		}
-
+		String scopesParameter = scopes.stream().collect(Collectors.joining(", "));
+		if (!scopesParameter.isEmpty()) {
+			requestParameter.put(SCOPE, scopesParameter);
+		}
 		try {
 			OAuth2TokenResponse accessToken = tokenService
 					.retrieveAccessTokenViaClientCredentialsGrant(request.getTokenEndpoint(),

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenServiceTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenServiceTest.java
@@ -3,25 +3,31 @@ package com.sap.cloud.security.xsuaa.client;
 import com.sap.cloud.security.xsuaa.http.HttpHeaders;
 import com.sap.cloud.security.xsuaa.http.HttpHeadersFactory;
 import com.sap.cloud.security.xsuaa.util.HttpClientTestFactory;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.assertj.core.util.Maps;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultOAuth2TokenServiceTest {
@@ -29,7 +35,7 @@ public class DefaultOAuth2TokenServiceTest {
 	private static final String ACCESS_TOKEN = "abc123";
 	private static final String REFRESH_TOKEN = "def456";
 	private static final String VALID_JSON_RESPONSE = String
-			.format("{expires_in: 1234, access_token: %s, refresh_token: %s}",
+			.format("{expires_in: 10000, access_token: %s, refresh_token: %s}",
 					ACCESS_TOKEN, REFRESH_TOKEN);
 
 	private CloseableHttpClient mockHttpClient;
@@ -46,39 +52,37 @@ public class DefaultOAuth2TokenServiceTest {
 		CloseableHttpResponse response = HttpClientTestFactory.createHttpResponse("{}");
 		when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(response);
 
-		assertThatThrownBy(() -> requestAccessToken())
+		assertThatThrownBy(() -> requestAccessToken(Collections.emptyMap()))
 				.isInstanceOf(OAuth2ServiceException.class)
 				.hasMessageContaining("expires_in");
 	}
 
 	@Test
-	public void httpResponseWithExpiresIn_yieldsExpiresInTokenResponse() throws IOException {
+	public void execute_yieldsTokenResponseWithCorrectData() throws IOException {
 		CloseableHttpResponse response = HttpClientTestFactory.createHttpResponse(VALID_JSON_RESPONSE);
 		when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(response);
 
-		OAuth2TokenResponse re = requestAccessToken();
-
-		assertThat(re.getExpiredAtDate()).isNotNull();
-	}
-
-	@Test
-	public void httpResponseWithToken_yieldsTokenInTokenResponse() throws IOException {
-		CloseableHttpResponse response = HttpClientTestFactory.createHttpResponse(VALID_JSON_RESPONSE);
-		when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(response);
-
-		OAuth2TokenResponse re = requestAccessToken();
+		OAuth2TokenResponse re = requestAccessToken(Collections.emptyMap());
 
 		assertThat(re.getAccessToken()).isEqualTo(ACCESS_TOKEN);
+		assertThat(re.getRefreshToken()).isEqualTo(REFRESH_TOKEN);
+		assertThat(re.getExpiredAt()).isAfter(Instant.now());
 	}
 
 	@Test
-	public void httpResponseWithRefreshToken_yieldsTokenInTokenResponse() throws IOException {
+	public void executeWithAdditionalParameters_putsParametersIntoPostBody() throws IOException {
+		ArgumentCaptor<HttpPost> httpPostCaptor = ArgumentCaptor.forClass(HttpPost.class);
 		CloseableHttpResponse response = HttpClientTestFactory.createHttpResponse(VALID_JSON_RESPONSE);
 		when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(response);
 
-		OAuth2TokenResponse re = requestAccessToken();
+		requestAccessToken(Maps.newHashMap("myKey", "myValue"));
 
-		assertThat(re.getRefreshToken()).isEqualTo(REFRESH_TOKEN);
+		verify(mockHttpClient, times(1)).execute(httpPostCaptor.capture());
+		HttpPost httpPost = httpPostCaptor.getValue();
+		HttpEntity httpEntity = httpPost.getEntity();
+		assertThat(httpEntity).isNotNull();
+		String postBody = IOUtils.toString(httpEntity.getContent(), StandardCharsets.UTF_8);
+		assertThat(postBody).contains("myKey=myValue");
 	}
 
 	@Test
@@ -88,15 +92,14 @@ public class DefaultOAuth2TokenServiceTest {
 				.createHttpResponse(unauthorizedResponseText, HttpStatus.SC_UNAUTHORIZED);
 		when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(response);
 
-		assertThatThrownBy(() -> requestAccessToken())
+		assertThatThrownBy(() -> requestAccessToken(Collections.emptyMap()))
 				.isInstanceOf(OAuth2ServiceException.class)
 				.hasMessageContaining(unauthorizedResponseText);
 	}
 
-	private OAuth2TokenResponse requestAccessToken() throws OAuth2ServiceException {
+	private OAuth2TokenResponse requestAccessToken(Map<String, String> parameters) throws OAuth2ServiceException {
 		URI tokenEndpointUri = URI.create("https://subdomain.myauth.server.com/oauth/token");
 		HttpHeaders withoutAuthorizationHeader = HttpHeadersFactory.createWithoutAuthorizationHeader();
-		Map<String, String> parameters = Collections.emptyMap();
 		return cut.requestAccessToken(tokenEndpointUri, withoutAuthorizationHeader, parameters);
 	}
 


### PR DESCRIPTION
Support reducing the scope of created tokens by adding the scope attribute to the request.