### PR TITLE
Added Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-<!-- Please read carefully [Report an Issue](#report-an-issue) section before creating an Issue. -->
+<!-- Please read carefully https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/CONTRIBUTING.md#report-an-issue section before creating an Issue. -->
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -26,7 +26,9 @@ If applicable, add screenshots to help explain your problem.
 **Additional context**
 Add any other context about the problem here.
 
-### Issue Report Checklist
+<!-- Please make sure checklist is complete -->
+
+**Issue Report Checklist**
 
 - [ ] Real, current bug
 - [ ] Not a duplicate  

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Please read carefully [Report an Issue](#report-an-issue) section before creating an Issue.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1.  '...'
+2.  '...'
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.
+
+### Issue Report Checklist
+
+- [ ] Real, current bug
+- [ ] Not a duplicate  
+- [ ] Not covered in "Common Pitfalls" section of corresponding module's README.md e.g. [java-security#common-pitfalls](https://github.com/SAP/cloud-security-xsuaa-integration/tree/master/java-security#common-pitfalls)
+- [ ] Reproducible
+- [ ] Good summary
+- [ ] Well-documented 
+    - [ ] log level increased to `DEBUG` debug logs provided
+    - [ ] POM provided
+    - [ ] dependency tree provided
+    - [ ] code snippet provided

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Please read carefully [Report an Issue](#report-an-issue) section before creating an Issue.
+<!-- Please read carefully [Report an Issue](#report-an-issue) section before creating an Issue. -->
 
 **Describe the bug**
 A clear and concise description of what the bug is.


### PR DESCRIPTION
This PR will add an issue template. 
With issue templates we can customize and standardize the information you'd like contributors to include when they open issues in this repository. Please see this for more [info](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates).

This feature will help to reduce communication overhead & save time and effort.


To configure issue templates for your repository please see [this](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).
See a preview [here](https://github.com/rahuldeepattri/cloud-security-xsuaa-integration/issues/new?assignees=&labels=&template=bug_report.md&title=).