### PR TITLE
Cache statistics

### DIFF
--- a/java-api/src/main/java/com/sap/cloud/security/config/CacheConfiguration.java
+++ b/java-api/src/main/java/com/sap/cloud/security/config/CacheConfiguration.java
@@ -30,4 +30,14 @@ public interface CacheConfiguration {
 	default boolean isCacheDisabled() {
 		return false;
 	}
+
+	/**
+	 * Returns {@code true} if cache statistics recording has been enabled.
+	 * If it is enabled, cache statistics might be obtained from the {@code Cacheable}.
+	 *
+	 * @return {@code true} if cache statistics is enabled
+	 */
+	default boolean isCacheStatisticsEnabled() {
+		return false;
+	}
 }

--- a/java-api/src/main/java/com/sap/cloud/security/config/CacheConfiguration.java
+++ b/java-api/src/main/java/com/sap/cloud/security/config/CacheConfiguration.java
@@ -32,8 +32,8 @@ public interface CacheConfiguration {
 	}
 
 	/**
-	 * Returns {@code true} if cache statistics recording has been enabled.
-	 * If it is enabled, cache statistics might be obtained from the {@code Cacheable}.
+	 * Returns {@code true} if cache statistics recording has been enabled. If it is
+	 * enabled, cache statistics might be obtained from the {@code Cacheable}.
 	 *
 	 * @return {@code true} if cache statistics is enabled
 	 */

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
@@ -1,19 +1,11 @@
 package com.sap.cloud.security.token.validation.validators;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.Ticker;
-import com.sap.cloud.security.config.CacheConfiguration;
-import com.sap.cloud.security.xsuaa.Assertions;
-import com.sap.cloud.security.xsuaa.client.DefaultOAuth2TokenKeyService;
-import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
-import com.sap.cloud.security.xsuaa.client.OAuth2TokenKeyService;
-import com.sap.cloud.security.xsuaa.tokenflows.Cacheable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.sap.cloud.security.xsuaa.Assertions.assertHasText;
+import static com.sap.cloud.security.xsuaa.Assertions.assertNotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -21,8 +13,17 @@ import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 import java.util.Set;
 
-import static com.sap.cloud.security.xsuaa.Assertions.assertHasText;
-import static com.sap.cloud.security.xsuaa.Assertions.assertNotNull;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.sap.cloud.security.config.CacheConfiguration;
+import com.sap.cloud.security.xsuaa.Assertions;
+import com.github.benmanes.caffeine.cache.Ticker;
+import com.sap.cloud.security.xsuaa.client.DefaultOAuth2TokenKeyService;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
+import com.sap.cloud.security.xsuaa.client.OAuth2TokenKeyService;
+import com.sap.cloud.security.xsuaa.tokenflows.Cacheable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Decorates {@link OAuth2TokenKeyService} with a cache, which gets looked up
@@ -55,7 +56,8 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 	 * Creates a new instance and sets the cache ticker. This is used for testing.
 	 *
 	 * @param cacheTicker
