### PR TITLE
Fix TokenBrokerResolver: use header creds in case of CLIENT_CREDENTIALS

### DIFF
--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/BasicCredentialExtractorTest.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/BasicCredentialExtractorTest.java
@@ -107,7 +107,7 @@ public class BasicCredentialExtractorTest {
 				"basic " + Base64.getEncoder().encodeToString("client1234:secret1234".getBytes()));
 
 		String token = extractor.resolve(request);
-		assertThat(token).isEqualTo("token_cc");
+		assertThat(token).isEqualTo("token_client1234");
 	}
 
 	@Test
@@ -135,7 +135,7 @@ public class BasicCredentialExtractorTest {
 		request.setScheme("http");
 		request.setServerName("t1.cloudfoundry");
 		String token = extractor.resolve(request);
-		assertThat(token).isEqualTo("token_cc");
+		assertThat(token).isEqualTo("token_client1234");
 	}
 
 	@Test

--- a/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/TokenBrokerTestConfiguration.java
+++ b/spring-xsuaa-it/src/test/java/com/sap/cloud/security/xsuaa/extractor/TokenBrokerTestConfiguration.java
@@ -43,7 +43,7 @@ public class TokenBrokerTestConfiguration {
 					@Nullable Map<String, String> optionalParameters, boolean disableCacheForRequest)
 					throws OAuth2ServiceException {
 				try {
-					return new OAuth2TokenResponse("token_cc", 100, null);
+					return new OAuth2TokenResponse("token_" + clientIdentity.getId(), 100, null);
 				} catch (Exception e) {
 					throw new OAuth2ServiceException("Error retrieving token: " + e.getMessage());
 				}

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/extractor/TokenBrokerResolver.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/extractor/TokenBrokerResolver.java
@@ -247,7 +247,7 @@ public class TokenBrokerResolver implements BearerTokenResolver {
 					String token;
 					if (oAuth2TokenService != null) {
 						token = oAuth2TokenService.retrieveAccessTokenViaClientCredentialsGrant(
-								URI.create(oauthTokenUrl), clientIdentity, null, null,
+								URI.create(oauthTokenUrl), clientCredentialsFromHeader, null, null,
 								null, false).getAccessToken();
 					} else {
 						// only when deprecated constructors are used, for backward compatibility


### PR DESCRIPTION
fixes #705 
relates to https://github.com/SAP/cloud-security-xsuaa-integration/pull/562 