### PR TITLE
suppress CVE-2022-22978 

### DIFF
--- a/etc/suppression.xml
+++ b/etc/suppression.xml
@@ -14,4 +14,12 @@
         <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-*.*$</packageUrl>
         <cve>CVE-2016-1000027</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   spring-boot-starter-security-2.7.0.jar is flagged as vulnerable, but the vulnerability is relevant for Spring Security versions below 5.5.7 and 5.6.4
+   Ignored as spring-security 5.7.1 is used which has fix for CVE-2022-22978 https://spring.io/blog/2022/05/15/spring-security-5-7-0-5-6-4-5-5-7-released-fixes-cve-2022-22978-cve-2022-22976
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot\-starter\-security@.*$</packageUrl>
+        <cve>CVE-2022-22978</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
spring-boot-starter-security-2.7.0.jar is flagged as vulnerable, but seems to be false positive as I cannot find any reference where spring-security 5.7.x (which is used in project) would be vulnerable 

References:
https://spring.io/blog/2022/05/15/spring-security-5-7-0-5-6-4-5-5-7-released-fixes-cve-2022-22978-cve-2022-22976
https://nvd.nist.gov/vuln/detail/CVE-2022-22978 