### PR TITLE
fix misuse of OAuth2ServiceConfiguration.getClientIdentity() in XsuaaServiceConfiguration

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfiguration.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfiguration.java
@@ -5,6 +5,7 @@
  */
 package com.sap.cloud.security.xsuaa;
 
+import com.sap.cloud.security.config.ClientIdentity;
 import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
 import com.sap.cloud.security.config.Service;
 
@@ -63,6 +64,14 @@ public interface XsuaaServiceConfiguration extends OAuth2ServiceConfiguration {
 	@Override
 	default boolean hasProperty(String name) {
 		throw new UnsupportedOperationException("hasProperty method is not supported");
+	}
+
+	@Override
+	default ClientIdentity getClientIdentity() {
+		throw new UnsupportedOperationException(
+				"This default method needs to be overridden to be used! Default method from " +
+						"com.sap.cloud.security.config.OAuth2ServiceConfiguration#getClientIdentity() " +
+						"is not compatible with XsuaaServiceConfiguration interface");
 	}
 
 	@Override

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/DummyXsuaaServiceConfiguration.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/DummyXsuaaServiceConfiguration.java
@@ -5,6 +5,8 @@
  */
 package com.sap.cloud.security.xsuaa;
 
+import com.sap.cloud.security.config.ClientCredentials;
+import com.sap.cloud.security.config.ClientIdentity;
 import com.sap.cloud.security.config.CredentialType;
 
 public class DummyXsuaaServiceConfiguration implements XsuaaServiceConfiguration {
@@ -56,9 +58,9 @@ public class DummyXsuaaServiceConfiguration implements XsuaaServiceConfiguration
 		return null;
 	}
 
-	// TODO remove once credential-type is available in IAS configuration
 	@Override
-	public String getProperty(String name) {
-		return null;
+	public ClientIdentity getClientIdentity() {
+		return new ClientCredentials(getClientId(), getClientSecret());
 	}
+
 }


### PR DESCRIPTION
To avoid confusion when exception `java.lang.UnsupportedOperationException: getProperty method` is thrown for custom `XsuaaServiceConfiguration` implementations where the default `OAuth2ServiceConfiguration.getClientIdentity()` is not overridden, provide default `getClientIdentity()` method in `XsuaaClientConfiguration` interface that will notify user to implement the method and won't use the default from `OAuth2ServiceConfiguration` interface that calls unsupported `getProperty()` method.