### PR TITLE
Skipe code analysis on skip tests

### DIFF
--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -93,15 +93,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>findbugs</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -127,15 +127,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>findbugs</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,22 @@
 							</executions>
 						</plugin>
 						<plugin>
+							<groupId>org.codehaus.mojo</groupId>
+							<artifactId>findbugs-maven-plugin</artifactId>
+							<version>3.0.5</version>
+							<configuration>
+								<skip>${skipTests}</skip>
+							</configuration>
+							<executions>
+								<execution>
+									<phase>verify</phase>
+									<goals>
+										<goal>findbugs</goal>
+									</goals>
+								</execution>
+							</executions>
+						</plugin>
+						<plugin>
 							<groupId>org.owasp</groupId> <!--scans for vulnerabilities-->
 							<artifactId>dependency-check-maven</artifactId>
 							<version>5.3.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
 		<mockito.version>2.23.0</mockito.version>
 		<assertj.version>3.13.2</assertj.version>
 		<reactor.test.version>3.2.12.RELEASE</reactor.test.version>
+		<skipTests>false</skipTests>
 	</properties>
 
 	<modules>
@@ -355,6 +356,7 @@
 								</execution>
 							</executions>
 							<configuration>
+								<skip>${skipTests}</skip>
 								<skipProvidedScope>true</skipProvidedScope>
 								<failBuildOnCVSS>7</failBuildOnCVSS>
 								<suppressionFile>${project.basedir}/../etc/suppression.xml</suppressionFile>

--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,9 @@
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-pmd-plugin</artifactId>
 							<version>3.13.0</version>
+							<configuration>
+								<skip>${skipTests}</skip>
+							</configuration>
 							<executions>
 								<execution>
 									<phase>verify</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
 		<assertj.version>3.13.2</assertj.version>
 		<reactor.test.version>3.2.12.RELEASE</reactor.test.version>
 		<skipTests>false</skipTests>
+		<jacoco.skip>${skipTests}</jacoco.skip>
 	</properties>
 
 	<modules>

--- a/spring-xsuaa-mock/pom.xml
+++ b/spring-xsuaa-mock/pom.xml
@@ -104,15 +104,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>findbugs</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-xsuaa-test/pom.xml
+++ b/spring-xsuaa-test/pom.xml
@@ -83,15 +83,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>findbugs</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -153,18 +153,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
-				<configuration>
-					<skip>${skipTests}</skip>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>findbugs</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/token-client/pom.xml
+++ b/token-client/pom.xml
@@ -129,18 +129,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
-				<configuration>
-					<skip>${skipTests}</skip>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>findbugs</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
This PR adds skipping of static code analysis and the maven dependency check when maven is run with -DskipTests