### PR TITLE
add dependency-check suppression for CVE-2016-1000027

### DIFF
--- a/etc/suppression.xml
+++ b/etc/suppression.xml
@@ -9,4 +9,9 @@
         ]]></notes>
         <cve>CVE-2018-1258</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[Ignored as vulnerable classes of ^HttpInvoker* are not used in the project]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-*.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Suppresses https://tanzu.vmware.com/security/cve-2022-22978

Unfortunately all the latest spring core versions were flagged by the vulnerability [CVE-2016-100002](https://nvd.nist.gov/vuln/detail/CVE-2016-1000027#vulnConfigurationsArea).

No fix as of now https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-1132113566, but seems to be false positive.

As we don't use any of the [^HttpInvoker* classes](https://docs.spring.io/spring-framework/docs/current/reference/html/integration.html#remoting-httpinvoker) from spring framework in our project, I think it's a false positive in our case and until spring 6.0.0 is out we can suppress it in owasp.dependency-check