### PR TITLE
XsuaaDefaultEndpoints: provide another constructor to compensate the deprecated one

### DIFF
--- a/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
+++ b/java-security-test/src/main/java/com/sap/cloud/security/test/SecurityTest.java
@@ -270,7 +270,7 @@ public class SecurityTest
 		}
 		// TODO return JSON Media type
 		OAuth2ServiceEndpointsProvider endpointsProvider = new XsuaaDefaultEndpoints(
-				String.format(LOCALHOST_PATTERN, wireMockServer.port()));
+				String.format(LOCALHOST_PATTERN, wireMockServer.port()), null);
 		wireMockServer.stubFor(get(urlEqualTo(endpointsProvider.getJwksUri().getPath()))
 				.willReturn(aResponse().withBody(createDefaultTokenKeyResponse())
 						.withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.value())));

--- a/java-security-test/src/test/java/com/sap/cloud/security/test/SecurityTestRuleTest.java
+++ b/java-security-test/src/test/java/com/sap/cloud/security/test/SecurityTestRuleTest.java
@@ -135,7 +135,7 @@ public class SecurityTestRuleTest {
 		Token token = cut.getJwtGeneratorFromFile("/token.json").createToken();
 
 		String baseUrl = cut.base.wireMockServer.baseUrl();
-		URI jwksUrl = new XsuaaDefaultEndpoints(baseUrl).getJwksUri();
+		URI jwksUrl = new XsuaaDefaultEndpoints(baseUrl, null).getJwksUri();
 		assertThat(token.getHeaderParameterAsString(TokenHeader.JWKS_URL)).isEqualTo(jwksUrl.toString());
 		assertThat(token.getClaimAsString(TokenClaims.ISSUER)).isEqualTo(baseUrl);
 	}

