### PR TITLE
Reduced build logs by muting download progress of depenedencies

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,22 +21,23 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Maven
-        run: mvn -B install --file pom.xml
+        run: mvn -B install --file pom.xml --no-transfer-progress
       - name: Run integration tests
-        run: cd java-security-it; mvn -B package --file pom.xml
+        run: cd java-security-it; mvn -B package --file pom.xml --no-transfer-progress
       - name: Build spring-security-basic-auth
-        run: cd samples/spring-security-basic-auth; mvn -B package --file pom.xml
+        run: cd samples/spring-security-basic-auth; mvn -B package --file pom.xml --no-transfer-progress
       - name: Build spring-security-xsuaa-usage
-        run: cd samples/spring-security-xsuaa-usage; mvn -B package --file pom.xml
+        run: cd samples/spring-security-xsuaa-usage; mvn -B package --file pom.xml --no-transfer-progress
       - name: Build spring-webflux-security-xsuaa-usage
-        run: cd samples/spring-webflux-security-xsuaa-usage; mvn -B package --file pom.xml
+        run: cd samples/spring-webflux-security-xsuaa-usage; mvn -B package --file pom.xml --no-transfer-progress
       - name: Build java-security-usage
-        run: cd samples/java-security-usage; mvn -B package --file pom.xml
+        run: cd samples/java-security-usage; mvn -B package --file pom.xml --no-transfer-progress
       - name: Build sap-java-buildpack-api-usage
-        run: cd samples/sap-java-buildpack-api-usage; mvn -B package --file pom.xml
+        run: cd samples/sap-java-buildpack-api-usage; mvn -B package --file pom.xml --no-transfer-progress
       - name: Build java-tokenclient-usage
-        run: cd samples/java-tokenclient-usage; mvn -B package --file pom.xml
+        run: cd samples/java-tokenclient-usage; mvn -B package --file pom.xml --no-transfer-progress
       - name: Build java-security-usage-ias
-        run: cd samples/java-security-usage-ias; mvn -B package --file pom.xml
+        run: cd samples/java-security-usage-ias; mvn -B package --file pom.xml --no-transfer-progress
       - name: Build spring-security-hybrid-usage
-        run: cd samples/spring-security-hybrid-usage; mvn -B package --file pom.xml
+        run: cd samples/spring-security-hybrid-usage; mvn -B package --file pom.xml --no-transfer-progress
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,6 +20,15 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Build with Maven
         run: mvn -B install --file pom.xml --no-transfer-progress
       - name: Run integration tests


### PR DESCRIPTION
This pull request will prevent to display the download progress of libraries during a maven build and it will cache the local maven repository for already downloaded libraries.

The below log output will not be displayed anymore and results into a more clear output and it will make it easier to analyse the build output when failures occur.

Current build log outputting verbose download progress:
```
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/security/spring-security-bom/5.6.0/spring-security-bom-5.6.0.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/security/spring-security-bom/5.6.0/spring-security-bom-5.6.0.pom (5.7 kB at 13 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.6.1/spring-boot-dependencies-2.6.1.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.6.1/spring-boot-dependencies-2.6.1.pom (105 kB at 1.5 MB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/datastax/oss/java-driver-bom/4.13.0/java-driver-bom-4.13.0.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/datastax/oss/java-driver-bom/4.13.0/java-driver-bom-4.13.0.pom (4.1 kB at 160 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/io/dropwizard/metrics/metrics-bom/4.2.4/metrics-bom-4.2.4.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/io/dropwizard/metrics/metrics-bom/4.2.4/metrics-bom-4.2.4.pom (6.4 kB at 247 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/io/dropwizard/metrics/metrics-parent/4.2.4/metrics-parent-4.2.4.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/io/dropwizard/metrics/metrics-parent/4.2.4/metrics-parent-4.2.4.pom (20 kB at 662 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-bom/3.0.9/groovy-bom-3.0.9.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/groovy/groovy-bom/3.0.9/groovy-bom-3.0.9.pom (26 kB at 880 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/infinispan/infinispan-bom/12.1.7.Final/infinispan-bom-12.1.7.Final.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/infinispan/infinispan-bom/12.1.7.Final/infinispan-bom-12.1.7.Final.pom (18 kB at 924 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/infinispan/infinispan-build-configuration-parent/12.1.7.Final/infinispan-build-configuration-parent-12.1.7.Final.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/infinispan/infinispan-build-configuration-parent/12.1.7.Final/infinispan-build-configuration-parent-12.1.7.Final.pom (14 kB at 540 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/jboss/jboss-parent/36/jboss-parent-36.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/jboss/jboss-parent/36/jboss-parent-36.pom (66 kB at 2.1 MB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.13.0/jackson-bom-2.13.0.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.13.0/jackson-bom-2.13.0.pom (17 kB at 780 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.13/jackson-parent-2.13.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.13/jackson-parent-2.13.pom (7.4 kB at 371 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/43/oss-parent-43.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/43/oss-parent-43.pom (24 kB at 1.2 MB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-bom/2.35/jersey-bom-2.35.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/glassfish/jersey/jersey-bom/2.35/jersey-bom-2.35.pom (19 kB at 966 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/ee4j/project/1.0.6/project-1.0.6.pom
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/eclipse/ee4j/project/1.0.6/project-1.0.6.pom (13 kB at 667 kB/s)
[INFO] Downloading from central: https://repo.maven.apache.org/maven2/org/eclipse/jetty/jetty-bom/9.4.44.v20210927/jetty-bom-9.4.44.v20210927.pom
```