### PR TITLE
XsuaaServiceConfigurationDefault supports access to other VCAP_SERVICES credentials properties

### DIFF
--- a/java-security/README.md
+++ b/java-security/README.md
@@ -89,7 +89,7 @@ OAuth2ServiceConfiguration serviceConfig = OAuth2ServiceConfigurationBuilder.for
       .withClientSecret("oauth-client-secret")
       .build();
 ```
-:bulb: `OAuth2ServiceConfiguration.getClientIdentity()` is a convenience method that with `OAuth2ServiceConfigurationBuilder` implementation will resolve `ClientCredential` or `ClientCertificate` implementations of `ClientIdentity` interface based on the `credential-type` from the Xsuaa service binding. Therefore, providing the correct implementation for the configured authentication type e.g. X.509 or client secret based
+:bulb: `OAuth2ServiceConfiguration.getClientIdentity()` is a convenience method that with `OAuth2ServiceConfigurationBuilder` implementation will resolve `ClientCredentials` or `ClientCertificate` implementations of `ClientIdentity` interface based on the `credential-type` from the Xsuaa service binding. Therefore, providing the correct implementation for the configured authentication type e.g. X.509 or client secret based.
 
 ### Setup Step 2: Setup Validators
 Now configure the `JwtValidatorBuilder` once with the service configuration from the previous step.

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationDefault.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationDefault.java
@@ -12,7 +12,9 @@ import com.sap.cloud.security.config.CredentialType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
+import java.io.IOException;
 import java.net.URI;
+import java.util.Properties;
 
 @Configuration
 public class XsuaaServiceConfigurationDefault implements XsuaaServiceConfiguration {
@@ -28,9 +30,6 @@ public class XsuaaServiceConfigurationDefault implements XsuaaServiceConfigurati
 
 	@Value("${xsuaa.uaadomain:#{null}}")
 	private String uaadomain;
-
-	@Value("${xsuaa.identityzoneid:}")
-	private String identityZoneId;
 
 	@Value("${xsuaa.xsappname:}")
 	private String appid;
@@ -49,6 +48,8 @@ public class XsuaaServiceConfigurationDefault implements XsuaaServiceConfigurati
 
 	@Value("${xsuaa.certurl:#{null}}")
 	private String certUrl;
+
+	private Properties vcapServiceProperties;
 
 	/*
 	 * (non-Javadoc)
@@ -101,5 +102,26 @@ public class XsuaaServiceConfigurationDefault implements XsuaaServiceConfigurati
 	@Override
 	public URI getCertUrl() {
 		return URI.create(certUrl);
+	}
+
+	private Properties getVcapServiceProperties() {
+		if(vcapServiceProperties == null) {
+			try {
+				vcapServiceProperties = new XsuaaServicesParser().parseCredentials();
+			} catch (IOException e) {
+				vcapServiceProperties = new Properties();
+			}
+		}
+		return vcapServiceProperties;
+	}
+
+	@Override
+	public String getProperty(String name) {
+		return getVcapServiceProperties().getProperty(name);
+	}
+
+	@Override
+	public boolean hasProperty(String name) {
+		return getVcapServiceProperties().containsKey(name);
 	}
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServicePropertySourceFactory.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServicePropertySourceFactory.java
@@ -46,7 +46,7 @@ public class XsuaaServicePropertySourceFactory implements PropertySourceFactory 
 	public static final String UAA_DOMAIN = "xsuaa.uaadomain";
 
 	private static final List<String> XSUAA_ATTRIBUTES = Arrays
-			.asList("clientid", "clientsecret", "identityzoneid",
+			.asList("clientid", "clientsecret",
 					"sburl", "tenantid", "tenantmode", "uaadomain", "url", "verificationkey", "xsappname",
 					"certificate",
 					"key", "credential-type", "certurl");

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/XsuaaServicesParserTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/XsuaaServicesParserTest.java
@@ -39,4 +39,15 @@ public class XsuaaServicesParserTest {
 		Properties properties = cut.parseCredentials();
 		assertThat(properties.getProperty("clientid")).isEqualTo("client-id");
 	}
+
+	@Test
+	public void acceptOtherVcapServicesProperties() throws IOException {
+		String vcapWithAddProperties = "{\"xsuaa\":[{\"credentials\":{\"apiurl\":\"https://api.mydomain.com\",\"tenantid\":\"tenant-id\",\"clientid\":\"client-id\"},\"tags\":[\"xsuaa\"]}]}";
+		XsuaaServicesParser cut = new XsuaaServicesParser(vcapWithAddProperties);
+		Properties properties = cut.parseCredentials();
+		assertThat(properties.getProperty("apiurl")).isEqualTo("https://api.mydomain.com");
+		assertThat(properties.containsKey("apiurl")).isTrue();
+		assertThat(properties.getProperty("tenantid")).isEqualTo("tenant-id");
+		assertThat(properties.getProperty("clientid")).isEqualTo("client-id");
+	}
 }


### PR DESCRIPTION
- cleanup "identityzoneid" as it was never exposed
- `XsuaaServiceConfigurationDefault.hasProperty("apiurl")` returns true if VCAP_SERVICES-xsuaa-credentials contains attribute "apiurl"
- `XsuaaServiceConfigurationDefault.getProperty("apiurl")` returns value from VCAP_SERVICES-xsuaa-credentials-apiurl or null, if attribute does not exist.

closes #601 