### PR TITLE
fix 'key' attribute name mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to this project will be documented in this file.
     - Introduces X.509 certificate thumbprint validator `JwtX5tValidator` as described [here](https://github.com/SAP/cloud-security-xsuaa-integration/blob/master/java-security/README.md#x509-certificate-thumbprint-x5t-validation)
     - `IasTokenAuthenticator` and `XsuaaTokenAuthenticator` store the forwarded X.509 certificate for incoming requests in `SecurityContext`
     - `XsuaaDefaultEndpoints` provides a new [constructor(url, certUrl)](https://github.com/SAP/cloud-security-xsuaa-integration/blob/main/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java#L56) (issue [707](https://github.com/SAP/cloud-security-xsuaa-integration/issues/707))
-- [spring-xsuaa] `XsuaaServiceConfiguration` interface default method `getClientIdentity()` needs to be overridden to be used
+- [spring-xsuaa] 
+    - `XsuaaServiceConfiguration` interface default method `getClientIdentity()` needs to be overridden to be used
+    - :exclamation: Incompatible change `XsuaaCredentials`  `getPrivateKey()` `setPrivateKey()` has changed to `getKey()` `setKey()` to reflect the attribute name from configuration
 - [token-client] Adds ``X-CorrelationID`` header to outgoing requests. In case MDC provides "correlation_id" this one is taken (issue [691](https://github.com/SAP/cloud-security-xsuaa-integration/issues/691))
 
 #### Dependency upgrades

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaCredentials.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaCredentials.java
@@ -6,10 +6,12 @@
 package com.sap.cloud.security.xsuaa;
 
 import com.sap.cloud.security.config.CredentialType;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Represents the XSUAA credentials of VCAP_SERVICES.
  */
+@ConfigurationProperties
 public class XsuaaCredentials {
 	private String clientId;
 	private String clientSecret;
@@ -94,11 +96,11 @@ public class XsuaaCredentials {
 		this.credentialType = credentialType;
 	}
 
-	public String getPrivateKey() {
+	public String getKey() {
 		return privateKey;
 	}
 
-	public void setPrivateKey(String privateKey) {
+	public void setKey(String privateKey) {
 		this.privateKey = privateKey;
 	}
 }

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationCustom.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationCustom.java
@@ -70,7 +70,7 @@ public class XsuaaServiceConfigurationCustom implements XsuaaServiceConfiguratio
 
 	@Override
 	public ClientIdentity getClientIdentity() {
-		ClientIdentity identity = new ClientCertificate(credentials.getCertificate(), credentials.getPrivateKey(),
+		ClientIdentity identity = new ClientCertificate(credentials.getCertificate(), credentials.getKey(),
 				getClientId());
 		if (!identity.isValid()) {
 			identity = new ClientCredentials(getClientId(), getClientSecret());

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationCustomTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/XsuaaServiceConfigurationCustomTest.java
@@ -23,7 +23,7 @@ class XsuaaServiceConfigurationCustomTest {
 		credentials.setXsAppName("xsappname");
 		credentials.setCertificate("-----BEGIN CERTIFICATE-----");
 		credentials.setCertUrl("cert-url");
-		credentials.setPrivateKey("-----BEGIN RSA PRIVATE KEY-----");
+		credentials.setKey("-----BEGIN RSA PRIVATE KEY-----");
 		credentials.setCredentialType(CredentialType.X509);
 
 		cut = new XsuaaServiceConfigurationCustom(credentials);
@@ -39,7 +39,7 @@ class XsuaaServiceConfigurationCustomTest {
 		assertEquals(credentials.getCredentialType(), cut.getCredentialType());
 		assertEquals(credentials.getCertUrl(), cut.getCertUrl().toString());
 		assertEquals(credentials.getCertificate(), cut.getClientIdentity().getCertificate());
-		assertEquals(credentials.getPrivateKey(), cut.getClientIdentity().getKey());
+		assertEquals(credentials.getKey(), cut.getClientIdentity().getKey());
 	}
 
 	@Test


### PR DESCRIPTION
fix issue when `@ConfigurationProperties` doesn't load private key due to attribute name mismatch. In configuration files X509 private key is with 'key' attribute name

rename privateKey -> key

https://jtrack.wdf.sap.corp/browse/NGPBUG-168786 