### PR TITLE
Ngpbug 120051

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.7.4
+- [java-security] 
+  - Audience Validation is skipped when `client_id` of broker-clone token matches the trusted client. This is relevant to support tokens of grant type `user_token` that contains no scopes.
+
 ## 2.7.3
 - [java-security] 
-  - Audience Validation is skipped when `client_id` of token matches the trusted client. This is relevant to support tokens of grant type `user_token` that contains no scopes.
+  - Audience Validation is skipped when `client_id` of token exactly matches the trusted client. This is relevant to support tokens of grant type `user_token` that contains no scopes.
   - provides the subaccount identifier from the `ext_attr` claim.
 - [spring-xsuaa] provides the subaccount identifier from the `ext_attr` claim.
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.4</version>
 	</parent>
 
 	<packaging>jar</packaging>

--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.4</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security-test/README.md
+++ b/java-security-test/README.md
@@ -22,7 +22,7 @@ It includes for example a `JwtGenerator` that generates JSON Web Tokens (JWT) th
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-security-test</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.4</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/Migration_SAPJavaBuildpackProjects.md
+++ b/java-security/Migration_SAPJavaBuildpackProjects.md
@@ -27,7 +27,7 @@ The above mentioned dependencies should be removed / replaced with this one:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>api</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <scope>provided</scope> <!-- provided with buildpack -->
 </dependency>
 ```

--- a/java-security/Migration_SAPJavaBuildpackProjects_V2.md
+++ b/java-security/Migration_SAPJavaBuildpackProjects_V2.md
@@ -19,7 +19,7 @@ First make sure you have the following dependency defined in your pom.xml:
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-api</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <scope>provided</scope> <!-- provided with buildpack -->
 </dependency>
 ```
