### PR TITLE
Fix wrong DEFAULT_JWKS_URL in JwtGenerator

### DIFF
--- a/java-security-test/src/main/java/com/sap/cloud/security/test/JwtGenerator.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/JwtGenerator.java
@@ -33,7 +33,7 @@ public class JwtGenerator {
 	public static final Instant NO_EXPIRE_DATE = new GregorianCalendar(2190, 11, 31).getTime().toInstant();
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(JwtGenerator.class);
-	private static final String DEFAULT_JWKS_URL = "http://localhost";
+	private static final String DEFAULT_JWKS_URL = "http://localhost/token_keys";
 	private static final String DEFAULT_KEY_ID = "default-kid";
 	private static final char DOT = '.';
 

--- a/java-security-test/src/test/java/com/sap/cloud/security/test/JwtGeneratorTest.java
+++ b/java-security-test/src/test/java/com/sap/cloud/security/test/JwtGeneratorTest.java
@@ -137,7 +137,7 @@ public class JwtGeneratorTest {
 		assertThat(token.getHeaderParameterAsString(TokenHeader.JWKS_URL)).isEqualTo(tokenKeyServiceUrl);
 	}
 
-		@Test
+	@Test
 	public void withScopes_containsScopeWhenServiceIsXsuaa() {
 		String[] scopes = new String[] { "openid", "app1.scope" };
 		Token token = cut.withScopes(scopes).createToken();

--- a/java-security-test/src/test/java/com/sap/cloud/security/test/TokenValidationIntegrationTest.java
+++ b/java-security-test/src/test/java/com/sap/cloud/security/test/TokenValidationIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.sap.cloud.security.test;
+
+import com.sap.cloud.security.config.Environments;
+import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
+import com.sap.cloud.security.config.OAuth2ServiceConfigurationBuilder;
+import com.sap.cloud.security.config.Service;
+import com.sap.cloud.security.config.cf.CFConstants;
+import com.sap.cloud.security.token.Token;
+import com.sap.cloud.security.token.TokenClaims;
+import com.sap.cloud.security.token.TokenHeader;
+import com.sap.cloud.security.token.validation.CombiningValidator;
+import com.sap.cloud.security.token.validation.ValidationResult;
+import com.sap.cloud.security.token.validation.validators.JwtValidatorBuilder;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
+import com.sap.cloud.security.xsuaa.client.OAuth2TokenKeyService;
+import com.sap.cloud.security.xsuaa.client.OidcConfigurationService;
+import org.apache.commons.io.IOUtils;
+import org.junit.*;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import static com.sap.cloud.security.config.Service.IAS;
+import static com.sap.cloud.security.config.Service.XSUAA;
+import static com.sap.cloud.security.test.SecurityTestRule.DEFAULT_CLIENT_ID;
+import static com.sap.cloud.security.test.SecurityTestRule.DEFAULT_DOMAIN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class TokenValidationIntegrationTest {
+
+	private static RSAKeys keys;
+
+	private Properties originalSystemProperties;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		keys = RSAKeys.fromKeyFiles("/publicKey.txt", "/privateKey.txt");
+	}
+
+	@Before
+	public void setUp() {
+		originalSystemProperties = System.getProperties();
+	}
+
+	@After
+	public void tearDown() {
+		System.setProperties(originalSystemProperties);
+	}
+
+	@Test
+	public void createToken_withCorrectVerificationKey_tokenIsValid() throws IOException {
+		String publicKey = IOUtils.resourceToString("/publicKey.txt", StandardCharsets.UTF_8);
+		OAuth2ServiceConfiguration configuration = OAuth2ServiceConfigurationBuilder
+				.forService(XSUAA)
+				.withProperty(CFConstants.XSUAA.UAA_DOMAIN, DEFAULT_DOMAIN)
+				.withClientId(DEFAULT_CLIENT_ID)
+				.withProperty("verificationkey", publicKey)
+				.build();
+
+		CombiningValidator<Token> tokenValidator = JwtValidatorBuilder.getInstance(configuration)
+				// mocked because we use the key from the verificationkey property here
+				.withOAuth2TokenKeyService(Mockito.mock(OAuth2TokenKeyService.class))
+				.build();
+
+		Token token = JwtGenerator.getInstance(XSUAA, DEFAULT_CLIENT_ID)
+				.withPrivateKey(keys.getPrivate())
+				.createToken();
+
+		ValidationResult result = tokenValidator.validate(token);
+		assertThat(result.isValid()).isTrue();
+	}
+
+	@Test
+	public void createToken_integrationTest_tokenValidation() throws IOException {
+		System.setProperty("VCAP_SERVICES", IOUtils
+				.resourceToString("/vcap.json", StandardCharsets.UTF_8));
+		OAuth2ServiceConfiguration configuration = Environments.getCurrent().getXsuaaConfiguration();
+
+		OAuth2TokenKeyService tokenKeyServiceMock = Mockito.mock(OAuth2TokenKeyService.class);
+		when(tokenKeyServiceMock.retrieveTokenKeys(any()))
+				.thenReturn(IOUtils.resourceToString("/jsonWebTokenKeys.json", StandardCharsets.UTF_8));
+
+		CombiningValidator<Token> tokenValidator = JwtValidatorBuilder.getInstance(configuration)
+				.withOAuth2TokenKeyService(tokenKeyServiceMock)
+				.build();
+
+		Token token = JwtGenerator.getInstance(XSUAA, DEFAULT_CLIENT_ID)
+				.withPrivateKey(keys.getPrivate())
+				.withHeaderParameter(TokenHeader.JWKS_URL, "http://auth.com/token_keys")
+				.createToken();
+
+		ValidationResult result = tokenValidator.validate(token);
+		assertThat(result.isValid()).isTrue();
+	}
+
+	@Test
+	public void createToken_discoverOidcJwksEndpoint_tokenIsValid() throws Exception {
+		String clientId = "T000310";
+		String url = "https://app.auth.com";
+		OAuth2ServiceConfiguration configuration = OAuth2ServiceConfigurationBuilder.forService(IAS)
+				.withUrl(url)
+				.withClientId(clientId)
+				.build();
+
+		OAuth2TokenKeyService tokenKeyServiceMock = Mockito.mock(OAuth2TokenKeyService.class);
+		when(tokenKeyServiceMock.retrieveTokenKeys(any()))
+				.thenReturn(IOUtils.resourceToString("/jsonWebTokenKeys.json", StandardCharsets.UTF_8));
+		OAuth2ServiceEndpointsProvider endpointsProviderMock = Mockito.mock(OAuth2ServiceEndpointsProvider.class);
+		when(endpointsProviderMock.getJwksUri()).thenReturn(URI.create("http://auth.com/token_keys"));
+		OidcConfigurationService oidcConfigServiceMock = Mockito.mock(OidcConfigurationService.class);
+		when(oidcConfigServiceMock.retrieveEndpoints(any())).thenReturn(endpointsProviderMock);
+
+		CombiningValidator<Token> tokenValidator = JwtValidatorBuilder.getInstance(configuration)
+				.withOAuth2TokenKeyService(tokenKeyServiceMock)
+				.withOidcConfigurationService(oidcConfigServiceMock)
+				.build();
+
+		Token token = JwtGenerator.getInstance(Service.IAS, clientId)
+				.withClaimValue(TokenClaims.ISSUER, url)
+				.withPrivateKey(keys.getPrivate())
+				.withExpiration(JwtGenerator.NO_EXPIRE_DATE)
+				.createToken();
+
+		ValidationResult result = tokenValidator.validate(token);
+		assertThat(result.isValid()).isTrue();
+	}
+}

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JwtAudienceValidatorTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JwtAudienceValidatorTest.java
@@ -192,5 +192,4 @@ public class JwtAudienceValidatorTest {
 		assertThat(audiences).containsExactlyInAnyOrder("test1!t1", "client", "xsappid");
 	}
 
-
 }


### PR DESCRIPTION
This also changes the existing validation test so that the defaults of the JwtGenerator are not overridden in the test. 