### PR TITLE
Fix CURL user notation instead of "inline to URL"

### DIFF
--- a/docs/HowToFetchToken.md
+++ b/docs/HowToFetchToken.md
@@ -46,7 +46,7 @@ The documentation assumes the utility `curl` and `awk` to be installed (Mac OS: 
         
     ❗Replace the `<<>>` placeholders with the values from the service configuration.  
     ```shell script   
-    curl -XPOST https://<<credentials.clientid>>:<<credentials.clientsecret>>@<<credentials.url>>/oauth2/token \
+    curl -XPOST -u '<<credentials.clientid>>:<<credentials.clientsecret>>' https://<<credentials.url>>/oauth2/token \
          -d 'grant_type=password&username=<<your ias user>>&password=<<your ias password>>'
     ```
     </details>


### PR DESCRIPTION
Most CURL do not support the `https://username:password@hostname` notation. Instead the parameter `-u` must be used. See also https://linux.die.net/man/1/curl on that.