### PR TITLE
Log token content/jwt validator config on failed authentication

### DIFF
--- a/java-api/src/main/java/com/sap/cloud/security/config/Service.java
+++ b/java-api/src/main/java/com/sap/cloud/security/config/Service.java
@@ -28,7 +28,7 @@ public enum Service {
 	 */
 	public String getCFName() {
 		if (this == IAS && cloudFoundryName == null) {
-			LoggerFactory.getLogger(Service.class).error("IAS Service is not yet supported!!!"); // TODO remove
+			LoggerFactory.getLogger(Service.class).info("IAS Service is not yet supported!!!"); // TODO remove
 		}
 		return cloudFoundryName;
 	}

--- a/java-security/Migration_SAPJavaBuildpackProjects.md
+++ b/java-security/Migration_SAPJavaBuildpackProjects.md
@@ -43,9 +43,29 @@ Whether the token is issued for your application or not is now validated by the 
 
 ### Congratulation! With that you're Done!
 
+### Troubleshooting
 
-### Get stuck with migration
-[Open an issue on Github](https://github.com/SAP/cloud-security-xsuaa-integration/issues/new) and provide details like client-lib / migration guide / issue you’re facing.
+If you run into issues with the migration of your application, you can increase the logging level. 
+This helps to identify the root cause of the issue. In the buildpack this can be done by setting the `SET_LOGGING_LEVEL`
+environment variable for your application. You can do this in the `manifest.yml` with the `env` option like so:
+
+```yaml
+env:
+    SET_LOGGING_LEVEL: '{com.sap.xs.security: DEBUG, com.sap.cloud.security: DEBUG}'
+```
+After you have made changes to the `manifest.yml` you need do re-deploy your app.
+This sets the logging level for this library and the security parts of the buildpack to `DEBUG`.
+For a running application this can also be done with the `cf` command line tool:
+
+```shell
+cf set-env <your app name> SET_LOGGING_LEVEL "{com.sap.xs.security: DEBUG, com.sap.cloud.security: DEBUG}"
+```
+
+You need to restage your application for the changes to take effect.
+
+If you are still stuck with migration, please
+[open an issue on Github](https://github.com/SAP/cloud-security-xsuaa-integration/issues/new)
+and provide details like client-lib / migration guide / issue you’re facing and, when available, (debug) logs.
 
 ### [OPTIONAL] Leverage new API and features
 You can continue [here](Migration_SAPJavaBuildpackProjects_V2.md) to understand what needs to be done to leverage the new `java-api` that is exposed by the SAP Java Buildpack as of version `1.26.1`.

--- a/java-security/src/main/java/com/sap/cloud/security/config/OAuth2ServiceConfigurationBuilder.java
+++ b/java-security/src/main/java/com/sap/cloud/security/config/OAuth2ServiceConfigurationBuilder.java
@@ -166,5 +166,14 @@ public class OAuth2ServiceConfigurationBuilder {
 		public int hashCode() {
 			return Objects.hash(properties, runInLegacyMode, service);
 		}
+
+		@Override
+		public String toString() {
+			return "OAuth2ServiceConfigurationImpl{" +
+					"properties=" + properties +
+					", service=" + service +
+					", legacyMode=" + isLegacyMode() +
+					'}';
+		}
 	}
 }

--- a/java-security/src/main/java/com/sap/cloud/security/json/DefaultJsonObject.java
+++ b/java-security/src/main/java/com/sap/cloud/security/json/DefaultJsonObject.java
@@ -190,4 +190,8 @@ public class DefaultJsonObject implements JsonObject {
 		}
 	}
 
+	@Override
+	public String toString() {
+		return jsonObject.toString(2);
+	}
 }

