### PR TITLE
add further logs in respect to key mismatches

### DIFF
--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
@@ -235,7 +235,7 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 		JsonWebKeySet keySet = JsonWebKeySetFactory
 				.createFromJson(getTokenKeyService().retrieveTokenKeys(jwksUri, zoneId));
 		if (keySet == null || keySet.getAll().isEmpty()) {
-			LOGGER.error("Retrieved no token keys from {} for zone id '{}'", jwksUri, zoneId);
+			LOGGER.error("Retrieved no token keys from {} for zone '{}'", jwksUri, zoneId);
 			return;
 		}
 		Set<JsonWebKey> jwks = keySet.getAll();

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
@@ -17,6 +17,7 @@ import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.time.Duration;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -199,7 +200,13 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 		if (publicKey == null) {
 			retrieveTokenKeysAndFillCache(keyUri, zoneId);
 		}
-		return getCache().getIfPresent(cacheKey);
+		publicKey = getCache().getIfPresent(cacheKey);
+		if (publicKey == null && LOGGER.isDebugEnabled()) {
+			Set<String> keys = getCache().asMap().keySet();
+			LOGGER.debug("Key {} not found in cache. Keys cached: {}", cacheKey,
+					keys.stream().map(String::valueOf).collect(Collectors.joining("|")));
+		}
+		return publicKey;
 	}
 
 	private TokenKeyCacheConfiguration getCheckedConfiguration(CacheConfiguration cacheConfiguration) {
@@ -227,7 +234,8 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 			throws OAuth2ServiceException, InvalidKeySpecException, NoSuchAlgorithmException {
 		JsonWebKeySet keySet = JsonWebKeySetFactory
 				.createFromJson(getTokenKeyService().retrieveTokenKeys(jwksUri, zoneId));
-		if (keySet == null) {
+		if (keySet == null || keySet.getAll().isEmpty()) {
+			LOGGER.error("Retrieved no token keys from {} for zone id '{}'", jwksUri, zoneId);
 			return;
 		}
 		Set<JsonWebKey> jwks = keySet.getAll();
@@ -277,7 +285,7 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 
 	public static String getUniqueCacheKey(JwtSignatureAlgorithm keyAlgorithm, String keyId, URI jwksUri,
 			String zoneId) {
-		return jwksUri + String.valueOf(JsonWebKeyImpl.calculateUniqueId(keyAlgorithm, keyId)) + zoneId;
+		return jwksUri + keyId + keyAlgorithm + zoneId;
 	}
 
 }

--- a/java-security/src/test/resources/simplelogger.properties
+++ b/java-security/src/test/resources/simplelogger.properties
@@ -1,0 +1,2 @@
+org.slf4j.simpleLogger.defaultLogLevel: WARN
+org.slf4j.simpleLogger.log.com.sap.cloud.security.token.validation.validators: DEBUG

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenKeyService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenKeyService.java
@@ -13,6 +13,8 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -22,6 +24,8 @@ import java.net.URI;
 import static com.sap.cloud.security.xsuaa.http.HttpHeaders.X_ZONE_UUID;
 
 public class DefaultOAuth2TokenKeyService implements OAuth2TokenKeyService {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(DefaultOAuth2TokenKeyService.class);
 
 	private final CloseableHttpClient httpClient;
 
@@ -44,6 +48,7 @@ public class DefaultOAuth2TokenKeyService implements OAuth2TokenKeyService {
 		try (CloseableHttpResponse response = httpClient.execute(request)) {
 			String bodyAsString = HttpClientUtil.extractResponseBodyAsString(response);
 			int statusCode = response.getStatusLine().getStatusCode();
+			LOGGER.debug("retrieve token keys {} for zone '{}'", tokenKeysEndpointUri, zoneId);
 			if (statusCode == HttpStatus.SC_OK) {
 				return bodyAsString;
 			} else {


### PR DESCRIPTION
#### Motivation
as of now, in case of validation error the decoded jwt token gets logged (debug mode) and the JwtSignatureValidator error itself. Also, in case service returns error or status code != 200, an error will be written.

Additionally, with that PR also these circumstances / details gets logged as well, mostly in DEBUG mode.

**1. jku url does not provide any keys:**
> [main] DEBUG com.sap.cloud.security.token.validation.validators.OAuth2TokenKeyServiceWithCache - Configured token key cache with cacheDuration=600 seconds, cacheSize=1000 and statisticsRecording=false
[main] ERROR com.sap.cloud.security.token.validation.validators.OAuth2TokenKeyServiceWithCache - Retrieved no token keys from https://myauth.com/jwks_uri for zone id 'zone_uuid'
[main] DEBUG com.sap.cloud.security.token.validation.validators.OAuth2TokenKeyServiceWithCache - Key https://myauth.com/jwks_urikey-id-0RS256zone_uuid not found in cache. Keys cached: 

**2. keys mismatch** 
> [main] DEBUG com.sap.cloud.security.token.validation.validators.OAuth2TokenKeyServiceWithCache - Key https://myauth.com/jwks_urinot-seen-yetRS256zone_uuid not found in cache. Keys cached: https://myauth.com/jwks_urikey-id-1RS256zone_uuid|https://myauth.com/jwks_urikey-id-0RS256zone_uuid|https://myauth.com/jwks_urilegacy-token-keyRS256zone_uuid


**3. token keys endpoint is called** 
> [main] DEBUG com.sap.cloud.security.xsuaa.client.DefaultOAuth2TokenKeyService - retrieve token keys https://tokenKeys.io/token_keys for zone '92768714-4c2e-4b79-bc1b-009a4127ee3c'