### PR TITLE
Cas update

### DIFF
--- a/spring-cas/pom.xml
+++ b/spring-cas/pom.xml
@@ -47,6 +47,7 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-resource-server</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>

--- a/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcServiceAutoConfiguration.java
+++ b/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcServiceAutoConfiguration.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class AdcServiceConfiguration {
+public class AdcServiceAutoConfiguration {
 
 	@Value("${ADC_URL:http://localhost:8181}")
 	private String adcUrl;

--- a/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcSpringMethodSecurityAutoConfiguration.java
+++ b/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcSpringMethodSecurityAutoConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.security.config.annotation.method.configuration.Globa
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @AutoConfigureAfter(name = "com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaAutoConfiguration")
-public class MethodSecurityConfiguration extends GlobalMethodSecurityConfiguration {
+public class AdcSpringMethodSecurityAutoConfiguration extends GlobalMethodSecurityConfiguration {
 
 
 	@Autowired

--- a/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcSpringSecurityExpression.java
+++ b/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcSpringSecurityExpression.java
@@ -9,10 +9,7 @@ import org.springframework.security.access.expression.SecurityExpressionRoot;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
-import java.util.Map;
 
 /**
  */
@@ -29,19 +26,11 @@ public class AdcSpringSecurityExpression extends SecurityExpressionRoot implemen
 	private String userId;
 	private String zoneId;
 
-	public AdcSpringSecurityExpression(JwtAuthenticationToken authentication) {
-		super(authentication);
-		logger.debug("Create AdcSpringSecurityExpression with jwtAuthenticationToken");
-
-		extractAttributesFromAuthentication(authentication);
-		setTrustResolver(new AuthenticationTrustResolverImpl());
-	}
-
-	public AdcSpringSecurityExpression(Authentication authentication) {
+	public AdcSpringSecurityExpression(Authentication authentication, String zoneId, String userId) {
 		super(authentication);
 		logger.debug("Create AdcSpringSecurityExpression with authentication");
-
-		extractAttributesFromPrincipal(authentication.getPrincipal());
+		this.zoneId = zoneId;
+		this.userId = userId;
 		setTrustResolver(new AuthenticationTrustResolverImpl());
 	}
 
@@ -125,20 +114,4 @@ public class AdcSpringSecurityExpression extends SecurityExpressionRoot implemen
 		return null;
 	}
 
-	private void extractAttributesFromAuthentication(JwtAuthenticationToken authentication) {
-		Map<String, Object> attributes = authentication.getTokenAttributes();
-		zoneId = (String) attributes.getOrDefault(ZONE_UUID_KEY, attributes.get(ZID));
-		userId = (String) attributes.getOrDefault(USER_UUID_KEY, attributes.get(XSUAA_USER_ID));
-		logger.debug("Extracted attribute zoneId={} and userId={} from authentication", zoneId, userId);
-	}
-
-	private void extractAttributesFromPrincipal(Object principal) {
-		if (principal instanceof OAuth2AuthenticatedPrincipal) {
-			OAuth2AuthenticatedPrincipal userPrincipal = (OAuth2AuthenticatedPrincipal) principal;
-			zoneId = (String) userPrincipal.getAttributes()
-					.getOrDefault(ZONE_UUID_KEY, userPrincipal.getAttribute(ZID));
-			userId = userPrincipal.getAttribute(USER_UUID_KEY);
-			logger.debug("Extracted attribute zoneId={} and userId={} from principal", zoneId, userId);
-		}
-	}
 }

--- a/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcSpringSecurityExpressionHandler.java
+++ b/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcSpringSecurityExpressionHandler.java
@@ -2,12 +2,18 @@ package com.sap.cloud.security.cas.spring;
 
 import com.sap.cloud.security.cas.client.AdcService;
 import org.aopalliance.intercept.MethodInvocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+
+import static com.sap.cloud.security.cas.spring.AdcSpringSecurityExpression.*;
 
 public class AdcSpringSecurityExpressionHandler extends DefaultMethodSecurityExpressionHandler {
 	private AdcService service;
+	private Logger logger = LoggerFactory.getLogger(getClass());
 
 	private AdcSpringSecurityExpressionHandler() {
 		// use factory methods instead
@@ -22,7 +28,18 @@ public class AdcSpringSecurityExpressionHandler extends DefaultMethodSecurityExp
 	@Override
 	protected MethodSecurityExpressionOperations createSecurityExpressionRoot(
 			Authentication authentication, MethodInvocation invocation) {
-		return new AdcSpringSecurityExpression(authentication)
-				.withAdcService(service);
+		String zoneId;
+		String userId;
+
+		if (authentication.getPrincipal() instanceof OAuth2AuthenticatedPrincipal) {
+			OAuth2AuthenticatedPrincipal userPrincipal = (OAuth2AuthenticatedPrincipal) authentication.getPrincipal();
+			zoneId = (String) userPrincipal.getAttributes()
+					.getOrDefault(ZONE_UUID_KEY, userPrincipal.getAttribute(ZID));
+			userId = (String) userPrincipal.getAttributes()
+					.getOrDefault(USER_UUID_KEY, userPrincipal.getAttribute("sub"));
+			logger.debug("Extracted attribute zoneId={} and userId={} from principal", zoneId, userId);
+			return new AdcSpringSecurityExpression(authentication, zoneId, userId).withAdcService(service);
+		}
+		return null;
 	}
 }

--- a/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcSpringSecurityExpressionHandlerXsuaa.java
+++ b/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcSpringSecurityExpressionHandlerXsuaa.java
@@ -7,6 +7,10 @@ import org.springframework.security.access.expression.method.MethodSecurityExpre
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
+/**
+ * This class is only loaded in case org.springframework.security:spring-security-oauth2-resource-server
+ * is provided by the consuming application.
+ */
 public class AdcSpringSecurityExpressionHandlerXsuaa extends DefaultMethodSecurityExpressionHandler {
 	private AdcService service;
 

--- a/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcSpringSecurityExpressionHandlerXsuaa.java
+++ b/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/AdcSpringSecurityExpressionHandlerXsuaa.java
@@ -2,10 +2,16 @@ package com.sap.cloud.security.cas.spring;
 
 import com.sap.cloud.security.cas.client.AdcService;
 import org.aopalliance.intercept.MethodInvocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.Map;
+
+import static com.sap.cloud.security.cas.spring.AdcSpringSecurityExpression.*;
 
 /**
  * This class is only loaded in case org.springframework.security:spring-security-oauth2-resource-server
@@ -13,6 +19,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
  */
 public class AdcSpringSecurityExpressionHandlerXsuaa extends DefaultMethodSecurityExpressionHandler {
 	private AdcService service;
+	private Logger logger = LoggerFactory.getLogger(getClass());
 
 	private AdcSpringSecurityExpressionHandlerXsuaa() {
 		// use factory methods instead
@@ -27,9 +34,16 @@ public class AdcSpringSecurityExpressionHandlerXsuaa extends DefaultMethodSecuri
 	@Override
 	protected MethodSecurityExpressionOperations createSecurityExpressionRoot(
 			Authentication authentication, MethodInvocation invocation) {
+		String zoneId;
+		String userId;
+
 		if (authentication instanceof JwtAuthenticationToken) {
-			return new AdcSpringSecurityExpression((JwtAuthenticationToken) authentication).withAdcService(service);
+			Map<String, Object> attributes = ((JwtAuthenticationToken) authentication).getTokenAttributes();
+			zoneId = (String) attributes.getOrDefault(ZONE_UUID_KEY, attributes.get(ZID));
+			userId = (String) attributes.getOrDefault(USER_UUID_KEY, attributes.get(XSUAA_USER_ID));
+			logger.debug("Extracted attribute zoneId={} and userId={} from authentication", zoneId, userId);
+			return new AdcSpringSecurityExpression(authentication, zoneId, userId).withAdcService(service);
 		}
-		return new AdcSpringSecurityExpression(authentication).withAdcService(service);
+		return null;
 	}
 }

--- a/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/MethodSecurityConfiguration.java
+++ b/spring-cas/src/main/java/com/sap/cloud/security/cas/spring/MethodSecurityConfiguration.java
@@ -16,30 +16,25 @@ import org.springframework.security.config.annotation.method.configuration.Globa
 @AutoConfigureAfter(name = "com.sap.cloud.security.xsuaa.autoconfiguration.XsuaaAutoConfiguration")
 public class MethodSecurityConfiguration extends GlobalMethodSecurityConfiguration {
 
-	@Autowired
-	AdcService adcService;
 
 	@Autowired
-	ExpressionHandlerService expressionHandlerService;
+	MethodSecurityExpressionHandler expressionHandler;
 
 	@Override
 	protected MethodSecurityExpressionHandler createExpressionHandler() {
-		return expressionHandlerService.createMethodSecurityExpressionHandler();
+		return expressionHandler;
 	}
 
 	@Bean
 	@ConditionalOnBean(type = "com.sap.cloud.security.xsuaa.XsuaaServiceConfiguration")
-	ExpressionHandlerService expressionHandlerXsuaa() {
-		return () -> AdcSpringSecurityExpressionHandlerXsuaa.getInstance(adcService);
+	MethodSecurityExpressionHandler expressionHandlerXsuaa(AdcService adcService) {
+		return AdcSpringSecurityExpressionHandlerXsuaa.getInstance(adcService);
 	}
 
 	@Bean
 	@ConditionalOnMissingBean
-	ExpressionHandlerService expressionHandler() {
-		return () -> AdcSpringSecurityExpressionHandler.getInstance(adcService);
+	MethodSecurityExpressionHandler expressionHandler(AdcService adcService) {
+		return AdcSpringSecurityExpressionHandler.getInstance(adcService);
 	}
 
-	interface ExpressionHandlerService {
-		MethodSecurityExpressionHandler createMethodSecurityExpressionHandler();
-	}
 }

--- a/spring-cas/src/main/resources/META-INF/spring.factories
+++ b/spring-cas/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration= \
-com.sap.cloud.security.cas.spring.AdcServiceConfiguration, \
-com.sap.cloud.security.cas.spring.MethodSecurityConfiguration
+com.sap.cloud.security.cas.spring.AdcServiceAutoConfiguration, \
+com.sap.cloud.security.cas.spring.AdcSpringMethodSecurityAutoConfiguration

--- a/spring-cas/src/test/java/com/sap/cloud/security/cas/spring/AdcSpringSecurityExpressionTest.java
+++ b/spring-cas/src/test/java/com/sap/cloud/security/cas/spring/AdcSpringSecurityExpressionTest.java
@@ -37,7 +37,7 @@ class AdcSpringSecurityExpressionTest {
 		adcService = Mockito.mock(AdcService.class);
 		adcServiceRequestArgumentCaptor = ArgumentCaptor.forClass(AdcServiceRequest.class);
 		when(adcService.isUserAuthorized(any())).thenReturn(createResponse(true));
-		cut = new AdcSpringSecurityExpression(createAuthentication()).withAdcService(adcService);
+		cut = (AdcSpringSecurityExpression) AdcSpringSecurityExpressionHandler.getInstance(adcService).createSecurityExpressionRoot(createAuthentication(), null);
 	}
 
 	@Test
@@ -128,7 +128,8 @@ class AdcSpringSecurityExpressionTest {
 	@Test
 	void forResourceAction_withJwtAuthenticationToken_createsServiceRequest() {
 		JwtAuthenticationToken authentication = createJwtAuthenticationToken();
-		cut = new AdcSpringSecurityExpression(authentication).withAdcService(adcService);
+		cut = (AdcSpringSecurityExpression) AdcSpringSecurityExpressionHandlerXsuaa.getInstance(adcService)
+				.createSecurityExpressionRoot(authentication, null);
 
 		cut.forResourceAction("newResource", "newAction", "newAttribute=newValue");
 

--- a/spring-cas/src/test/java/com/sap/cloud/security/cas/spring/AutoConfigurationTest.java
+++ b/spring-cas/src/test/java/com/sap/cloud/security/cas/spring/AutoConfigurationTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AutoConfigurationTest {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(AdcServiceConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(AdcServiceAutoConfiguration.class));
 
 	@Test
 	void adcService_isCreated() {

--- a/spring-cas/src/test/java/com/sap/cloud/security/cas/spring/MethodSecurityConfigurationTest.java
+++ b/spring-cas/src/test/java/com/sap/cloud/security/cas/spring/MethodSecurityConfigurationTest.java
@@ -11,12 +11,12 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = { XsuaaAutoConfiguration.class, AdcServiceConfiguration.class,
-		MethodSecurityConfiguration.class })
+@SpringBootTest(classes = { XsuaaAutoConfiguration.class, AdcServiceAutoConfiguration.class,
+		AdcSpringMethodSecurityAutoConfiguration.class })
 public class MethodSecurityConfigurationTest {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(AdcServiceConfiguration.class, MethodSecurityConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(AdcServiceAutoConfiguration.class, AdcSpringMethodSecurityAutoConfiguration.class));
 
 	@Test
 	void hasExpressionHandler() {


### PR DESCRIPTION
- simplify Auto-configuration MethodSecurityConfiguration in that regard that the interface with lazy load is not required anymore
- rename Autoconfiguation classes
  - AdcServiceConfiguration --> AdcServiceAutoConfiguration
  - MethodSecurityConfiguration 	--> AdcSpringMethodSecurityAutoConfiguration
- AdcSpringSecurityExpression should not have any dependency to spring-security-oauth2-resource-server
  - dependency should only be provided as part of pom.xml


@hassler-d can you please test this with your xsuaa sample?