### PR TITLE
XsuaaJwtDecoder raises BadJwtException instead of JwtException

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
@@ -74,14 +74,20 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 	}
 
 	@Override
-	public Jwt decode(String token) throws JwtException {
+	/**
+	 * @throws BadJwtException as of version 2.9.1 (instead of JwtException)
+	 * @see https://github.com/spring-projects/spring-security/issues/9395
+	 * @see https://github.com/spring-projects/spring-security/commit/0c3754c
+	 *
+	 */
+	public Jwt decode(String token) throws BadJwtException {
 		Assert.notNull(token, "token is required");
 		JWT jwt;
 
 		try {
 			jwt = JWTParser.parse(token);
 		} catch (ParseException ex) {
-			throw new JwtException("Error initializing JWT decoder: " + ex.getMessage());
+			throw new BadJwtException("Error initializing JWT decoder: " + ex.getMessage());
 		}
 		final Jwt verifiedToken = verifyToken(jwt);
 		postValidationActions.forEach(action -> action.perform(verifiedToken));
@@ -111,13 +117,11 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 		try {
 			canVerifyWithKey(jku, kid, uaaDomain);
 			validateJku(jku, uaaDomain);
-			Jwt verifiedToken = verifyWithKey(token, jku, kid);
-
-			return verifiedToken;
+			return verifyWithKey(token, jku, kid);
 		} catch (JwtValidationException ex) {
 			throw ex;
 		} catch (JwtException ex) {
-			throw new JwtException("JWT verification failed: " + ex.getMessage());
+			throw new BadJwtException("JWT verification failed: " + ex.getMessage());
 		}
 	}
 
@@ -133,7 +137,7 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 		if (uaadomain == null)
 			nullParams.add("uaadomain");
 
-		throw new JwtException(String.format("Cannot verify with online token key, %s is null",
+		throw new BadJwtException(String.format("Cannot verify with online token key, %s is null",
 				String.join(", ", nullParams)));
 	}
 
@@ -141,18 +145,18 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 		try {
 			URI jkuUri = new URI(jku);
 			if (jkuUri.getHost() == null) {
-				throw new JwtException("JKU of token is not valid");
+				throw new BadJwtException("JKU of token is not valid");
 			} else if (!jkuUri.getHost().endsWith(uaadomain)) {
 				logger.warn("Error: Do not trust jku '{}' because it does not match uaa domain '{}'.",
 						jku, uaadomain);
-				throw new JwtException("Do not trust 'jku' token header.");
+				throw new BadJwtException("Do not trust 'jku' token header.");
 			} else if (!jkuUri.getPath().endsWith("token_keys") || hasText(jkuUri.getQuery())
 					|| hasText(jkuUri.getFragment())) {
 				logger.warn("Error: Do not trust jku '{}' because it contains invalid path, query or fragment.", jku);
-				throw new JwtException("Jwt token does not contain a valid 'jku' header parameter: " + jkuUri);
+				throw new BadJwtException("Jwt token does not contain a valid 'jku' header parameter: " + jkuUri);
 			}
 		} catch (URISyntaxException e) {
-			throw new JwtException("JKU of token header is not valid");
+			throw new BadJwtException("JKU of token header is not valid");
 		}
 	}
 
@@ -188,7 +192,7 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 			decoder.setJwtValidator(tokenValidators);
 			return decoder.decode(token);
 		} catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-			throw new JwtException(e.getMessage());
+			throw new BadJwtException(e.getMessage());
 		}
 	}
 


### PR DESCRIPTION
As of org.springframework.security version 5.5.0 AuthenticationServiceException gets no longer handled and does not result into 401 status code. 

But BadJwtException results into InvalidBearerTokenException which then gets mapped to 401 status code as expected.

Further References
- https://github.com/spring-projects/spring-security/issues/9395
- https://github.com/spring-projects/spring-security/commit/0c3754c81133afd33bfdac28569473d8ac2cdaff#diff-eff4fee1a4b87fa8efaa934f4d2383df1c50192c36870d6b51db3bd7ff37d35e