### PR TITLE
Dependency on spotbugs-annotations should be optional #851

### DIFF
--- a/env/pom.xml
+++ b/env/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>httpclient</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- test utilities -->
         <dependency>

--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -26,6 +26,7 @@
 		<dependency>
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -69,6 +69,11 @@
 			<groupId>com.github.tomakehurst</groupId>
 			<artifactId>wiremock-jre8</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-annotations</artifactId>
+			<optional>true</optional>
+		</dependency>
 
 		<!-- test dependencies -->
 		<dependency>

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -38,6 +38,11 @@
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-annotations</artifactId>
+			<optional>true</optional>
+		</dependency>
 
 		<!-- for call to tokenKeyService -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,7 @@
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-annotations</artifactId>
 				<version>${spotbugs.annotations.version}</version>
+				<optional>true</optional>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>

--- a/spring-security-compatibility/src/main/java/com/sap/cloud/security/comp/XsuaaTokenComp.java
+++ b/spring-security-compatibility/src/main/java/com/sap/cloud/security/comp/XsuaaTokenComp.java
@@ -11,7 +11,6 @@ import com.sap.cloud.security.token.Token;
 import com.sap.cloud.security.token.TokenClaims;
 import org.springframework.security.core.GrantedAuthority;
 
-import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
@@ -141,7 +140,6 @@ public class XsuaaTokenComp implements com.sap.cloud.security.xsuaa.token.Token 
 	 * @return unique principal name or null if it can not be determined.
 	 * @deprecated use {@link Token#getClaimAsString(String)} instead.
 	 */
-	@Nullable
 	@Deprecated
 	public String getLogonName() {
 		return token.getClaimAsString("user_name");
@@ -155,7 +153,6 @@ public class XsuaaTokenComp implements com.sap.cloud.security.xsuaa.token.Token 
 	 * @return the given name if present.
 	 * @deprecated use {@link Token#getClaimAsString(String)} instead
 	 */
-	@Nullable
 	@Deprecated
 	public String getGivenName() {
 		return token.getClaimAsString(TokenClaims.GIVEN_NAME);
@@ -169,7 +166,6 @@ public class XsuaaTokenComp implements com.sap.cloud.security.xsuaa.token.Token 
 	 * @return the family name if present.
 	 * @deprecated use {@link Token#getClaimAsString(String)} instead
 	 */
-	@Nullable
 	@Deprecated
 	public String getFamilyName() {
 		return token.getClaimAsString(TokenClaims.FAMILY_NAME);
@@ -181,7 +177,6 @@ public class XsuaaTokenComp implements com.sap.cloud.security.xsuaa.token.Token 
 	 * @return The email address if present.
 	 * @deprecated use {@link Token#getClaimAsString(String)} instead
 	 */
-	@Nullable
 	@Deprecated
 	public String getEmail() {
 		return token.getClaimAsString(TokenClaims.EMAIL);
@@ -199,7 +194,6 @@ public class XsuaaTokenComp implements com.sap.cloud.security.xsuaa.token.Token 
 	 * @return the user origin if present.
 	 * @deprecated use {@link Token#getClaimAsString(String)} instead
 	 */
-	@Nullable
 	@Deprecated
 	public String getOrigin() {
 		return token.getClaimAsString(TokenClaims.XSUAA.ORIGIN);
@@ -213,7 +207,6 @@ public class XsuaaTokenComp implements com.sap.cloud.security.xsuaa.token.Token 
      * @return the attribute values array or null if there exists no such attribute.
 	 * @deprecated use {@link Token#getAttributeFromClaimAsStringList(String, String)} (String)} instead
      */
-    @Nullable
 	@Deprecated
     public String[] getXSUserAttribute(String attributeName) {
 		return Optional.ofNullable(token.getAttributeFromClaimAsStringList(TokenClaims.XSUAA.XS_USER_ATTRIBUTES, attributeName))
@@ -231,7 +224,6 @@ public class XsuaaTokenComp implements com.sap.cloud.security.xsuaa.token.Token 
 	 * @return additional attribute value if present.
 	 * @deprecated use {@link Token#getAttributeFromClaimAsString(String, String)} instead
 	 */
-	@Nullable
 	@Deprecated
 	public String getAdditionalAuthAttribute(String attributeName) {
 		return token.getAttributeFromClaimAsString("az_attr", attributeName);
@@ -245,7 +237,6 @@ public class XsuaaTokenComp implements com.sap.cloud.security.xsuaa.token.Token 
 	 * @return the XSUAA clone service instance id if present.
 	 * @deprecated use {@link Token#getAttributeFromClaimAsString(String, String)} instead
 	 */
-	@Nullable
 	@Deprecated
 	public String getCloneServiceInstanceId() {
 		return token.getAttributeFromClaimAsString(TokenClaims.XSUAA.EXTERNAL_ATTRIBUTE, "serviceinstanceid");
@@ -300,7 +291,6 @@ public class XsuaaTokenComp implements com.sap.cloud.security.xsuaa.token.Token 
 	 * @return the expiration point in time if present.
 	 * @deprecated use {@link Token#getExpiration()} instead
 	 */
-	@Nullable
 	@Deprecated
 	public Instant getExpiration() {
 		return token.getExpiration();
@@ -313,7 +303,6 @@ public class XsuaaTokenComp implements com.sap.cloud.security.xsuaa.token.Token 
 	 * @deprecated use {@link Token#getExpiration()} instead
 	 */
 	@Deprecated
-	@Nullable
 	public Date getExpirationDate() {
 		return token.getExpiration() != null ? Date.from(token.getExpiration()) : null;
 	}

--- a/spring-security/pom.xml
+++ b/spring-security/pom.xml
@@ -33,7 +33,6 @@
 			<artifactId>spring-boot-autoconfigure</artifactId>
 			<scope>provided</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>com.sap.cloud.security</groupId>
 			<artifactId>java-security</artifactId>
@@ -42,6 +41,11 @@
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-annotations</artifactId>
+			<optional>true</optional>
 		</dependency>
 
 		<!-- test utilities -->

--- a/spring-xsuaa-it/pom.xml
+++ b/spring-xsuaa-it/pom.xml
@@ -70,14 +70,9 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-annotations</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
@@ -86,6 +81,18 @@
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-jwt</artifactId>
+		</dependency>
+
+		<!-- test utilities -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -39,6 +39,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-annotations</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-to-slf4j</artifactId>
 		</dependency>

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -34,8 +34,8 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.spotbugs</groupId>
-			<artifactId>spotbugs-annotations</artifactId>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -34,8 +34,9 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
+			<groupId>com.github.spotbugs</groupId>
+			<artifactId>spotbugs-annotations</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
@@ -74,7 +75,6 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>token-client</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
@@ -89,7 +89,13 @@
 			<artifactId>reactor-core</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<scope>compile</scope>
+		</dependency>
 
+		<!-- test utilities -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -134,11 +140,6 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-jwt</artifactId>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/token-client/pom.xml
+++ b/token-client/pom.xml
@@ -46,6 +46,7 @@
 		<dependency>
 			<groupId>com.github.spotbugs</groupId>
 			<artifactId>spotbugs-annotations</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>


### PR DESCRIPTION
closes #851 
follows recommendation from [here](https://spotbugs.readthedocs.io/en/stable/migration.html#guide-for-migration-from-findbugs-3-0-to-spotbugs-3-1)

[all]
- Dependency on spotbugs-annotations should be optional <br>

[spring-xsuaa]
- Dependency on javax.annotation-api should be optional 