--- a/java-security/src/main/java/com/sap/cloud/security/token/AbstractToken.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/AbstractToken.java
@@ -27,12 +27,14 @@ import static com.sap.cloud.security.token.TokenClaims.XSUAA.ISSUED_AT;
  * header parameters and claims.
  */
 public abstract class AbstractToken implements Token {
+	private final DecodedJwt decodedJwt;
 	protected final DefaultJsonObject tokenHeader;
 	protected final DefaultJsonObject tokenBody;
-	protected final String jwtToken;
 
 	public AbstractToken(@Nonnull DecodedJwt decodedJwt) {
-		this(decodedJwt.getHeader(), decodedJwt.getPayload(), decodedJwt.getEncodedToken());
+		this.tokenHeader = new DefaultJsonObject(decodedJwt.getHeader());
+		this.tokenBody = new DefaultJsonObject(decodedJwt.getPayload());
+		this.decodedJwt = decodedJwt;
 	}
 
 	/**
@@ -45,12 +47,6 @@ public abstract class AbstractToken implements Token {
 	 */
 	public AbstractToken(@Nonnull String jwtToken) {
 		this(Base64JwtDecoder.getInstance().decode(removeBearer(jwtToken)));
-	}
-
-	AbstractToken(String jsonHeader, String jsonPayload, String jwtToken) {
-		tokenHeader = new DefaultJsonObject(jsonHeader);
-		tokenBody = new DefaultJsonObject(jsonPayload);
-		this.jwtToken = jwtToken;
 	}
 
 	@Nullable
@@ -109,7 +105,7 @@ public abstract class AbstractToken implements Token {
 
 	@Override
 	public String getTokenValue() {
-		return jwtToken;
+		return decodedJwt.getEncodedToken();
 	}
 
 	@Override
@@ -167,5 +163,10 @@ public abstract class AbstractToken implements Token {
 	@Override
 	public String getZoneId() {
 		return getClaimAsString(TokenClaims.SAP_GLOBAL_ZONE_ID);
+	}
+
+	@Override
+	public String toString() {
+		return decodedJwt.toString();
 	}
 }

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/CombiningValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/CombiningValidator.java
@@ -1,6 +1,8 @@
 package com.sap.cloud.security.token.validation;
 
 import com.sap.cloud.security.xsuaa.Assertions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -18,6 +20,7 @@ public class CombiningValidator<T> implements Validator<T> {
 
 	private final List<Validator<T>> validators;
 	private final Set<ValidationListener> validationListeners = new HashSet<>();
+	private static final Logger LOGGER = LoggerFactory.getLogger(CombiningValidator.class);
 
 	public CombiningValidator(List<Validator<T>> validators) {
 		Assertions.assertNotNull(validators, "validators must not be null.");
@@ -34,6 +37,7 @@ public class CombiningValidator<T> implements Validator<T> {
 		for (Validator<T> validator : validators) {
 			ValidationResult result = validator.validate(t);
 			if (result.isErroneous()) {
+				LOGGER.debug("Validator that caused the failed validation: {}", validator.getClass().getName());
 				validationListeners.forEach(listener -> listener.onValidationError(result));
 				return result;
 			}

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtValidatorBuilder.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtValidatorBuilder.java
@@ -6,13 +6,10 @@ import com.sap.cloud.security.config.cf.CFConstants;
 import com.sap.cloud.security.token.Token;
 import com.sap.cloud.security.token.validation.CombiningValidator;
 import com.sap.cloud.security.token.validation.ValidationListener;
-import com.sap.cloud.security.token.validation.ValidationResult;
 import com.sap.cloud.security.token.validation.Validator;
 import com.sap.cloud.security.xsuaa.Assertions;
 import com.sap.cloud.security.xsuaa.client.*;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -27,8 +24,6 @@ import static com.sap.cloud.security.config.cf.CFConstants.XSUAA.UAA_DOMAIN;
  * Custom validators can be added via {@link #with(Validator)} method.
  */
 public class JwtValidatorBuilder {
-	private static final Logger LOGGER = LoggerFactory.getLogger(JwtValidatorBuilder.class);
-
 	private static Map<OAuth2ServiceConfiguration, JwtValidatorBuilder> instances = new HashMap<>();
 	private final Collection<Validator<Token>> validators = new ArrayList<>();
 	private final List<ValidationListener> validationListeners = new ArrayList<>();
@@ -181,25 +176,9 @@ public class JwtValidatorBuilder {
 		List<Validator<Token>> allValidators = createDefaultValidators();
 		allValidators.addAll(validators);
 
-		CombiningValidator<Token> combiningValidator = new CombiningTokenValidator(allValidators);
+		CombiningValidator<Token> combiningValidator = new CombiningValidator<>(allValidators);
 		validationListeners.forEach(combiningValidator::registerValidationListener);
 		return combiningValidator;
-	}
-
-	private class CombiningTokenValidator extends CombiningValidator<Token> {
-
-		public CombiningTokenValidator(List<Validator<Token>> validators) {
-			super(validators);
-		}
-
-		@Override
-		public ValidationResult validate(Token token) {
-			ValidationResult validationResult = super.validate(token);
-			if (validationResult.isErroneous()) {
-				LOGGER.debug("Token that caused the failed validation: {}{}", System.lineSeparator(), token);
-			}
-			return validationResult;
-		}
 	}
 
 	private List<Validator<Token>> createDefaultValidators() {

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtValidatorBuilder.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtValidatorBuilder.java
@@ -196,7 +196,7 @@ public class JwtValidatorBuilder {
 		public ValidationResult validate(Token token) {
 			ValidationResult validationResult = super.validate(token);
 			if (validationResult.isErroneous()) {
-				LOGGER.debug("Validation failed for token:{}{}", System.lineSeparator(), token);
+				LOGGER.debug("Token that caused the failed validation: {}{}", System.lineSeparator(), token);
 			}
 			return validationResult;
 		}

--- a/java-security/src/test/java/com/sap/cloud/security/token/AbstractTokenTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/AbstractTokenTest.java
@@ -124,4 +124,19 @@ public class AbstractTokenTest {
 		assertThat(cut.getClaimAsJsonObject("doesNotExist")).isNull();
 	}
 
+	@Test
+	public void toString_doesNotContainEncodedToken() {
+		assertThat(cut.toString()).doesNotContain(cut.getTokenValue());
+	}
+
+	@Test
+	public void toString_containsTokenContent() {
+		assertThat(cut.toString())
+				.contains(cut.getHeaderParameterAsString(TokenHeader.JWKS_URL))
+				.contains(cut.getHeaderParameterAsString(TokenHeader.KEY_ID))
+				.contains(cut.getAudiences())
+				.contains(cut.getClaimAsString(TokenClaims.XSUAA.CLIENT_ID))
+				.contains(cut.getClaimAsString(TokenClaims.XSUAA.GRANT_TYPE))
+				.contains(cut.getClaimAsStringList(TokenClaims.XSUAA.SCOPES));
+	}
 }

--- a/samples/sap-java-buildpack-api-usage/manifest.yml
+++ b/samples/sap-java-buildpack-api-usage/manifest.yml
@@ -17,7 +17,7 @@ applications:
   services:
     - xsuaa-buildpack
   env:
-    SET_LOGGING_LEVEL: '{com.sap.cloud.security: DEBUG}'
+    SET_LOGGING_LEVEL: '{com.sap.xs.security: DEBUG, com.sap.cloud.security: DEBUG}'
     ENABLE_SECURITY_JAVA_API_V2: true
 # Application Router as web server
 - name: approuter-sap-java-buildpack-api-usage

--- a/samples/sap-java-buildpack-api-usage/manifest.yml
+++ b/samples/sap-java-buildpack-api-usage/manifest.yml
@@ -17,6 +17,7 @@ applications:
   services:
     - xsuaa-buildpack
   env:
+    SET_LOGGING_LEVEL: '{com.sap.cloud.security: DEBUG}'
     ENABLE_SECURITY_JAVA_API_V2: true
 # Application Router as web server
 - name: approuter-sap-java-buildpack-api-usage


### PR DESCRIPTION
This is the simple solution for token logging more information on failed authentication attemps.

Todos:
- [x] AbstractToken.toString() provides token payload (maybe via DecodedJwt)
- [x] This should be logged in case validation fails.
- [x] Optional: log should provide validator that fails.
- [x] Optional: logging should be possible not only via Authenticator
