### PR TITLE
Log actual cache configuration and not the unchecked one

### DIFF
--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
@@ -94,7 +94,7 @@ public class OAuth2TokenKeyServiceWithCache implements Cacheable {
 	public OAuth2TokenKeyServiceWithCache withCacheConfiguration(CacheConfiguration cacheConfiguration) {
 		this.cacheConfiguration = getCheckedConfiguration(cacheConfiguration);
 		LOGGER.debug("Configured token key cache with cacheDuration={} seconds and cacheSize={}",
-				cacheConfiguration.getCacheDuration().getSeconds(), cacheConfiguration.getCacheSize());
+				getCacheConfiguration().getCacheDuration().getSeconds(), getCacheConfiguration().getCacheSize());
 		return this;
 	}
 


### PR DESCRIPTION
In case a user tries to configure a cache that is not allowed (too low cache duration or size), the log still would state that the cache was configured this way but it is actually not.