### PR TITLE
exclude nimbus library to resolve security vulnerability

### DIFF
--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -23,6 +23,12 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-jose</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>net.minidev</groupId>
+					<artifactId>json-smart</artifactId>
+				</exclusion>
+			</exclusions>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
nimbus is not required as dependency in spring-xsuaa as all usage have been replaced with org.json, therefore excluding it.