-	 *            ticker the cache uses to determine time
+	 * 			ticker the cache uses to determine time
+	 *
 	 * @return the new instance.
 	 */
 	static OAuth2TokenKeyServiceWithCache getInstance(Ticker cacheTicker) {

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
@@ -1,11 +1,19 @@
 package com.sap.cloud.security.token.validation.validators;
 
-import static com.sap.cloud.security.xsuaa.Assertions.assertHasText;
-import static com.sap.cloud.security.xsuaa.Assertions.assertNotNull;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Ticker;
+import com.sap.cloud.security.config.CacheConfiguration;
+import com.sap.cloud.security.xsuaa.Assertions;
+import com.sap.cloud.security.xsuaa.client.DefaultOAuth2TokenKeyService;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
+import com.sap.cloud.security.xsuaa.client.OAuth2TokenKeyService;
+import com.sap.cloud.security.xsuaa.tokenflows.Cacheable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
@@ -13,17 +21,8 @@ import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 import java.util.Set;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.sap.cloud.security.config.CacheConfiguration;
-import com.sap.cloud.security.xsuaa.Assertions;
-import com.github.benmanes.caffeine.cache.Ticker;
-import com.sap.cloud.security.xsuaa.client.DefaultOAuth2TokenKeyService;
-import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
-import com.sap.cloud.security.xsuaa.client.OAuth2TokenKeyService;
-import com.sap.cloud.security.xsuaa.tokenflows.Cacheable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.sap.cloud.security.xsuaa.Assertions.assertHasText;
+import static com.sap.cloud.security.xsuaa.Assertions.assertNotNull;
 
 /**
  * Decorates {@link OAuth2TokenKeyService} with a cache, which gets looked up
@@ -56,8 +55,7 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 	 * Creates a new instance and sets the cache ticker. This is used for testing.
 	 *
 	 * @param cacheTicker
-	 * 			ticker the cache uses to determine time
-	 *
+	 *            ticker the cache uses to determine time
 	 * @return the new instance.
 	 */
 	static OAuth2TokenKeyServiceWithCache getInstance(Ticker cacheTicker) {
@@ -77,7 +75,7 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 	@Deprecated
 	public OAuth2TokenKeyServiceWithCache withCacheTime(int timeInSeconds) {
 		withCacheConfiguration(TokenKeyCacheConfiguration
-				.getInstance(Duration.ofSeconds(timeInSeconds), this.cacheConfiguration.getCacheSize()));
+				.getInstance(Duration.ofSeconds(timeInSeconds), this.cacheConfiguration.getCacheSize(), false));
 		return this;
 	}
 
@@ -91,14 +89,15 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 	 */
 	@Deprecated
 	public OAuth2TokenKeyServiceWithCache withCacheSize(int size) {
-		withCacheConfiguration(TokenKeyCacheConfiguration.getInstance(cacheConfiguration.getCacheDuration(), size));
+		withCacheConfiguration(TokenKeyCacheConfiguration
+				.getInstance(cacheConfiguration.getCacheDuration(), size, false));
 		return this;
 	}
 
 	/**
 	 * Configures the token key cache. Use
-	 * {@link TokenKeyCacheConfiguration#getInstance(Duration, int)} to pass a
-	 * custom configuration.
+	 * {@link TokenKeyCacheConfiguration#getInstance(Duration, int, boolean)} to
+	 * pass a custom configuration.
 	 *
 	 * Note that the cache size must be 1000 or more and the cache duration must be
 	 * at least 600 seconds!
@@ -109,8 +108,10 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 	 */
 	public OAuth2TokenKeyServiceWithCache withCacheConfiguration(CacheConfiguration cacheConfiguration) {
 		this.cacheConfiguration = getCheckedConfiguration(cacheConfiguration);
-		LOGGER.debug("Configured token key cache with cacheDuration={} seconds and cacheSize={}",
-				getCacheConfiguration().getCacheDuration().getSeconds(), getCacheConfiguration().getCacheSize());
+		LOGGER.debug(
+				"Configured token key cache with cacheDuration={} seconds, cacheSize={} and statisticsRecording={}",
+				getCacheConfiguration().getCacheDuration().getSeconds(), getCacheConfiguration().getCacheSize(),
+				getCacheConfiguration().isCacheStatisticsEnabled());
 		return this;
 	}
 
@@ -181,7 +182,7 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 					duration.getSeconds(), currentDuration.getSeconds());
 			duration = currentDuration;
 		}
-		return TokenKeyCacheConfiguration.getInstance(duration, size);
+		return TokenKeyCacheConfiguration.getInstance(duration, size, cacheConfiguration.isCacheStatisticsEnabled());
 	}
 
 	private void retrieveTokenKeysAndFillCache(URI jwksUri)
@@ -198,11 +199,14 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 
 	private Cache<String, PublicKey> getCache() {
 		if (cache == null) {
-			cache = Caffeine.newBuilder()
+			Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder()
 					.ticker(cacheTicker)
-					.expireAfterWrite(cacheConfiguration.getCacheDuration())
-					.maximumSize(cacheConfiguration.getCacheSize())
-					.build();
+					.expireAfterWrite(getCacheConfiguration().getCacheDuration())
+					.maximumSize(getCacheConfiguration().getCacheSize());
+			if (getCacheConfiguration().isCacheStatisticsEnabled()) {
+				cacheBuilder.recordStats();
+			}
+			cache = cacheBuilder.build();
 		}
 		return cache;
 	}
