### PR TITLE
Migration guide for request token via UserInfo

### DIFF
--- a/java-security/Migration_SAPJavaBuildpackProjects_V2.md
+++ b/java-security/Migration_SAPJavaBuildpackProjects_V2.md
@@ -93,7 +93,6 @@ import com.sap.cloud.security.token.*;
 AccessToken accessToken = SecurityContext.getAccessToken();
 ```
 
-
 ### New Feature: SAP Java Buildpack without application roles
 In case you are not interested in Authorization checks with application specific roles in your J2EE application, this is now possible. You can just disable local scopes as authorities in the buildpack via the system environment variable `DISABLE_LOCAL_SCOPE_AS_AUTHORITIES`. By default it is set to `false`. If it is set to `true`, then the scopes/role check will not be performed on the local scopes but on the original scopes which are part of the `scope` claim of the token, such as "openid".
 
@@ -104,6 +103,9 @@ public class HelloJavaServlet extends HttpServlet {
     ...
 }
 ```
+
+## [OPTIONAL] Use new token-client
+If your application is requesting tokens using `requestToken`, `requestTokenForUser` or `requestTokenForClient` methods of the `(XS)UserInfo` object, you can migrate this to the new `token-client` library. You can find the migration guide [here](/token-client/Migration_XSUserInfoRequestToken.md).
 
 ### Sample using new API
 - [J2EE java web servlet sample using SAP Java Buildpack](https://github.com/SAP/cloud-security-xsuaa-integration/tree/master/samples/sap-java-buildpack-api-usage)

--- a/spring-xsuaa/Migration_JavaContainerSecurityProjects.md
+++ b/spring-xsuaa/Migration_JavaContainerSecurityProjects.md
@@ -192,8 +192,8 @@ See the following table for methods that are not available anymore and workaroun
 | `getToken`              | Not implemented.                                                                                 |
 | `hasAttributes`         | Use `getXSUserAttribute` and check of the attribute is available.                                |
 | `isInForeignMode`       | Not implemented.                                                                                 |
-| `requestToken`          | Was removed with version `2.0.0`in favor of [XsuaaTokenFlows](https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/XsuaaTokenFlows.java) which is provided with [token-client](/token-client) library. 
-| `requestTokenForClient` | Was removed with version `2.0.0`in favor of [XsuaaTokenFlows](https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/XsuaaTokenFlows.java) which is provided with [token-client](/token-client) library.
+| `requestToken`          | Deprecated in favor of [XsuaaTokenFlows](https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/XsuaaTokenFlows.java) which is provided with [token-client](/token-client) library. You can find a  migration guide [here](/token-client/Migration_XSUserInfoRequestToken.md).
+| `requestTokenForClient` | Deprecated in favor of [XsuaaTokenFlows](https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/XsuaaTokenFlows.java) which is provided with [token-client](/token-client) library. You can find a  migration guide [here](/token-client/Migration_XSUserInfoRequestToken.md).
 
 
 ### XsuaaToken

--- a/token-client/Migration_XSUserInfoRequestToken.md
+++ b/token-client/Migration_XSUserInfoRequestToken.md
@@ -1,0 +1,34 @@
+# Migration guide for applications that perform tokenflows using (XS)UserInfo
+
+This guide is for you if you are performing token flows with `requestToken`, `requestTokenForUser` or
+`requestTokenForClient` from `(XS)UserInfo`. Those methods are being deprecated. The new way to perform token flows is
+by using the [token-client](/token-client) library. This step-by-step guide explains how to migrate to this library.
+
+
+## Prerequisite
+
+Make sure you have a dependency to token-client defined in your `pom.xml` like described
+[here](/token-client#configuration-for-javaspring-applications) if you are using Spring or
+[here](/token-client#configuration-for-java-applications) if you are not using Spring.
+
+## Use token-client
+
+With `(XS)UserInfo` you can perform **Client Credentials** and **User Token** flows by using the following methods:
+
+  - **User Token** via `requestTokenForUser` method. Needs to be replaced with a user token flow [described here](/token-client#user-token-flow).
+  - **Client Credentials** via `requestTokenForClient` method.  Needs to be replaced with a client credentials token flow [described here](/token-client#client-credentials-token-flow).
+  - **User Token** or **Client Credentials** via  `requestToken`. Here you have to check how you have configured the `XSTokenRequest` object and perform a user token flow or a client credentials flow.
+
+General instructions and more information can be found in the token-client [documentation](/token-client).
+
+Note that the user token flow is an exchange flow. This means that you *exchange* your user token for an access token.
+When using `requestToken` or `requestTokenForUser` you did not have to pass a token. The `UserInfo` object already has
+the token information and automatically uses it for the request. Using the `token-client` library this is different! It
+is decoupled from the token itself. That is why you have to pass it via the `token` method. You can obtain the token if
+you are using the new API with `getTokenValue()` or, if you are using `(XS)UserInfo`, you can obtain it via
+`getAppToken()`.
+
+## Samples
+- Token client used in java application: [Java sample](/samples/java-tokenclient-usage)
+- Token-client used in spring boot application: [Spring Boot sample](/samples/spring-security-xsuaa-usage)
+

--- a/token-client/Migration_XSUserInfoRequestToken.md
+++ b/token-client/Migration_XSUserInfoRequestToken.md
@@ -7,7 +7,7 @@ by using the [token-client](/token-client) library. This step-by-step guide expl
 
 ## Prerequisite
 
-Make sure you have a dependency to token-client defined in your `pom.xml` like described
+Make sure you have a dependency to `token-client` defined in your `pom.xml` like described
 [here](/token-client#configuration-for-javaspring-applications) if you are using Spring or
 [here](/token-client#configuration-for-java-applications) if you are not using Spring.
 
@@ -19,7 +19,7 @@ With `(XS)UserInfo` you can perform **Client Credentials** and **User Token** fl
   - **Client Credentials** via `requestTokenForClient` method.  Needs to be replaced with a client credentials token flow [described here](/token-client#client-credentials-token-flow).
   - **User Token** or **Client Credentials** via  `requestToken`. Here you have to check how you have configured the `XSTokenRequest` object and perform a user token flow or a client credentials flow.
 
-General instructions and more information can be found in the token-client [documentation](/token-client).
+General instructions and more information can be found in the [token-client documentation](/token-client).
 
 Note that the user token flow is an exchange flow. This means that you *exchange* your user token for an access token.
 When using `requestToken` or `requestTokenForUser` you did not have to pass a token. The `UserInfo` object already has

--- a/token-client/Migration_XSUserInfoRequestToken.md
+++ b/token-client/Migration_XSUserInfoRequestToken.md
@@ -1,7 +1,7 @@
-# Migration guide for applications that perform tokenflows using (XS)UserInfo
+# Migration guide for applications that perform token flows using (XS)UserInfo
 
-This guide is for you if you are performing token flows with `requestToken`, `requestTokenForUser` or
-`requestTokenForClient` from `(XS)UserInfo`. Those methods are being deprecated. The new way to perform token flows is
+This guide is for you if your application is requesting tokens using `requestToken`, `requestTokenForUser` or
+`requestTokenForClient` from `(XS)UserInfo`. **Those methods are being deprecated.** The new way to perform token flows is
 by using the [token-client](/token-client) library. This step-by-step guide explains how to migrate to this library.
 
 

--- a/token-client/Migration_XSUserInfoRequestToken.md
+++ b/token-client/Migration_XSUserInfoRequestToken.md
@@ -11,22 +11,40 @@ Make sure you have a dependency to `token-client` defined in your `pom.xml` like
 [here](/token-client#configuration-for-javaspring-applications) if you are using Spring or
 [here](/token-client#configuration-for-java-applications) if you are not using Spring.
 
-## Use token-client
+## Use the new token-client library
 
-With `(XS)UserInfo` you can perform **Client Credentials** and **User Token** flows by using the following methods:
+Before you can use the new token-client library you first have to understand what token flows you
+are currently executing in your application.
 
-  - **User Token** via `requestTokenForUser` method. Needs to be replaced with a user token flow [described here](/token-client#user-token-flow).
-  - **Client Credentials** via `requestTokenForClient` method.  Needs to be replaced with a client credentials token flow [described here](/token-client#client-credentials-token-flow).
-  - **User Token** or **Client Credentials** via  `requestToken`. Here you have to check how you have configured the `XSTokenRequest` object and perform a user token flow or a client credentials flow.
+With `(XS)UserInfo` you can only execute **client credentials** and **user token** flows.  If you
+are using the `requestTokenForUser` method, a user token flow is executed.  If you are using
+`requestTokenForClient`, a client credentials flow is performed.  With the `requestToken` method
+either an user token or a client credentials token flow can be performed! In this case you have to
+check the `XSTokenRequest` object's `type` attribute to see if you need to replace this call with an
+user token flow or a client credentials flow!
 
-General instructions and more information can be found in the [token-client documentation](/token-client).
+You can proceed to the respective section for more information on how to perform client credentials or user token flows.
 
-Note that the user token flow is an exchange flow. This means that you *exchange* your user token for an access token.
-When using `requestToken` or `requestTokenForUser` you did not have to pass a token. The `UserInfo` object already has
-the token information and automatically uses it for the request. Using the `token-client` library this is different! It
-is decoupled from the token itself. That is why you have to pass it via the `token` method. You can obtain the token if
-you are using the new API with `getTokenValue()` or, if you are using `(XS)UserInfo`, you can obtain it via
-`getAppToken()`.
+### Perform a client credentials flow
+
+See the documentation [here](/token-client#client-credentials-token-flow) to perform a client
+credentials flow using the token-client library.
+Make sure you pass `clientId`, `clientSecret` and the `uaaUrl` to the flow.
+
+### Perform a user token flow
+
+See the documentation [here](/token-client#user-token-flow) to perform a user token flow
+using the token-client library.
+
+Note that the user token flow is an exchange flow. This means that you *exchange* your user token
+for an access token.  When using `requestToken` or `requestTokenForUser` from `(XS)UserInfo` you did
+not have to pass a token. The `(XS)UserInfo` object already has the token information and
+automatically uses it for the request. Using the `token-client` library this is different! It is
+decoupled from the token itself. That is why you have to pass it via the `token` method. You can
+obtain the token if you are using the new API with `getTokenValue()` or, if you are using
+`(XS)UserInfo`, you can obtain it via `getAppToken()`.
+
+Make also sure you pass `clientId`, `clientSecret` and the `uaaUrl` to the flow!
 
 ## Samples
 - Token client used in java application: [Java sample](/samples/java-tokenclient-usage)

--- a/token-client/Migration_XSUserInfoRequestToken.md
+++ b/token-client/Migration_XSUserInfoRequestToken.md
@@ -16,6 +16,8 @@ Make sure you have a dependency to `token-client` defined in your `pom.xml` like
 Before you can use the new token-client library you first have to understand what token flows you
 are currently executing in your application.
 
+### 1. Understand your application
+
 With `(XS)UserInfo` you can only execute **client credentials** and **user token** flows.  If you
 are using the `requestTokenForUser` method, a user token flow is executed.  If you are using
 `requestTokenForClient`, a client credentials flow is performed.  With the `requestToken` method
@@ -23,18 +25,22 @@ either an user token or a client credentials token flow can be performed! In thi
 check the `XSTokenRequest` object's `type` attribute to see if you need to replace this call with an
 user token flow or a client credentials flow!
 
-You can proceed to the respective section for more information on how to perform client credentials or user token flows.
 
-### Perform a client credentials flow
+### 2. Create an XsuaaTokenFlows object
 
-See the documentation [here](/token-client#client-credentials-token-flow) to perform a client
-credentials flow using the token-client library.
-Make sure you pass `clientId`, `clientSecret` and the `uaaUrl` to the flow.
+Before you can perform a specific token flow, you first have to create an `XsuaaTokenFlows` object.
+To create this object you have to pass in the following data: `clientId`, `clientSecret` and
+the `uaaUrl`. How you would create the `XsuaaTokenFlows` depends on the type of your application.
+If you are using spring see [here](/token-client#initialization-1) if not see [here](/token-client#initialization).
 
-### Perform a user token flow
 
-See the documentation [here](/token-client#user-token-flow) to perform a user token flow
-using the token-client library.
+### 3. Perform the flow
+
+Now you are ready to perform the specific flow!
+
+If you want to perform a client credentials flow  see the documentation [here](/token-client#client-credentials-token-flow)
+
+If you want to perform a user token flow see the documentation [here](/token-client#user-token-flow).
 
 Note that the user token flow is an exchange flow. This means that you *exchange* your user token
 for an access token.  When using `requestToken` or `requestTokenForUser` from `(XS)UserInfo` you did
@@ -44,9 +50,6 @@ decoupled from the token itself. That is why you have to pass it via the `token`
 obtain the token if you are using the new API with `getTokenValue()` or, if you are using
 `(XS)UserInfo`, you can obtain it via `getAppToken()`.
 
-Make also sure you pass `clientId`, `clientSecret` and the `uaaUrl` to the flow!
-
 ## Samples
 - Token client used in java application: [Java sample](/samples/java-tokenclient-usage)
 - Token-client used in spring boot application: [Spring Boot sample](/samples/spring-security-xsuaa-usage)
-


### PR DESCRIPTION
This PR adds a migration guide that describes how to replace the `requestToken`, `requestTokenForUser` and `requestTokenForClient` methods calls of `(XS)UserInfo` with the `token-client` library.
