### PR TITLE
Simplifications of XsuaaAudienceValidator

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidator.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidator.java
@@ -22,8 +22,8 @@ import com.sap.cloud.security.xsuaa.XsuaaServicesParser;
 import com.sap.cloud.security.xsuaa.token.TokenClaims;
 
 /**
- * Validate audience using audience field content. in case this field is empty,
- * the audience is derived from the scope field
+ * Validate audience using audience field content. In case this field is empty,
+ * the audience is derived from the scope field.
  */
 public class XsuaaAudienceValidator implements OAuth2TokenValidator<Jwt> {
 	private Map<String, String> appIdClientIdMap = new HashMap<>();
@@ -73,11 +73,11 @@ public class XsuaaAudienceValidator implements OAuth2TokenValidator<Jwt> {
 	}
 
 	/**
-	 * Retrieve audiences from token. In case the audience list is empty, take
+	 * Retrieve audiences from token. In case the audience list is empty, takes
 	 * audiences based on the scope names.
 	 *
 	 * @param token
-	 * @return (empty) list of audiences
+	 * @return (empty) set of audiences
 	 */
 	static Set<String> getAllowedAudiences(Jwt token) {
 		final Set<String> allAudiences = new HashSet<>();

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidator.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidator.java
@@ -56,7 +56,7 @@ public class XsuaaAudienceValidator implements OAuth2TokenValidator<Jwt> {
 				return OAuth2TokenValidatorResult.success();
 			}
 		}
-		
+
 		final String description = String.format("Jwt token with allowed audiences %s matches none of these: %s",
 				allowedAudiences, appIdClientIdMap.keySet().toString());
 		return OAuth2TokenValidatorResult.failure(new OAuth2Error(OAuth2ErrorCodes.INVALID_CLIENT, description, null));
@@ -99,9 +99,9 @@ public class XsuaaAudienceValidator implements OAuth2TokenValidator<Jwt> {
 				}
 			}
 		}
-		
+
 		allAudiences.remove("");
-		
+
 		return allAudiences;
 	}
 

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidatorTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaAudienceValidatorTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -67,8 +68,7 @@ public class XsuaaAudienceValidatorTest {
 	public void testExtractAudiencesFromTokenScopes() {
 		Jwt token = new JwtGenerator()
 				.addScopes("test1!t1.read", "test2!t1.read", "test2!t1.write", ".scopeWithoutAppId").getToken();
-		List<String> audiences = new XsuaaAudienceValidator(serviceConfigurationSameClientId)
-				.getAllowedAudiences(token);
+		Set<String> audiences = XsuaaAudienceValidator.getAllowedAudiences(token);
 		Assert.assertThat(audiences.size(), is(2));
 		Assert.assertThat(audiences, hasItem("test1!t1"));
 		Assert.assertThat(audiences, hasItem("test2!t1"));


### PR DESCRIPTION
Recently, I had to debug through `XsuaaAudienceValidator` and I felt that it was partially hard to read. In method `getAllowedAudiences` I had the impression that you have a hard time handling things using Java Lists, but in fact do not want to use the property of ordering at all. Instead, you are busy fixing things afterwards using Java Streams.

Therefore, I'd like to propose this PR making things simpler to read without losing any kind of functionality or quality. The general idea is to not make use of Lists, but to use a (Hash)Set instead. This also sightly will have advantages in terms of performance (in case JWTs do get larger).

Feel free to merge; I do not claim any ownership of my changes, but only want to make things better...