### PR TITLE
Update dependencies

### DIFF
--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -16,10 +16,8 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<apache.httpclient.version>4.5.8</apache.httpclient.version>
-		<jetty.version>9.4.24.v20191120</jetty.version>
-		<javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-		<wiremock.version>2.26.0</wiremock.version>
+		<jetty.version>9.4.31.v20200723</jetty.version>
+		<wiremock.version>2.27.2</wiremock.version>
 	</properties>
 
 	<dependencies>
@@ -58,11 +56,9 @@
 			<artifactId>jetty-io</artifactId>
 			<version>${jetty.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-			<version>${javax.servlet-api.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -75,19 +71,16 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>${apache.httpclient.version}</version>
 			<scope>test</scope>
 		</dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
 		<dependency> <!-- check if it's still needed when slf4j-api 1.8 is available -->

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.source.plugin.version>3.1.0</maven.source.plugin.version>
 		<!-- make sure that spring core and spring boot versions are compatible-->
-		<spring.boot.version>2.3.1.RELEASE</spring.boot.version>
-		<spring.core.version>5.2.8.RELEASE</spring.core.version>
+		<spring.boot.version>2.3.4.RELEASE</spring.boot.version>
+		<spring.core.version>5.2.9.RELEASE</spring.core.version>
 		<spring.security.version>5.3.4.RELEASE</spring.security.version>
 		<spring.security.oauth2.version>2.5.0.RELEASE</spring.security.oauth2.version>
 		<spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>
@@ -69,7 +69,7 @@
 		<apache.httpclient.version>4.5.9</apache.httpclient.version>
 		<caffeine.version>2.8.2</caffeine.version>
 		<commons.io.version>2.6</commons.io.version>
-		<javax.servlet.api.version>3.0.1</javax.servlet.api.version>
+		<javax.servlet.api.version>3.1.0</javax.servlet.api.version>
 		<mockwebserver.version>3.9.1</mockwebserver.version>
 		<junit.version>4.12</junit.version>
 		<junit-jupiter.version>5.6.2</junit-jupiter.version>

--- a/samples/java-security-usage/pom.xml
+++ b/samples/java-security-usage/pom.xml
@@ -11,11 +11,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <sap.cloud.security.version>2.7.7</sap.cloud.security.version>
         <slf4j.api.version>1.7.30</slf4j.api.version>
-        <apache.httpclient.version>4.5.8</apache.httpclient.version>
+        <apache.httpclient.version>4.5.9</apache.httpclient.version>
         <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
-        <wiremock.version>2.25.1</wiremock.version>
         <assertj.version>3.13.2</assertj.version>
-        <jetty.version>9.4.24.v20191120</jetty.version>
+        <jetty.version>9.4.31.v20200723</jetty.version>
         <junit.version>4.12</junit.version>
     </properties>
 

--- a/samples/java-tokenclient-usage/pom.xml
+++ b/samples/java-tokenclient-usage/pom.xml
@@ -10,8 +10,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <sap.cloud.security.version>2.7.7</sap.cloud.security.version>
-        <apache.httpclient.version>4.5.8</apache.httpclient.version>
-        <javax.servlet.api.version>3.0.1</javax.servlet.api.version>
+        <apache.httpclient.version>4.5.9</apache.httpclient.version>
+        <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
     </properties>
 
     <dependencies>

--- a/samples/sap-java-buildpack-api-usage/pom.xml
+++ b/samples/sap-java-buildpack-api-usage/pom.xml
@@ -9,8 +9,8 @@
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<sap.cloud.security.version>2.7.3</sap.cloud.security.version>
-		<javax.servlet.api.version>3.0.1</javax.servlet.api.version>
+		<sap.cloud.security.version>2.7.7</sap.cloud.security.version>
+		<javax.servlet.api.version>3.1.0</javax.servlet.api.version>
 	</properties>
 
 	<dependencies>

--- a/samples/spring-security-basic-auth/pom.xml
+++ b/samples/spring-security-basic-auth/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.0.RELEASE</version>
+		<version>2.3.4.RELEASE</version>
 		<relativePath/>
 	</parent>
 

--- a/samples/spring-security-xsuaa-usage/pom.xml
+++ b/samples/spring-security-xsuaa-usage/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.3.0.RELEASE</version>
+		<version>2.3.4.RELEASE</version>
 		<relativePath/>
 	</parent>
 

--- a/samples/spring-webflux-security-xsuaa-usage/pom.xml
+++ b/samples/spring-webflux-security-xsuaa-usage/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.0.RELEASE</version>
+        <version>2.3.4.RELEASE</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
The following dependencies were updated:

- Spring Boot 2.3.1.RELEASE --> 2.3.4.RELEASE
- Spring Core 5.2.8.RELEASE --> 5.2.9.RELEASE
- Jetty 9.4.24.v20191120 --> 9.4.31.v20200723
- javax.servlet-api.version 3.0.1 --> 3.1.0
- Apache HTTP client 4.5.8 --> 4.5.9
- Wiremock 2.25.1 --> 2.27.2

Integration Test Script ran successfully!
After this has been merged, #350 can be closed.
