### PR TITLE
SECAUTH-1483

### DIFF
--- a/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/XsuaaTokenAuthorizationConverter.java
+++ b/spring-security/src/main/java/com/sap/cloud/security/spring/token/authentication/XsuaaTokenAuthorizationConverter.java
@@ -41,14 +41,18 @@ public class XsuaaTokenAuthorizationConverter implements Converter<Jwt, Abstract
 	}
 
 	protected Collection<GrantedAuthority> localScopeAuthorities(Jwt jwt) {
-		Collection<GrantedAuthority> localScopeAuthorities = new ArrayList<>();
 		Collection<String> scopes = jwt.getClaimAsStringList(TokenClaims.XSUAA.SCOPES);
 		if (scopes == null) {
 			return Collections.emptySet();
 		}
+		return localScopeAuthorities(jwt, scopes);
+	}
+
+	protected Collection<GrantedAuthority> localScopeAuthorities(Jwt jwt, Collection<String> scopes) {
+		Collection<GrantedAuthority> localScopeAuthorities = new ArrayList<>();
 		for (String scope : scopes) {
 			if (scope.startsWith(appId + ".")) {
-				localScopeAuthorities.add(new SimpleGrantedAuthority(scope.replaceFirst(appId + ".", "")));
+				localScopeAuthorities.add(new SimpleGrantedAuthority(scope.substring(appId.length() + 1)));
 			}
 		}
 		return localScopeAuthorities;

--- a/spring-security/src/test/java/com/sap/cloud/security/spring/token/authentication/XsuaaTokenAuthorizationConverterTest.java
+++ b/spring-security/src/test/java/com/sap/cloud/security/spring/token/authentication/XsuaaTokenAuthorizationConverterTest.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 import static com.sap.cloud.security.config.Service.XSUAA;
 import static org.junit.jupiter.api.Assertions.*;
 
-class XsuaaTokenAuthenticationConverterTest {
+class XsuaaTokenAuthorizationConverterTest {
 	String xsAppName = "my-app-name!400";
 	JwtGenerator jwtGenerator = JwtGenerator.getInstance(XSUAA, "theClientId").withAppId(xsAppName);
 	XsuaaTokenAuthorizationConverter cut = new XsuaaTokenAuthorizationConverter(xsAppName);

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/extractor/LocalAuthoritiesExtractor.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/extractor/LocalAuthoritiesExtractor.java
@@ -43,7 +43,7 @@ public class LocalAuthoritiesExtractor implements AuthoritiesExtractor {
 		}
 		return scopes.stream()
 				.filter(scope -> scope.startsWith(appId + "."))
-				.map(scope -> scope.replaceFirst(appId + ".", ""))
+				.map(scope -> scope.substring(appId.length() + 1))
 				.collect(Collectors.toSet());
 	}
 

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/TokenAuthenticationConverterTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/TokenAuthenticationConverterTest.java
@@ -109,12 +109,13 @@ public class TokenAuthenticationConverterTest {
 
 	@Test
 	public void checkFollowingInstanceScope() {
-		String scopeWithClientId =  "7cf2e319-3a7d-4f99-8207-afdc8e8e6d64!b123|trustedclientid!b333.API_OVERVIEW";
+		String scopeWithClientId = "7cf2e319-3a7d-4f99-8207-afdc8e8e6d64!b123|trustedclientid!b333.API_OVERVIEW";
 
 		Jwt jwt = new JwtGenerator("sb-7cf2e319-3a7d-4f99-8207-afdc8e8e6d64!b123|trustedclientid!b333")
 				.addScopes(xsAppName + "." + scopeAdmin, scopeRead, scopeWithClientId)
 				.getToken();
-		TokenAuthenticationConverter converter = new TokenAuthenticationConverter(new MyFollowingInstanceAuthoritiesExtractor());
+		TokenAuthenticationConverter converter = new TokenAuthenticationConverter(
+				new MyFollowingInstanceAuthoritiesExtractor());
 
 		assertThat(converter.convert(jwt).getAuthorities().size(), is(1));
 		assertThat(converter.convert(jwt).getAuthorities(), hasItem(new SimpleGrantedAuthority("API_OVERVIEW")));
@@ -162,7 +163,7 @@ public class TokenAuthenticationConverterTest {
 		@Override
 		public Collection<GrantedAuthority> getAuthorities(XsuaaToken token) {
 			String appId = "";
-			if(token.getClientId().startsWith("sb-")) {
+			if (token.getClientId().startsWith("sb-")) {
 				appId = token.getClientId().replaceFirst("sb-", "");
 			}
 			AuthoritiesExtractor authoritiesExtractor = new LocalAuthoritiesExtractor(appId);

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/TokenAuthenticationConverterTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/TokenAuthenticationConverterTest.java
@@ -109,9 +109,9 @@ public class TokenAuthenticationConverterTest {
 
 	@Test
 	public void checkFollowingInstanceScope() {
-		String scopeWithClientId =  "7cf2e319-3a7d-4f99-8207-afdc8e8e6d64!b34404|control-controllibsystemtest!b4702.API_OVERVIEW";
+		String scopeWithClientId =  "7cf2e319-3a7d-4f99-8207-afdc8e8e6d64!b123|trustedclientid!b333.API_OVERVIEW";
 
-		Jwt jwt = new JwtGenerator("sb-7cf2e319-3a7d-4f99-8207-afdc8e8e6d64!b34404|control-controllibsystemtest!b4702")
+		Jwt jwt = new JwtGenerator("sb-7cf2e319-3a7d-4f99-8207-afdc8e8e6d64!b123|trustedclientid!b333")
 				.addScopes(xsAppName + "." + scopeAdmin, scopeRead, scopeWithClientId)
 				.getToken();
 		TokenAuthenticationConverter converter = new TokenAuthenticationConverter(new MyFollowingInstanceAuthoritiesExtractor());


### PR DESCRIPTION
### In `spring-xsuaa` 
**Before**
```java
Converter<Jwt, AbstractAuthenticationToken> getJwtAuthenticationConverter() {
		TokenAuthenticationConverter converter = new TokenAuthenticationConverter(xsuaaServiceConfiguration);
		converter.setLocalScopeAsAuthorities(true);
		return converter;
}
```
**New**
```java
Converter<Jwt, AbstractAuthenticationToken> getJwtAuthenticationConverter() {
          return new TokenAuthenticationConverter(new MyCustomAuthoritiesExtractor());
}

private static class MyCustomAuthoritiesExtractor implements AuthoritiesExtractor {

		@Override
		public Collection<GrantedAuthority> getAuthorities(XsuaaToken token) {
			String appId = "";
			if(token.getClientId().startsWith("sb-")) {
				appId = token.getClientId().replaceFirst("sb-", "");
			}
			AuthoritiesExtractor authoritiesExtractor = new LocalAuthoritiesExtractor(appId);
			return authoritiesExtractor.getAuthorities(token);
		}

	}
```
### In `spring-security` 
You can subclass `XsuaaTokenAuthorizationConverter` and overwrite `localScopeAuthorities(Jwt jwt, Collection<String> scopes)`. An example is not yet available.
