### PR TITLE
Reduce log message severity

### DIFF
--- a/java-security/src/main/java/com/sap/cloud/security/servlet/HybridTokenFactory.java
+++ b/java-security/src/main/java/com/sap/cloud/security/servlet/HybridTokenFactory.java
@@ -76,7 +76,7 @@ public class HybridTokenFactory implements TokenFactory {
 		if (xsAppId == null) {
 			OAuth2ServiceConfiguration serviceConfiguration = Environments.getCurrent().getXsuaaConfiguration();
 			if (serviceConfiguration == null) {
-				LOGGER.error("There is no xsuaa service configuration: no local scope check possible.");
+				LOGGER.warn("There is no xsuaa service configuration: no local scope check possible.");
 			} else {
 				xsAppId = serviceConfiguration.getProperty(CFConstants.XSUAA.APP_ID);
 			}


### PR DESCRIPTION
In our k8s environment the xsuaa service configs can't be automatically derived (even #607 will not change this for now). However, an internal audit-logging library uses this class, which leads to error messages being logged.

I am hoping one can reduce the severity of the log message to `warning` as it is able to continue with some limitations.
What do you think?