### PR TITLE
Fix javax.servlet-api dependency scope

### DIFF
--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
-			<version>${javax.servlet.api.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- test utilities -->

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -26,6 +26,11 @@
 			<artifactId>commons-io</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
 		<!-- for call to tokenKeyService -->
 		<dependency>


### PR DESCRIPTION
`javax.servlet-api` dependency should always use `provided` scope, as those classes are provided by the Servlet container like Tomcat.

Also add the same dependency on `java-security` as `provided` dependencies are not transitive.

Fixes #427.