### PR TITLE
AbstractTokenAuthenticator provides withAudienceValidator()

### DIFF
--- a/java-security/src/main/java/com/sap/cloud/security/servlet/AbstractTokenAuthenticator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/servlet/AbstractTokenAuthenticator.java
@@ -40,6 +40,7 @@ public abstract class AbstractTokenAuthenticator implements TokenAuthenticator {
 	protected CloseableHttpClient httpClient;
 	protected OAuth2ServiceConfiguration serviceConfiguration;
 	private CacheConfiguration tokenKeyCacheConfiguration;
+	private Validator<Token> audienceValidator;
 
 	@Override
 	public TokenAuthenticationResult validateRequest(ServletRequest request, ServletResponse response) {
@@ -98,6 +99,11 @@ public abstract class AbstractTokenAuthenticator implements TokenAuthenticator {
 		return this;
 	}
 
+	public AbstractTokenAuthenticator withAudienceValidator(Validator<Token> validator) {
+		this.audienceValidator = validator;
+		return this;
+	}
+
 	private void setupTokenFactory() {
 		if (serviceConfiguration.getService() == Service.XSUAA) {
 			HybridTokenFactory.withXsuaaAppId(serviceConfiguration.getProperty(CFConstants.XSUAA.APP_ID));
@@ -147,6 +153,7 @@ public abstract class AbstractTokenAuthenticator implements TokenAuthenticator {
 	Validator<Token> getOrCreateTokenValidator() {
 		if (tokenValidator == null) {
 			JwtValidatorBuilder jwtValidatorBuilder = JwtValidatorBuilder.getInstance(getServiceConfiguration())
+					.withAudienceValidator(audienceValidator)
 					.withHttpClient(httpClient);
 			jwtValidatorBuilder.configureAnotherServiceInstance(getOtherServiceConfiguration());
 			Optional.ofNullable(tokenKeyCacheConfiguration).ifPresent(jwtValidatorBuilder::withCacheConfiguration);
@@ -196,5 +203,4 @@ public abstract class AbstractTokenAuthenticator implements TokenAuthenticator {
 		}
 		return clientCert;
 	}
-
 }

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtValidatorBuilder.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtValidatorBuilder.java
@@ -15,9 +15,12 @@ import com.sap.cloud.security.token.validation.Validator;
 import com.sap.cloud.security.xsuaa.Assertions;
 import com.sap.cloud.security.xsuaa.client.*;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.sap.cloud.security.config.Service.IAS;
 import static com.sap.cloud.security.config.Service.XSUAA;
@@ -29,15 +32,16 @@ import static com.sap.cloud.security.config.cf.CFConstants.XSUAA.UAA_DOMAIN;
  * Custom validators can be added via {@link #with(Validator)} method.
  */
 public class JwtValidatorBuilder {
-	private static Map<OAuth2ServiceConfiguration, JwtValidatorBuilder> instances = new HashMap<>();
-	private final Collection<Validator<Token>> validators = new ArrayList<>();
-	private final List<ValidationListener> validationListeners = new ArrayList<>();
+	private static Map<OAuth2ServiceConfiguration, JwtValidatorBuilder> instances = new ConcurrentHashMap<>();
+	private final Set<Validator<Token>> validators = new HashSet<>();
+	private final Set<ValidationListener> validationListeners = new HashSet<>();
 	private OAuth2ServiceConfiguration configuration;
 	private final Set<OAuth2ServiceConfiguration> otherConfigurations = new HashSet();
 	private OidcConfigurationService oidcConfigurationService = null;
 	private OAuth2TokenKeyService tokenKeyService = null;
 	private Validator<Token> customAudienceValidator;
 	private CacheConfiguration tokenKeyCacheConfiguration;
+	private static final Logger LOGGER = LoggerFactory.getLogger(JwtValidatorBuilder.class);
 
 	private JwtValidatorBuilder() {
 		// use getInstance factory method
@@ -93,6 +97,7 @@ public class JwtValidatorBuilder {
 	 * @return this builder.
 	 */
 	public JwtValidatorBuilder withAudienceValidator(Validator<Token> audienceValidator) {
+		LOGGER.info("Configures a custom audience validator: {}", audienceValidator.getClass());
 		this.customAudienceValidator = audienceValidator;
 		return this;
 	}

--- a/java-security/src/test/java/com/sap/cloud/security/servlet/XsuaaTokenAuthenticatorTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/servlet/XsuaaTokenAuthenticatorTest.java
@@ -5,12 +5,16 @@
  */
 package com.sap.cloud.security.servlet;
 
+import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
 import com.sap.cloud.security.config.OAuth2ServiceConfigurationBuilder;
 import com.sap.cloud.security.config.Service;
 import com.sap.cloud.security.token.SapIdToken;
 import com.sap.cloud.security.token.SecurityContext;
+import com.sap.cloud.security.token.Token;
 import com.sap.cloud.security.token.XsuaaToken;
-import com.sap.cloud.security.token.validation.ValidationListener;
+import com.sap.cloud.security.token.validation.*;
+import com.sap.cloud.security.token.validation.validators.JwtAudienceValidator;
+import com.sap.cloud.security.token.validation.validators.JwtValidatorBuilder;
 import com.sap.cloud.security.util.HttpClientTestFactory;
 import com.sap.cloud.security.xsuaa.http.HttpHeaders;
 import com.sap.cloud.security.xsuaa.tokenflows.TokenFlowException;
@@ -26,6 +30,7 @@ import org.mockito.Mockito;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 
 import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static com.sap.cloud.security.config.cf.CFConstants.*;
@@ -33,8 +38,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class XsuaaTokenAuthenticatorTest {
 
@@ -305,6 +309,21 @@ public class XsuaaTokenAuthenticatorTest {
 		assertFalse(response[0].isAuthenticated());
 	}
 
+	@Test
+	public void withAudienceValidator_overridesDefaultJwtAudienceValidator() {
+		String errorMessage = "aud didn't match";
+		Validator<Token> validator = mock(Validator.class);
+		when(validator.validate(any())).thenReturn(ValidationResults.createInvalid(errorMessage));
+		cut = new XsuaaTokenAuthenticator()
+				.withHttpClient(mockHttpClient)
+				.withServiceConfiguration(oAuth2ServiceConfigBuilder.build())
+				.withAudienceValidator(validator);
+		TokenAuthenticationResult response = cut.validateRequest(createRequestWithToken(xsuaaToken.getTokenValue()), HTTP_RESPONSE);
+		Mockito.verify(validator, times(1)).validate(any());
+		assertThat(response.isAuthenticated()).isFalse();
+		assertThat(response.getUnauthenticatedReason()).contains(errorMessage);
+	}
+
 	private HttpServletRequest createRequestWithoutToken() {
 		return Mockito.mock(HttpServletRequest.class);
 	}
@@ -314,5 +333,4 @@ public class XsuaaTokenAuthenticatorTest {
 		when(httpRequest.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer " + jwtToken);
 		return httpRequest;
 	}
-
 }


### PR DESCRIPTION
closes #870 

Example:
```java
new XsuaaTokenAuthenticator()
  .withServiceConfiguration(<your service config>)
  .withAudienceValidator(<your custom audience validator of type Validator<Token>>);
```			