@@ -225,6 +229,11 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 		if (cache != null) {
 			cache.invalidateAll();
 		}
+	}
+
+	@Override
+	public Object getCacheStatistics() {
+		return getCacheConfiguration().isCacheStatisticsEnabled() ? getCache().stats() : null;
 	}
 
 	public static String getUniqueCacheKey(JwtSignatureAlgorithm keyAlgorithm, String keyId, URI jwksUri) {

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/TokenKeyCacheConfiguration.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/TokenKeyCacheConfiguration.java
@@ -22,15 +22,15 @@ class TokenKeyCacheConfiguration implements CacheConfiguration {
 	 * Creates a new {@link TokenKeyCacheConfiguration} instance with the given
 	 * properties. See {@link CacheConfiguration#getCacheDuration()},
 	 * {@link CacheConfiguration#getCacheSize()} and
-	 * {@link CacheConfiguration#isCacheStatisticsEnabled()}
-	 * for an explanation of the respective properties.
+	 * {@link CacheConfiguration#isCacheStatisticsEnabled()} for an explanation of
+	 * the respective properties.
 	 *
 	 * @param cacheDuration
 	 *            the cache duration property.
 	 * @param cacheSize
 	 *            the cache size property.
 	 * @param cacheStatisticsEnabled
-	 * 			  set to {@code true} if cache statists should be recorded
+	 *            set to {@code true} if cache statists should be recorded
 	 * @return a new {@link TokenKeyCacheConfiguration} instance.
 	 */
 	static TokenKeyCacheConfiguration getInstance(Duration cacheDuration, int cacheSize,

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/TokenKeyCacheConfiguration.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/TokenKeyCacheConfiguration.java
@@ -12,41 +12,48 @@ import java.time.Duration;
 class TokenKeyCacheConfiguration implements CacheConfiguration {
 
 	private static final TokenKeyCacheConfiguration DEFAULT = TokenKeyCacheConfiguration
-			.getInstance(Duration.ofMinutes(10), 1000);
+			.getInstance(Duration.ofMinutes(10), 1000, false);
 
-	private Duration cacheDuration;
-	private int cacheSize;
+	private final Duration cacheDuration;
+	private final int cacheSize;
+	private final boolean cacheStatisticsEnabled;
 
 	/**
 	 * Creates a new {@link TokenKeyCacheConfiguration} instance with the given
-	 * properties. See {@link CacheConfiguration#getCacheDuration()} and
-	 * {@link CacheConfiguration#getCacheSize()} for an explanation of the
-	 * respective properties.
+	 * properties. See {@link CacheConfiguration#getCacheDuration()},
+	 * {@link CacheConfiguration#getCacheSize()} and
+	 * {@link CacheConfiguration#isCacheStatisticsEnabled()}
+	 * for an explanation of the respective properties.
 	 *
 	 * @param cacheDuration
 	 *            the cache duration property.
 	 * @param cacheSize
 	 *            the cache size property.
+	 * @param cacheStatisticsEnabled
+	 * 			  set to {@code true} if cache statists should be recorded
 	 * @return a new {@link TokenKeyCacheConfiguration} instance.
 	 */
-	static TokenKeyCacheConfiguration getInstance(Duration cacheDuration, int cacheSize) {
+	static TokenKeyCacheConfiguration getInstance(Duration cacheDuration, int cacheSize,
+			boolean cacheStatisticsEnabled) {
 		Assertions.assertNotNull(cacheDuration, "The cache duration write must not be null!");
-		return new TokenKeyCacheConfiguration(cacheDuration, cacheSize);
+		return new TokenKeyCacheConfiguration(cacheDuration, cacheSize, cacheStatisticsEnabled);
 	}
 
 	/**
 	 * The default configuration for the token key cache. The default cache size is
-	 * 1000. The default cache duration is 10 minutes.
-	 * 
+	 * 1000. The default cache duration is 10 minutes. Cache statistics are not
+	 * enabled.
+	 *
 	 * @return the default configuration
 	 */
 	static TokenKeyCacheConfiguration defaultConfiguration() {
 		return DEFAULT;
 	}
 
-	private TokenKeyCacheConfiguration(Duration cacheDuration, int cacheSize) {
+	private TokenKeyCacheConfiguration(Duration cacheDuration, int cacheSize, boolean cacheStatisticsEnabled) {
 		this.cacheDuration = cacheDuration;
 		this.cacheSize = cacheSize;
+		this.cacheStatisticsEnabled = cacheStatisticsEnabled;
 	}
 
 	@Override
@@ -58,5 +65,10 @@ class TokenKeyCacheConfiguration implements CacheConfiguration {
 	@Override
 	public int getCacheSize() {
 		return cacheSize;
+	}
+
+	@Override
+	public boolean isCacheStatisticsEnabled() {
+		return cacheStatisticsEnabled;
 	}
 }

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCacheTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCacheTest.java
@@ -1,12 +1,11 @@
 package com.sap.cloud.security.token.validation.validators;
 
-import com.github.benmanes.caffeine.cache.Ticker;
-import com.github.benmanes.caffeine.cache.stats.CacheStats;
-import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
-import com.sap.cloud.security.xsuaa.client.OAuth2TokenKeyService;
-import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.URI;
@@ -16,10 +15,13 @@ import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import com.github.benmanes.caffeine.cache.Ticker;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
+import com.sap.cloud.security.xsuaa.client.OAuth2TokenKeyService;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
 
 public class OAuth2TokenKeyServiceWithCacheTest {
 
@@ -148,7 +150,6 @@ public class OAuth2TokenKeyServiceWithCacheTest {
 
 		verify(tokenKeyServiceMock, times(2)).retrieveTokenKeys(any());
 	}
-
 
 	@Test
 	public void retrieveTokenKeysForNewEndpoint()

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCacheTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCacheTest.java
@@ -1,11 +1,12 @@
 package com.sap.cloud.security.token.validation.validators;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
+import com.github.benmanes.caffeine.cache.Ticker;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
+import com.sap.cloud.security.xsuaa.client.OAuth2TokenKeyService;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URI;
@@ -15,17 +16,15 @@ import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 
-import com.github.benmanes.caffeine.cache.Ticker;
-import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
-import com.sap.cloud.security.xsuaa.client.OAuth2TokenKeyService;
-import com.sap.cloud.security.xsuaa.tokenflows.TokenCacheConfiguration;
-import org.apache.commons.io.IOUtils;
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 public class OAuth2TokenKeyServiceWithCacheTest {
 
-	public static final TokenCacheConfiguration CACHE_CONFIGURATION = TokenCacheConfiguration.defaultConfiguration();
+	public static final TokenKeyCacheConfiguration CACHE_CONFIGURATION = TokenKeyCacheConfiguration
+			.defaultConfiguration();
 
 	OAuth2TokenKeyServiceWithCache cut;
 	OAuth2TokenKeyService tokenKeyServiceMock;
@@ -39,10 +38,7 @@ public class OAuth2TokenKeyServiceWithCacheTest {
 				.thenReturn(IOUtils.resourceToString("/jsonWebTokenKeys.json", StandardCharsets.UTF_8));
 
 		testCacheTicker = new TestCacheTicker();
-		cut = OAuth2TokenKeyServiceWithCache
-				.getInstance(testCacheTicker)
-				.withTokenKeyService(tokenKeyServiceMock)
-				.withCacheConfiguration(CACHE_CONFIGURATION);
+		cut = createCut(CACHE_CONFIGURATION);
 	}
 
 	@Test
@@ -129,6 +125,22 @@ public class OAuth2TokenKeyServiceWithCacheTest {
 	}
 
 	@Test
+	public void cacheStatistics_isDisabled_statisticsObjectIsNull() {
+		cut = createCut(TokenKeyCacheConfiguration
+				.getInstance(CACHE_CONFIGURATION.getCacheDuration(), CACHE_CONFIGURATION.getCacheSize(), false));
+
+		assertThat(cut.getCacheStatistics()).isNull();
+	}
+
+	@Test
+	public void cacheStatistics_isEnabled_returnsStatisticsObject() {
+		cut = createCut(TokenKeyCacheConfiguration
+				.getInstance(CACHE_CONFIGURATION.getCacheDuration(), CACHE_CONFIGURATION.getCacheSize(), true));
+
+		assertThat(cut.getCacheStatistics()).isInstanceOf(CacheStats.class);
+	}
+
+	@Test
 	public void retrieveTokenKeysForNewKeyId()
 			throws OAuth2ServiceException, InvalidKeySpecException, NoSuchAlgorithmException {
 		cut.getPublicKey(JwtSignatureAlgorithm.RS256, "key-id-0", TOKEN_KEYS_URI);
@@ -147,7 +159,14 @@ public class OAuth2TokenKeyServiceWithCacheTest {
 		verify(tokenKeyServiceMock, times(2)).retrieveTokenKeys(any());
 	}
 
-	private class TestCacheTicker implements  Ticker {
+	private OAuth2TokenKeyServiceWithCache createCut(TokenKeyCacheConfiguration cacheConfiguration) {
+		return OAuth2TokenKeyServiceWithCache
+				.getInstance(testCacheTicker)
+				.withTokenKeyService(tokenKeyServiceMock)
+				.withCacheConfiguration(cacheConfiguration);
+	}
+
+	private class TestCacheTicker implements Ticker {
 		long elapsed = 0;
 
 		@Override

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/AbstractOAuth2TokenService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/AbstractOAuth2TokenService.java
@@ -280,7 +280,15 @@ public abstract class AbstractOAuth2TokenService implements OAuth2TokenService, 
 		if (sameThreadCache) {
 			cacheBuilder.executor(Runnable::run);
 		}
+		if (getCacheConfiguration().isCacheStatisticsEnabled()) {
+			cacheBuilder.recordStats();
+		}
 		return cacheBuilder.build();
+	}
+
+	@Override
+	public Object getCacheStatistics() {
+		return getCacheConfiguration().isCacheStatisticsEnabled() ? responseCache.stats() : null;
 	}
 
 	private class CacheKey {

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/Cacheable.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/Cacheable.java
@@ -3,6 +3,7 @@ package com.sap.cloud.security.xsuaa.tokenflows;
 import com.sap.cloud.security.config.CacheConfiguration;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Interface for components that manage a cache configured with
@@ -22,4 +23,17 @@ public interface Cacheable {
 	 * Clears the cache of the component.
 	 */
 	void clearCache();
+
+	/**
+	 * This returns an implementation specific statistics object
+	 * if the underlying cache supports it and cache statistics have been
+	 * enabled in the {@link CacheConfiguration}.
+	 *
+	 * Use with care. The type of the statistics object might change in
+	 * later versions.
+	 *
+	 * @return the cache statistics object.
+	 */
+	@Nullable
+	Object getCacheStatistics();
 }

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/Cacheable.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/Cacheable.java
@@ -25,12 +25,12 @@ public interface Cacheable {
 	void clearCache();
 
 	/**
-	 * This returns an implementation specific statistics object
-	 * if the underlying cache supports it and cache statistics have been
-	 * enabled in the {@link CacheConfiguration}.
+	 * This returns an implementation specific statistics object if the underlying
+	 * cache supports it and cache statistics have been enabled in the
+	 * {@link CacheConfiguration}.
 	 *
-	 * Use with care. The type of the statistics object might change in
-	 * later versions.
+	 * Use with care. The type of the statistics object might change in later
+	 * versions.
 	 *
 	 * @return the cache statistics object.
 	 */

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/TokenCacheConfiguration.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/TokenCacheConfiguration.java
@@ -48,8 +48,8 @@ public class TokenCacheConfiguration implements CacheConfiguration {
 	 * properties. See {@link CacheConfiguration#getCacheDuration()},
 	 * {@link CacheConfiguration#getCacheSize()},
 	 * {@link TokenCacheConfiguration#getTokenExpirationDelta()} and
-	 * {@link CacheConfiguration#isCacheStatisticsEnabled()} for an explanation
-	 * of the respective properties.
+	 * {@link CacheConfiguration#isCacheStatisticsEnabled()} for an explanation of
+	 * the respective properties.
 	 *
 	 * @param cacheDuration
 	 *            the cache duration property.
@@ -58,11 +58,12 @@ public class TokenCacheConfiguration implements CacheConfiguration {
 	 * @param tokenExpirationDelta
 	 *            the token expiration delta.
 	 * @param cacheStatisticsEnabled
-	 * 			  {@code true} if cache statistic recording has been enabled
+	 *            {@code true} if cache statistic recording has been enabled
 	 *
 	 * @return a new {@link TokenCacheConfiguration} instance.
 	 */
-	public static TokenCacheConfiguration getInstance(Duration cacheDuration, int cacheSize, Duration tokenExpirationDelta, boolean cacheStatisticsEnabled) {
+	public static TokenCacheConfiguration getInstance(Duration cacheDuration, int cacheSize,
+			Duration tokenExpirationDelta, boolean cacheStatisticsEnabled) {
 		return new TokenCacheConfiguration(cacheDuration, cacheSize, tokenExpirationDelta, cacheStatisticsEnabled);
 	}
 
@@ -114,7 +115,6 @@ public class TokenCacheConfiguration implements CacheConfiguration {
 	public Duration getTokenExpirationDelta() {
 		return tokenExpirationDelta;
 	}
-
 
 	@Override
 	public boolean isCacheStatisticsEnabled() {

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/TokenCacheConfiguration.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/tokenflows/TokenCacheConfiguration.java
@@ -13,13 +13,14 @@ import java.util.Objects;
 public class TokenCacheConfiguration implements CacheConfiguration {
 
 	private static final TokenCacheConfiguration DEFAULT = new TokenCacheConfiguration(Duration.ofMinutes(10), 1000,
-			Duration.ofSeconds(30));
+			Duration.ofSeconds(30), false);
 
 	private static final TokenCacheConfiguration CACHE_DISABLED = new DisabledCache();
 
 	private final Duration cacheDuration;
 	private final int cacheSize;
 	private final Duration tokenExpirationDelta;
+	private final boolean cacheStatisticsEnabled;
 
 	/**
 	 * Creates a new {@link TokenCacheConfiguration} instance with the given
@@ -39,7 +40,30 @@ public class TokenCacheConfiguration implements CacheConfiguration {
 	public static TokenCacheConfiguration getInstance(@Nonnull Duration cacheDuration, int cacheSize,
 			@Nonnull Duration tokenExpirationDelta) {
 		Assertions.assertNotNull(cacheDuration, "The cache duration write must not be null!");
-		return new TokenCacheConfiguration(cacheDuration, cacheSize, tokenExpirationDelta);
+		return new TokenCacheConfiguration(cacheDuration, cacheSize, tokenExpirationDelta, false);
+	}
+
+	/**
+	 * Creates a new {@link TokenCacheConfiguration} instance with the given
+	 * properties. See {@link CacheConfiguration#getCacheDuration()},
+	 * {@link CacheConfiguration#getCacheSize()},
+	 * {@link TokenCacheConfiguration#getTokenExpirationDelta()} and
+	 * {@link CacheConfiguration#isCacheStatisticsEnabled()} for an explanation
+	 * of the respective properties.
+	 *
+	 * @param cacheDuration
+	 *            the cache duration property.
+	 * @param cacheSize
+	 *            the cache size property.
+	 * @param tokenExpirationDelta
+	 *            the token expiration delta.
+	 * @param cacheStatisticsEnabled
+	 * 			  {@code true} if cache statistic recording has been enabled
+	 *
+	 * @return a new {@link TokenCacheConfiguration} instance.
+	 */
+	public static TokenCacheConfiguration getInstance(Duration cacheDuration, int cacheSize, Duration tokenExpirationDelta, boolean cacheStatisticsEnabled) {
+		return new TokenCacheConfiguration(cacheDuration, cacheSize, tokenExpirationDelta, cacheStatisticsEnabled);
 	}
 
 	/**
@@ -56,10 +80,12 @@ public class TokenCacheConfiguration implements CacheConfiguration {
 		return DEFAULT;
 	}
 
-	private TokenCacheConfiguration(Duration cacheDuration, int cacheSize, Duration tokenExpirationDelta) {
+	private TokenCacheConfiguration(Duration cacheDuration, int cacheSize, Duration tokenExpirationDelta,
+			boolean cacheStatisticsEnabled) {
 		this.cacheDuration = cacheDuration;
 		this.cacheSize = cacheSize;
 		this.tokenExpirationDelta = tokenExpirationDelta;
+		this.cacheStatisticsEnabled = cacheStatisticsEnabled;
 	}
 
 	@Nonnull
@@ -87,6 +113,12 @@ public class TokenCacheConfiguration implements CacheConfiguration {
 	 */
 	public Duration getTokenExpirationDelta() {
 		return tokenExpirationDelta;
+	}
+
+
+	@Override
+	public boolean isCacheStatisticsEnabled() {
+		return cacheStatisticsEnabled;
 	}
 
 	@Override
@@ -117,7 +149,7 @@ public class TokenCacheConfiguration implements CacheConfiguration {
 	private static class DisabledCache extends TokenCacheConfiguration {
 
 		private DisabledCache() {
-			super(Duration.ZERO, 0, Duration.ZERO);
+			super(Duration.ZERO, 0, Duration.ZERO, false);
 		}
 
 		@Override

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/AbstractOAuth2TokenServiceTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/AbstractOAuth2TokenServiceTest.java
@@ -291,7 +291,7 @@ public class AbstractOAuth2TokenServiceTest {
 
 	private TokenCacheConfiguration cacheConfigurationWithCacheStatistics(boolean enableCacheStatistics) {
 		return TokenCacheConfiguration.getInstance(TEST_CACHE_CONFIGURATION.getCacheDuration(),
-				TEST_CACHE_CONFIGURATION.getCacheSize(),  TEST_CACHE_CONFIGURATION.getTokenExpirationDelta(),
+				TEST_CACHE_CONFIGURATION.getCacheSize(), TEST_CACHE_CONFIGURATION.getTokenExpirationDelta(),
 				enableCacheStatistics);
 	}
 

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/AbstractOAuth2TokenServiceTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/AbstractOAuth2TokenServiceTest.java
@@ -1,6 +1,7 @@
 package com.sap.cloud.security.xsuaa.client;
 
 import com.github.benmanes.caffeine.cache.Ticker;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.sap.cloud.security.xsuaa.http.HttpHeaders;
 import com.sap.cloud.security.xsuaa.tokenflows.TokenCacheConfiguration;
 import org.assertj.core.util.Maps;
@@ -216,6 +217,22 @@ public class AbstractOAuth2TokenServiceTest {
 		assertThat(cut.tokenRequestCallCount).isEqualTo(2);
 	}
 
+	@Test
+	public void cacheStatistics_isDisabled_statisticsObjectIsNull() {
+		TokenCacheConfiguration tokenCacheConfiguration = cacheConfigurationWithCacheStatistics(false);
+		cut = new TestOAuth2TokenService(tokenCacheConfiguration);
+
+		assertThat(cut.getCacheStatistics()).isNull();
+	}
+
+	@Test
+	public void cacheStatistics_isEnabled_returnsStatisticsObject() {
+		TokenCacheConfiguration tokenCacheConfiguration = cacheConfigurationWithCacheStatistics(true);
+		cut = new TestOAuth2TokenService(tokenCacheConfiguration);
+
+		assertThat(cut.getCacheStatistics()).isInstanceOf(CacheStats.class);
+	}
+
 	private OAuth2TokenResponse retrieveAccessTokenViaJwtBearerTokenGrant(String token) throws OAuth2ServiceException {
 		return retrieveAccessTokenViaJwtBearerTokenGrant(token, null);
 	}
@@ -270,6 +287,12 @@ public class AbstractOAuth2TokenServiceTest {
 	private TokenCacheConfiguration cacheConfigurationWithSize(int size) {
 		return TokenCacheConfiguration.getInstance(TEST_CACHE_CONFIGURATION.getCacheDuration(), size,
 				TEST_CACHE_CONFIGURATION.getTokenExpirationDelta());
+	}
+
+	private TokenCacheConfiguration cacheConfigurationWithCacheStatistics(boolean enableCacheStatistics) {
+		return TokenCacheConfiguration.getInstance(TEST_CACHE_CONFIGURATION.getCacheDuration(),
+				TEST_CACHE_CONFIGURATION.getCacheSize(),  TEST_CACHE_CONFIGURATION.getTokenExpirationDelta(),
+				enableCacheStatistics);
 	}
 
 	private static class TestOAuth2TokenService extends AbstractOAuth2TokenService {


### PR DESCRIPTION
This PR adds the possibility to enable cache statistics in the `CacheConfiguration`. Every `Cacheable` can return their specific cache statistic object. 
This PR is motivated by #340