### PR TITLE
XsuaaJwtDecoder must ignore line breaks in verificationkey

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
@@ -202,6 +202,8 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 		String key = pemEncodedKey;
 		key = key.replace("-----BEGIN PUBLIC KEY-----", "");
 		key = key.replace("-----END PUBLIC KEY-----", "");
+		key = key.replace("\n", "");
+		key = key.replace("\\n", "");
 		return key;
 	}
 


### PR DESCRIPTION
#### Motivation
Solves issue, when decoding `verificationkey` (`VCAP_SERVICES`- `xsuaa`- `credentials`) fails because of line breaks.
See also [here](https://stackoverflow.com/questions/68019059/java-lang-illegalargumentexception-illegal-base64-character-a).

````
Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception
java.lang.IllegalArgumentException: Illegal base64 character a
at java.base/java.util.Base64$Decoder.decode0(Base64.java:746)
at java.base/java.util.Base64$Decoder.decode(Base64.java:538)
at java.base/java.util.Base64$Decoder.decode(Base64.java:561)
at com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoder.createPublicKey(XsuaaJwtDecoder.java:210)
at com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoder.verifyWithVerificationKey(XsuaaJwtDecoder.java:191)
at com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoder.tryToVerifyWithVerificationKey(XsuaaJwtDecoder.java:186)
at com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoder.verifyToken(XsuaaJwtDecoder.java:113)
at com.sap.cloud.security.xsuaa.token.authentication.XsuaaJwtDecoder.decode(XsuaaJwtDecoder.java:93)
````