--- a/java-security/src/main/java/com/sap/cloud/security/adapter/xs/XSUserInfoAdapter.java
+++ b/java-security/src/main/java/com/sap/cloud/security/adapter/xs/XSUserInfoAdapter.java
@@ -451,7 +451,7 @@ public class XSUserInfoAdapter implements XSUserInfo {
 	 */
 	XsuaaTokenFlows getXsuaaTokenFlows(String baseUaaUrl, ClientIdentity clientIdentity) {
 		return new XsuaaTokenFlows(getOrCreateOAuth2TokenService(),
-				new XsuaaDefaultEndpoints(baseUaaUrl), clientIdentity);
+				new XsuaaDefaultEndpoints(baseUaaUrl, null), clientIdentity);
 	}
 
 	private String performTokenFlow(String baseUaaUrl, int tokenRequestType, String clientId, String clientSecret,

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtIssuerValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtIssuerValidator.java
@@ -85,7 +85,8 @@ class JwtIssuerValidator implements Validator<Token> {
 			}
 			if (!issuer.startsWith("http")) {
 				return createInvalid(
-						"Issuer is not trusted because issuer '{}' does not provide a valid URI (missing http scheme). Please contact your Identity Provider Administrator.", issuer);
+						"Issuer is not trusted because issuer '{}' does not provide a valid URI (missing http scheme). Please contact your Identity Provider Administrator.",
+						issuer);
 			}
 			issuerUri = new URI(issuer);
 			if (issuerUri.getQuery() == null && issuerUri.getFragment() == null && issuerUri.getHost() != null) {

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationDefaultTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationDefaultTest.java
@@ -14,7 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@TestPropertySource(properties = {"xsuaa.clientid=client", "xsuaa.certificate=cert", "xsuaa.key=key", "xsuaa.certurl=https://my.cert.authentication.sap.com", "xsuaa.credentialtype=x509"})
+@TestPropertySource(properties = { "xsuaa.clientid=client", "xsuaa.certificate=cert", "xsuaa.key=key",
+		"xsuaa.certurl=https://my.cert.authentication.sap.com", "xsuaa.credentialtype=x509" })
 @ContextConfiguration(classes = { XsuaaServiceConfigurationDefault.class })
 public class XsuaaServiceConfigurationDefaultTest {
 

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
@@ -50,9 +50,8 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	 *            - the base URI of XSUAA. Based on the base URI the tokenEndpoint,
 	 *            authorize and key set URI (JWKS) will be derived.
 	 * @param certUri
-	 *            - the cert URI
-	 *            of XSUAA. It is required in case of X.509 certificate based
-	 *            authentication.
+	 *            - the cert URI of XSUAA. It is required in case of X.509
+	 *            certificate based authentication.
 	 */
 	public XsuaaDefaultEndpoints(String baseUri, @Nullable String certUri) {
 		assertNotNull(baseUri, "XSUAA base URI must not be null.");

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
@@ -53,7 +53,7 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	 *            - the cert URI of XSUAA. It is required in case of X.509
 	 *            certificate based authentication.
 	 */
-	public XsuaaDefaultEndpoints(String baseUri, @Nullable String certUri) {
+	public XsuaaDefaultEndpoints(@Nonnull String baseUri, @Nullable String certUri) {
 		assertNotNull(baseUri, "XSUAA base URI must not be null.");
 		LOGGER.debug("Xsuaa default service endpoint: base url = {}, (cert url = {})", baseUri, certUri);
 		this.baseUri = URI.create(baseUri);

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.URI;
 
 import static com.sap.cloud.security.xsuaa.Assertions.assertNotNull;
@@ -26,18 +27,36 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	private static final Logger LOGGER = LoggerFactory.getLogger(XsuaaDefaultEndpoints.class);
 
 	/**
-	 * Creates a new XsuaaDefaultEndpoints. Can't be used in context of certificate
-	 * based authentication, as certificate url remains undefined.
+	 * Creates a new XsuaaDefaultEndpoints.
 	 *
 	 * @param baseUri
 	 *            - the base URI of XSUAA. Based on the base URI the tokenEndpoint,
 	 *            authorize and key set URI (JWKS) will be derived.
+	 * @deprecated gets removed with the major release 3.0.0 Use instead
+	 *             {@link #XsuaaDefaultEndpoints(String, String)}
 	 */
+	@Deprecated
 	public XsuaaDefaultEndpoints(URI baseUri) {
 		assertNotNull(baseUri, "XSUAA base URI must not be null.");
-		LOGGER.debug("Xsuaa default service endpoint = {}", baseUri);
+		LOGGER.warn("Using deprecated constructor to initialize xsuaa default service endpoint = {}", baseUri);
 		this.baseUri = baseUri;
 		this.certUri = null;
+	}
+
+	/**
+	 * Creates a new XsuaaDefaultEndpoints.
+	 *
+	 * @param baseUri
+	 *            - the base URI of XSUAA. Based on the base URI the tokenEndpoint,
+	 *            authorize and key set URI (JWKS) will be derived. - the cert URI
+	 *            of XSUAA. It is required in case of X.509 certificate based
+	 *            authentication.
+	 */
+	public XsuaaDefaultEndpoints(String baseUri, @Nullable String certUri) {
+		assertNotNull(baseUri, "XSUAA base URI must not be null.");
+		LOGGER.debug("Xsuaa default service endpoint = {}, (cert url = {})", baseUri, certUri);
+		this.baseUri = URI.create(baseUri);
+		this.certUri = certUri != null ? URI.create(certUri) : null;
 	}
 
 	/**
@@ -59,13 +78,15 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	}
 
 	/**
-	 * Creates a new XsuaaDefaultEndpoints. Can't be used in context of certificate
-	 * based authentication, as certificate url remains undefined.
+	 * Creates a new XsuaaDefaultEndpoints.
 	 *
 	 * @param baseUri
 	 *            - the base URI of XSUAA. Based on the base URI the tokenEndpoint,
 	 *            authorize and key set URI (JWKS) will be derived.
+	 * @deprecated gets removed with the major release 3.0.0 Use instead
+	 *             {@link #XsuaaDefaultEndpoints(String, String)}
 	 */
+	@Deprecated
 	public XsuaaDefaultEndpoints(String baseUri) {
 		this(URI.create(baseUri));
 	}

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
@@ -48,13 +48,15 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	 *
 	 * @param baseUri
 	 *            - the base URI of XSUAA. Based on the base URI the tokenEndpoint,
-	 *            authorize and key set URI (JWKS) will be derived. - the cert URI
+	 *            authorize and key set URI (JWKS) will be derived.
+	 * @param certUri
+	 *            - the cert URI
 	 *            of XSUAA. It is required in case of X.509 certificate based
 	 *            authentication.
 	 */
 	public XsuaaDefaultEndpoints(String baseUri, @Nullable String certUri) {
 		assertNotNull(baseUri, "XSUAA base URI must not be null.");
-		LOGGER.debug("Xsuaa default service endpoint = {}, (cert url = {})", baseUri, certUri);
+		LOGGER.debug("Xsuaa default service endpoint: base url = {}, (cert url = {})", baseUri, certUri);
 		this.baseUri = URI.create(baseUri);
 		this.certUri = certUri != null ? URI.create(certUri) : null;
 	}

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
@@ -26,15 +26,13 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	private static final Logger LOGGER = LoggerFactory.getLogger(XsuaaDefaultEndpoints.class);
 
 	/**
-	 * Creates a new XsuaaDefaultEndpoints.
+	 * Creates a new XsuaaDefaultEndpoints. Can't be used in context of certificate
+	 * based authentication, as certificate url remains undefined.
 	 *
 	 * @param baseUri
 	 *            - the base URI of XSUAA. Based on the base URI the tokenEndpoint,
 	 *            authorize and key set URI (JWKS) will be derived.
-	 * @deprecated gets removed with the major release 3.0.0 Use instead
-	 *             {@link #XsuaaDefaultEndpoints(OAuth2ServiceConfiguration)}
 	 */
-	@Deprecated
 	public XsuaaDefaultEndpoints(URI baseUri) {
 		assertNotNull(baseUri, "XSUAA base URI must not be null.");
 		LOGGER.debug("Xsuaa default service endpoint = {}", baseUri);
@@ -61,15 +59,13 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	}
 
 	/**
-	 * Creates a new XsuaaDefaultEndpoints.
+	 * Creates a new XsuaaDefaultEndpoints. Can't be used in context of certificate
+	 * based authentication, as certificate url remains undefined.
 	 *
 	 * @param baseUri
 	 *            - the base URI of XSUAA. Based on the base URI the tokenEndpoint,
 	 *            authorize and key set URI (JWKS) will be derived.
-	 * @deprecated gets removed with the major release 3.0.0 Use instead
-	 *             {@link #XsuaaDefaultEndpoints(OAuth2ServiceConfiguration)}
 	 */
-	@Deprecated
 	public XsuaaDefaultEndpoints(String baseUri) {
 		this(URI.create(baseUri));
 	}

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpointsTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpointsTest.java
@@ -86,6 +86,13 @@ public class XsuaaDefaultEndpointsTest {
 	}
 
 	@Test
+	public void getEndpointX509() {
+		OAuth2ServiceEndpointsProvider cut = new XsuaaDefaultEndpoints(URL, CERT_URL);
+
+		assertThat(cut.getTokenEndpoint().toString(), is(CERT_URL + "/oauth/token"));
+	}
+
+	@Test
 	public void withEndingPathDelimiter() {
 		OAuth2ServiceEndpointsProvider cut = createXsuaaDefaultEndpointProvider("http://localhost:8080/uaa/");
 
@@ -114,6 +121,6 @@ public class XsuaaDefaultEndpointsTest {
 	}
 
 	private OAuth2ServiceEndpointsProvider createXsuaaDefaultEndpointProvider(String baseUri) {
-		return new XsuaaDefaultEndpoints(baseUri);
+		return new XsuaaDefaultEndpoints(baseUri, null);
 	}
 }

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpointsTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpointsTest.java
@@ -5,7 +5,6 @@
  */
 package com.sap.cloud.security.xsuaa.client;
 
-import com.sap.cloud.security.config.CredentialType;
 import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,6 +12,7 @@ import org.mockito.Mockito;
 
 import java.net.URI;
 
+import static com.sap.cloud.security.config.CredentialType.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -21,80 +21,61 @@ public class XsuaaDefaultEndpointsTest {
 	private static OAuth2ServiceConfiguration oAuth2ServiceConfiguration;
 	private static final String URL = "https://subdomain.myauth.com";
 	private static final String CERT_URL = "https://subdomain.cert.myauth.com";
+	private OAuth2ServiceEndpointsProvider cut;
 
 	@Before
 	public void setUp() {
 		oAuth2ServiceConfiguration = Mockito.mock(OAuth2ServiceConfiguration.class);
-		Mockito.when(oAuth2ServiceConfiguration.getUrl()).thenReturn(URI.create(URL));
 	}
 
 	@Test
-	public void getTokenEndpoint() {
-		OAuth2ServiceEndpointsProvider cut = createXsuaaDefaultEndpointProvider(URL);
+	public void getEndpoints() {
+		Mockito.when(oAuth2ServiceConfiguration.getUrl()).thenReturn(URI.create(URL));
+		Mockito.when(oAuth2ServiceConfiguration.getCredentialType()).thenReturn(INSTANCE_SECRET);
+
+		cut = new XsuaaDefaultEndpoints(oAuth2ServiceConfiguration);
 
 		assertThat(cut.getTokenEndpoint().toString(), is(URL + "/oauth/token"));
-
-		Mockito.when(oAuth2ServiceConfiguration.getCredentialType()).thenReturn(CredentialType.INSTANCE_SECRET);
-		OAuth2ServiceEndpointsProvider cut2 = new XsuaaDefaultEndpoints(oAuth2ServiceConfiguration);
-
-		assertThat(cut2.getTokenEndpoint().toString(), is(URL + "/oauth/token"));
-	}
-
-	@Test
-	public void getTokenEndpointX509() {
-		Mockito.when(oAuth2ServiceConfiguration.getCertUrl()).thenReturn(URI.create(CERT_URL));
-		Mockito.when(oAuth2ServiceConfiguration.getCredentialType()).thenReturn(CredentialType.X509);
-		OAuth2ServiceEndpointsProvider cut = new XsuaaDefaultEndpoints(oAuth2ServiceConfiguration);
-		assertThat(cut.getTokenEndpoint().toString(), is(CERT_URL + "/oauth/token"));
-	}
-
-	@Test
-	public void getAuthorizeEndpoint() {
-		OAuth2ServiceEndpointsProvider cut = createXsuaaDefaultEndpointProvider(URL);
-
 		assertThat(cut.getAuthorizeEndpoint().toString(), is(URL + "/oauth/authorize"));
-
-		Mockito.when(oAuth2ServiceConfiguration.getCredentialType()).thenReturn(CredentialType.INSTANCE_SECRET);
-		OAuth2ServiceEndpointsProvider cut2 = new XsuaaDefaultEndpoints(oAuth2ServiceConfiguration);
-
-		assertThat(cut2.getAuthorizeEndpoint().toString(), is(URL + "/oauth/authorize"));
-	}
-
-	@Test
-	public void getAuthorizeEndpointX509() {
-		Mockito.when(oAuth2ServiceConfiguration.getCertUrl()).thenReturn(URI.create(CERT_URL));
-		Mockito.when(oAuth2ServiceConfiguration.getCredentialType()).thenReturn(CredentialType.X509);
-		OAuth2ServiceEndpointsProvider cut2 = new XsuaaDefaultEndpoints(oAuth2ServiceConfiguration);
-
-		assertThat(cut2.getAuthorizeEndpoint().toString(), is(CERT_URL + "/oauth/authorize"));
-	}
-
-	@Test
-	public void getJwksUri() {
-		OAuth2ServiceEndpointsProvider cut = createXsuaaDefaultEndpointProvider(URL);
-
 		assertThat(cut.getJwksUri().toString(), is(URL + "/token_keys"));
 	}
 
 	@Test
-	public void getJwksUriX509() {
+	public void getEndpoints_forX509OAuth2ServiceConfiguration() {
+		Mockito.when(oAuth2ServiceConfiguration.getUrl()).thenReturn(URI.create(URL));
 		Mockito.when(oAuth2ServiceConfiguration.getCertUrl()).thenReturn(URI.create(CERT_URL));
-		Mockito.when(oAuth2ServiceConfiguration.getCredentialType()).thenReturn(CredentialType.X509);
-		OAuth2ServiceEndpointsProvider cut2 = new XsuaaDefaultEndpoints(oAuth2ServiceConfiguration);
+		Mockito.when(oAuth2ServiceConfiguration.getCredentialType()).thenReturn(X509);
 
-		assertThat(cut2.getJwksUri().toString(), is(URL + "/token_keys"));
+		cut = new XsuaaDefaultEndpoints(oAuth2ServiceConfiguration);
+
+		assertThat(cut.getTokenEndpoint().toString(), is(CERT_URL + "/oauth/token"));
+		assertThat(cut.getAuthorizeEndpoint().toString(), is(CERT_URL + "/oauth/authorize"));
+		assertThat(cut.getJwksUri().toString(), is(URL + "/token_keys"));
 	}
 
 	@Test
-	public void getEndpointX509() {
-		OAuth2ServiceEndpointsProvider cut = new XsuaaDefaultEndpoints(URL, CERT_URL);
+	public void getEndpoint_forCertUrl() {
+		cut = new XsuaaDefaultEndpoints(URL, CERT_URL);
 
 		assertThat(cut.getTokenEndpoint().toString(), is(CERT_URL + "/oauth/token"));
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void getEndpoint_throwsException_whenBaseUriIsNull() {
+		new XsuaaDefaultEndpoints(null, CERT_URL);
+	}
+
+	@Test
+	@Deprecated
+	public void getEndpoint_forBaseUrl() {
+		cut = new XsuaaDefaultEndpoints(URL);
+
+		assertThat(cut.getTokenEndpoint().toString(), is(URL + "/oauth/token"));
+	}
+
 	@Test
 	public void withEndingPathDelimiter() {
-		OAuth2ServiceEndpointsProvider cut = createXsuaaDefaultEndpointProvider("http://localhost:8080/uaa/");
+		cut = createXsuaaDefaultEndpointProvider("http://localhost:8080/uaa/");
 
 		assertThat(cut.getAuthorizeEndpoint().toString(), is("http://localhost:8080/uaa/oauth/authorize"));
 		assertThat(cut.getTokenEndpoint().toString(), is("http://localhost:8080/uaa/oauth/token"));
@@ -103,7 +84,7 @@ public class XsuaaDefaultEndpointsTest {
 
 	@Test
 	public void withQueryParameters() {
-		OAuth2ServiceEndpointsProvider cut = createXsuaaDefaultEndpointProvider("http://localhost:8080/uaa?abc=123");
+		cut = createXsuaaDefaultEndpointProvider("http://localhost:8080/uaa?abc=123");
 
 		assertThat(cut.getAuthorizeEndpoint().toString(), is("http://localhost:8080/uaa/oauth/authorize?abc=123"));
 		assertThat(cut.getTokenEndpoint().toString(), is("http://localhost:8080/uaa/oauth/token?abc=123"));
@@ -112,7 +93,7 @@ public class XsuaaDefaultEndpointsTest {
 
 	@Test
 	public void withQueryParametersAndEndingPathDelimiter() {
-		OAuth2ServiceEndpointsProvider cut = createXsuaaDefaultEndpointProvider(
+		cut = createXsuaaDefaultEndpointProvider(
 				"http://localhost:8080/uaa/?abc=123");
 
 		assertThat(cut.getAuthorizeEndpoint().toString(), is("http://localhost:8080/uaa/oauth/authorize?abc=123"));


### PR DESCRIPTION
fixes #707

Hi @liga-oz 
Alternatively we could provide a new constructor
````
XsuaaDefaultEndpoints(String baseUri, @Nullable String certUri)
````

Furthermore, we could set the default certUri by adding the  that `https://subdomain.authentication.cert.domain`