### PR TITLE
Add junit-bom to dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,6 @@
 		<javax.servlet.api.version>3.1.0</javax.servlet.api.version>
 		<mockwebserver.version>3.9.1</mockwebserver.version>
 		<junit.version>4.13.1</junit.version>
-		<!-- make sure junit-platform and junit-jupiter versions are compatible -->
-		<junit-platform.version>1.7.0</junit-platform.version>
 		<junit-jupiter.version>5.7.0</junit-jupiter.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<mockito.version>2.23.0</mockito.version>
@@ -267,29 +265,10 @@
 				<version>${junit.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter-api</artifactId>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
 				<version>${junit-jupiter.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter-engine</artifactId>
-				<version>${junit-jupiter.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.vintage</groupId>
-				<artifactId>junit-vintage-engine</artifactId>
-				<version>${junit-jupiter.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.jupiter</groupId>
-				<artifactId>junit-jupiter-params</artifactId>
-				<version>${junit-jupiter.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.junit.platform</groupId>
-				<artifactId>junit-platform-commons</artifactId>
-				<version>${junit-platform.version}</version>
+				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,8 @@
 		<javax.servlet.api.version>3.1.0</javax.servlet.api.version>
 		<mockwebserver.version>3.9.1</mockwebserver.version>
 		<junit.version>4.13.1</junit.version>
+		<!-- make sure junit-platform and junit-jupiter versions are compatible -->
+		<junit-platform.version>1.7.0</junit-platform.version>
 		<junit-jupiter.version>5.7.0</junit-jupiter.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<mockito.version>2.23.0</mockito.version>
@@ -283,6 +285,11 @@
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-params</artifactId>
 				<version>${junit-jupiter.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.junit.platform</groupId>
+				<artifactId>junit-platform-commons</artifactId>
+				<version>${junit-platform.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Adding the junit-platform-commons to the dependency management ensures that this specified version will be used. Without explicitly setting the version, third party dependencies might bring junit-platform-commons in an older version. This causes problem when this older version is not compatible with junit-jupiter used in this project.

With this change the performance tests can be run again from java-security-it via `mvn failsafe:integration-test`

**EDIT: I now use the junit 5 bom, see newest [comment](https://github.com/SAP/cloud-security-xsuaa-integration/pull/392#issuecomment-708341269)**