### PR TITLE
fix Internal Server error caused by getClientIdentity method 

### DIFF
--- a/env/src/test/java/com/sap/cloud/security/config/OAuth2ServiceConfigurationBuilderTest.java
+++ b/env/src/test/java/com/sap/cloud/security/config/OAuth2ServiceConfigurationBuilderTest.java
@@ -60,8 +60,10 @@ public class OAuth2ServiceConfigurationBuilderTest {
 	public void withCertificateAndKey() {
 		String certificate = "-----BEGIN CERTIFICATE-----";
 		String key = "-----BEGIN RSA PRIVATE KEY-----";
+		String clientId = "myClientId";
 
-		OAuth2ServiceConfiguration configuration = cut.withPrivateKey(key).withCertificate(certificate).build();
+		OAuth2ServiceConfiguration configuration = cut.withPrivateKey(key).withCertificate(certificate)
+				.withClientId(clientId).build();
 
 		assertThat(configuration.getClientIdentity().getKey()).isEqualTo(key);
 		assertThat(configuration.getClientIdentity().getCertificate()).isEqualTo(certificate);

--- a/java-api/src/main/java/com/sap/cloud/security/config/OAuth2ServiceConfiguration.java
+++ b/java-api/src/main/java/com/sap/cloud/security/config/OAuth2ServiceConfiguration.java
@@ -42,9 +42,9 @@ public interface OAuth2ServiceConfiguration {
 	 * @return ClientIdentity object
 	 */
 	default ClientIdentity getClientIdentity() {
-		ClientIdentity identity = new ClientCredentials(getClientId(), getClientSecret());
+		ClientIdentity identity = new ClientCertificate(getProperty(CERTIFICATE), getProperty(KEY), getClientId());
 		if (!identity.isValid()) {
-			identity = new ClientCertificate(getProperty(CERTIFICATE), getProperty(KEY), getClientId());
+			identity = new ClientCredentials(getClientId(), getClientSecret());
 		}
 		return identity;
 	}

--- a/spring-security/src/test/java/com/sap/cloud/security/spring/config/OAuth2ServiceConfigurationPropertiesTest.java
+++ b/spring-security/src/test/java/com/sap/cloud/security/spring/config/OAuth2ServiceConfigurationPropertiesTest.java
@@ -46,9 +46,12 @@ class OAuth2ServiceConfigurationPropertiesTest {
 	}
 
 	@Test
-	void setGetCertificateAndKey() {
+	void setGetCertificateAndKeyIAS() {
 		cutIas.setKey(ANY_VALUE);
 		cutIas.setCertificate(ANY_VALUE);
+		cutIas.setClientId(ANY_VALUE);
+		cutIas.setClientSecret(ANY_VALUE); // to make sure that getClientIdentity uses ClientCertificate impl as default
+											// when possible
 		assertEquals(ANY_VALUE, cutIas.getClientIdentity().getKey());
 		assertEquals(ANY_VALUE, cutIas.getClientIdentity().getCertificate());
 		assertTrue(cutIas.getClientIdentity().isCertificateBased());
@@ -59,7 +62,37 @@ class OAuth2ServiceConfigurationPropertiesTest {
 	}
 
 	@Test
+	void setGetCertificateAndKeyXSUAA() {
+		cutXsuaa.setCertificate(ANY_VALUE);
+		cutXsuaa.setKey(ANY_VALUE);
+		cutXsuaa.setClientId(ANY_VALUE);
+		cutXsuaa.setClientSecret(ANY_VALUE); // to make sure that getClientIdentity uses ClientCertificate impl as
+												// default when possible
+		assertEquals(ANY_VALUE, cutXsuaa.getClientIdentity().getCertificate());
+		assertEquals(ANY_VALUE, cutXsuaa.getClientIdentity().getKey());
+		assertTrue(cutXsuaa.hasProperty(CERTIFICATE));
+		assertEquals(ANY_VALUE, cutXsuaa.getProperty(CERTIFICATE));
+		assertTrue(cutXsuaa.hasProperty(KEY));
+		assertEquals(ANY_VALUE, cutXsuaa.getProperty(KEY));
+		assertTrue(cutXsuaa.getClientIdentity().isCertificateBased());
+	}
+
+	@Test
+	void getClientIdentityResolvesToClientCredentials() {
+		cutIas.setClientId(ANY_VALUE);
+		cutIas.setClientSecret(ANY_VALUE);
+		assertFalse(cutIas.getClientIdentity().isCertificateBased());
+
+		cutXsuaa.setClientId(ANY_VALUE);
+		cutXsuaa.setClientSecret(ANY_VALUE);
+		assertFalse(cutXsuaa.getClientIdentity().isCertificateBased());
+	}
+
+	@Test
 	void setGetCredentialType() {
+		cutXsuaa.setCertificate(ANY_VALUE);
+		cutXsuaa.setKey(ANY_VALUE);
+		cutXsuaa.setClientId(ANY_VALUE);
 		cutXsuaa.setCredentialType("x509");
 		assertEquals(CredentialType.X509, cutXsuaa.getCredentialType());
 		assertTrue(cutXsuaa.hasProperty(XSUAA.CREDENTIAL_TYPE));
@@ -69,6 +102,7 @@ class OAuth2ServiceConfigurationPropertiesTest {
 		assertFalse(cutIas.getClientIdentity().isCertificateBased());
 		cutIas.setCertificate(ANY_VALUE);
 		cutIas.setKey(ANY_VALUE);
+		cutIas.setClientId(ANY_VALUE);
 		assertTrue(cutIas.getClientIdentity().isCertificateBased());
 		assertEquals(CredentialType.X509, cutIas.getCredentialType());
 	}

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/XsuaaServiceConfigurationDummy.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/XsuaaServiceConfigurationDummy.java
@@ -46,4 +46,9 @@ public class XsuaaServiceConfigurationDummy implements XsuaaServiceConfiguration
 		return verificationKey;
 	}
 
+	@Override
+	public String getProperty(String name) {
+		return null;
+	}
+
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationCustom.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationCustom.java
@@ -70,9 +70,10 @@ public class XsuaaServiceConfigurationCustom implements XsuaaServiceConfiguratio
 
 	@Override
 	public ClientIdentity getClientIdentity() {
-		ClientIdentity identity = new ClientCredentials(getClientId(), getClientSecret());
+		ClientIdentity identity = new ClientCertificate(credentials.getCertificate(), credentials.getPrivateKey(),
+				getClientId());
 		if (!identity.isValid()) {
-			identity = new ClientCertificate(credentials.getCertificate(), credentials.getPrivateKey(), getClientId());
+			identity = new ClientCredentials(getClientId(), getClientSecret());
 		}
 		return identity;
 	}

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/DummyXsuaaServiceConfiguration.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/DummyXsuaaServiceConfiguration.java
@@ -55,4 +55,9 @@ public class DummyXsuaaServiceConfiguration implements XsuaaServiceConfiguration
 	public CredentialType getCredentialType() {
 		return null;
 	}
+
+	@Override
+	public String getProperty(String name) {
+		return null;
+	}
 }


### PR DESCRIPTION
As Xsuaa still delivers the clientSecret for X.509 credential type, logic to resolve the clientIdentity fails and results to Internal Server Error.
As a fix I propose to swap around creation of `ClientIdentity` implementation classes -> Try to resolve `ClientCertificate` first, if it's not valid only then `ClientCredentials`.
Regarding the getProperty method that is by default not supported in `XsuaaServiceConfiguration` interface all of our implementations now overrides this method. 
In case of custom implementations also the way around approach in getClientIdentity method that resolves `ClientCredentials` first would result also in `UnsupportedOperationException` exception once the clientsecret was removed from Xsuaa credentials in case of X.509. 