@@ -29,7 +29,7 @@ Now you are ready to **remove** the dependency to the **`api`** by deleting the 
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>api</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <scope>provided</scope>
 </dependency>
 ```

--- a/java-security/Migration_SpringSecurityProjects.md
+++ b/java-security/Migration_SpringSecurityProjects.md
@@ -37,19 +37,19 @@ First make sure you have the following dependencies defined in your pom.xml:
 <dependency>
   <groupId>com.sap.cloud.security.xsuaa</groupId>
   <artifactId>api</artifactId>
-  <version>2.7.3</version>
+  <version>2.7.4</version>
 </dependency>
 <dependency>
   <groupId>com.sap.cloud.security</groupId>
   <artifactId>java-security</artifactId>
-  <version>2.7.3</version>
+  <version>2.7.4</version>
 </dependency>
 
 <!-- new java-security dependencies for unit tests -->
 <dependency>
   <groupId>com.sap.cloud.security</groupId>
   <artifactId>java-security-test</artifactId>
-  <version>2.7.3</version>
+  <version>2.7.4</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -44,7 +44,7 @@ Token Validation for Java applications.
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-security</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.4</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JwtAudienceValidatorTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JwtAudienceValidatorTest.java
@@ -11,7 +11,6 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -186,7 +185,7 @@ public class JwtAudienceValidatorTest {
 		Mockito.when(token.getAudiences()).thenReturn(Collections.EMPTY_SET);
 
 		// configures audience validator with client-id from VCAP_SERVICES
-		Set audiences = JwtAudienceValidator.getAllowedAudiences(token);
+		Set audiences = JwtAudienceValidator.extractAudiencesFromToken(token);
 
 		assertThat(audiences.size()).isEqualTo(3);
 		assertThat(audiences).containsExactlyInAnyOrder("test1!t1", "client", "xsappid");

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.sap.cloud.security.xsuaa</groupId>
 	<artifactId>parent</artifactId>
-	<version>2.7.3</version>
+	<version>2.7.4</version>
 	<packaging>pom</packaging>
 
 	<name>parent</name>

--- a/samples/java-security-usage/pom.xml
+++ b/samples/java-security-usage/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <sap.cloud.security.version>2.7.3</sap.cloud.security.version>
+        <sap.cloud.security.version>2.7.4</sap.cloud.security.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
         <apache.httpclient.version>4.5.8</apache.httpclient.version>
         <javax.servlet.api.version>3.1.0</javax.servlet.api.version>

--- a/samples/java-tokenclient-usage/pom.xml
+++ b/samples/java-tokenclient-usage/pom.xml
@@ -3,13 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-tokenclient-usage</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <packaging>war</packaging>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <sap.cloud.security.version>2.7.3</sap.cloud.security.version>
+        <sap.cloud.security.version>2.7.4</sap.cloud.security.version>
         <apache.httpclient.version>4.5.8</apache.httpclient.version>
         <javax.servlet.api.version>3.0.1</javax.servlet.api.version>
     </properties>

--- a/samples/sap-java-buildpack-api-usage/pom.xml
+++ b/samples/sap-java-buildpack-api-usage/pom.xml
@@ -3,13 +3,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.cloud.security.xssec.samples</groupId>
 	<artifactId>sap-java-buildpack-api-usage</artifactId>
-	<version>2.7.3</version>
+	<version>2.7.4</version>
 	<packaging>war</packaging>
 
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<sap.cloud.security.version>2.7.3</sap.cloud.security.version>
+		<sap.cloud.security.version>2.7.4</sap.cloud.security.version>
 		<javax.servlet.api.version>3.0.1</javax.servlet.api.version>
 	</properties>
 

--- a/samples/spring-security-basic-auth/pom.xml
+++ b/samples/spring-security-basic-auth/pom.xml
@@ -11,14 +11,14 @@
 	</parent>
 
 	<artifactId>spring-security-basic-auth</artifactId>
-	<version>2.7.3</version>
+	<version>2.7.4</version>
 	<name>spring-security-basic-auth</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<sap.cloud.security.version>2.7.3</sap.cloud.security.version>
+		<sap.cloud.security.version>2.7.4</sap.cloud.security.version>
 	</properties>
 
 	<dependencies>

--- a/samples/spring-security-xsuaa-usage/pom.xml
+++ b/samples/spring-security-xsuaa-usage/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-xsuaa-usage</artifactId>
-	<version>2.7.3</version>
+	<version>2.7.4</version>
 	<name>spring-security-xsuaa-usage</name>
 
 	<properties>
@@ -27,7 +27,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<sap.cloud.security.version>2.7.3</sap.cloud.security.version>
+		<sap.cloud.security.version>2.7.4</sap.cloud.security.version>
 	</properties>
 
     <dependencies>

--- a/samples/spring-webflux-security-xsuaa-usage/pom.xml
+++ b/samples/spring-webflux-security-xsuaa-usage/pom.xml
@@ -12,12 +12,12 @@
 
     <groupId>com.sap.cloud.security.samples</groupId>
     <artifactId>spring-webflux-security-xsuaa-usage</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <name>spring-webflux-security-xsuaa-usage</name>
 
     <properties>
         <java.version>1.8</java.version>
-        <sap.cloud.security.version>2.7.3</sap.cloud.security.version>
+        <sap.cloud.security.version>2.7.4</sap.cloud.security.version>
     </properties>
 
     <dependencies>

--- a/spring-xsuaa-it/pom.xml
+++ b/spring-xsuaa-it/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.4</version>
 	</parent>
 
 	<artifactId>spring-xsuaa-it</artifactId>

--- a/spring-xsuaa-mock/README.md
+++ b/spring-xsuaa-mock/README.md
@@ -21,7 +21,7 @@ The default implementation offers already valid *token_keys* for JWT tokens, tha
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa-mock</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
 </dependency>
 <dependency> <!-- new with version 1.5.0 - provided with org.springframework.boot:spring-boot-starter:jar -->
     <groupId>org.springframework.boot</groupId>

--- a/spring-xsuaa-mock/pom.xml
+++ b/spring-xsuaa-mock/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.4</version>
 	</parent>
 
 	<artifactId>spring-xsuaa-mock</artifactId>

--- a/spring-xsuaa-starter/pom.xml
+++ b/spring-xsuaa-starter/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.4</version>
 	</parent>
 
 	<artifactId>xsuaa-spring-boot-starter</artifactId>

--- a/spring-xsuaa-test/README.md
+++ b/spring-xsuaa-test/README.md
@@ -27,7 +27,7 @@ This includes for example a `JwtGenerator` that generates JSON Web Tokens (JWT) 
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa-test</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <scope>test</scope>
 </dependency>
 

--- a/spring-xsuaa-test/pom.xml
+++ b/spring-xsuaa-test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.4</version>
 	</parent>
 
 	<artifactId>spring-xsuaa-test</artifactId>

--- a/spring-xsuaa/README.md
+++ b/spring-xsuaa/README.md
@@ -25,7 +25,7 @@ These (spring) dependencies needs to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
 </dependency>
 <dependency> <!-- new with version 1.5.0 -->
     <groupId>org.apache.logging.log4j</groupId>
@@ -40,7 +40,7 @@ These (spring) dependencies needs to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>xsuaa-spring-boot-starter</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
 </dependency>
 ```
 

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.4</version>
 	</parent>
 
 	<artifactId>spring-xsuaa</artifactId>

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidator.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidator.java
@@ -63,7 +63,6 @@ public class XsuaaAudienceValidator implements OAuth2TokenValidator<Jwt> {
 		// case 1 : token issued by own client (or master)
 		if (clientId.equals(tokenClientId)
 				|| (appId.contains("!b")
-						&& tokenClientId.contains("|")
 						&& tokenClientId.endsWith("|" + appId))) {
 			return true;
 		} else {

--- a/token-client/README.md
+++ b/token-client/README.md
@@ -23,7 +23,7 @@ The Resource owner password credentials (i.e., username and password) can be use
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
 </dependency>
 <dependency>
   <groupId>org.apache.httpcomponents</groupId>
@@ -62,7 +62,7 @@ By default, the `DefaultOAuth2TokenService` caches tokens internally. The Cache 
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
 </dependency>
 ```
 
@@ -91,7 +91,7 @@ In context of a Spring Boot application you may like to leverage auto-configurat
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>xsuaa-spring-boot-starter</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
 </dependency>
 ```
 

--- a/token-client/pom.xml
+++ b/token-client/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7.3</version>
+		<version>2.7.4</version>
 	</parent>
 
 	<artifactId>token-client</artifactId>


### PR DESCRIPTION
Audience Validation should validate to true when `client_id` of broker-clone token matches the trusted client. This is relevant to support tokens of grant type `user_token` that contains no scopes.