### PR TITLE
Ignore sb- prefix when checking audience

### DIFF
--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtAudienceValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtAudienceValidator.java
@@ -25,6 +25,7 @@ import java.util.*;
 public class JwtAudienceValidator implements Validator<Token> {
 	private static final Logger logger = LoggerFactory.getLogger(JwtAudienceValidator.class);
 	private static final char DOT = '.';
+	private static final String CID_PREFIX = "sb-";
 
 	private final Set<String> trustedClientIds = new LinkedHashSet<>();
 
@@ -35,6 +36,11 @@ public class JwtAudienceValidator implements Validator<Token> {
 	JwtAudienceValidator configureTrustedClientId(String clientId) {
 		assertHasText(clientId, "JwtAudienceValidator requires a clientId.");
 		trustedClientIds.add(clientId);
+
+		if (clientId.startsWith(CID_PREFIX)) {
+			trustedClientIds.add(clientId.replaceFirst(CID_PREFIX, ""));
+		}
+
 		logger.info("configured JwtAudienceValidator with clientId {}.", clientId);
 
 		return this;

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JwtAudienceValidatorTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JwtAudienceValidatorTest.java
@@ -43,7 +43,6 @@ public class JwtAudienceValidatorTest {
 		Mockito.when(token.getAudiences()).thenReturn(
 				Sets.newLinkedHashSet("appId!t1"));
 		ValidationResult result = new JwtAudienceValidator("sb-appId!t1")
-				.configureTrustedClientId("appId!t1")
 				.validate(token);
 		assertThat(result.isValid()).isTrue();
 	}
@@ -90,7 +89,6 @@ public class JwtAudienceValidatorTest {
 
 		// configures audience validator with client-id from VCAP_SERVICES
 		ValidationResult result = new JwtAudienceValidator("sb-" + XSUAA_BROKER_XSAPPNAME)
-				.configureTrustedClientId(XSUAA_BROKER_XSAPPNAME)
 				.validate(token);
 
 		assertThat(result.isValid()).isTrue(); // should match
@@ -129,7 +127,6 @@ public class JwtAudienceValidatorTest {
 
 		// configures audience validator with client-id from VCAP_SERVICES
 		ValidationResult result = new JwtAudienceValidator("sb-ANOTHERAPP!b12")
-				.configureTrustedClientId("ANOTHERAPP!b12")
 				.validate(token);
 
 		assertThat(result.isValid()).isTrue(); // should match


### PR DESCRIPTION
Currently `sb-` isn't ignored when validating audiences from the token. By looking at the existing unit tests, additional CIDs that doesn't have `sb-` are added to the trusted client ID list, but this behaviour is more intuitive if it's done in `JwtAudienceValidator`.