### PR TITLE
Bug fix - NPE in UriUtil.replaceSubdomain()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## 2.13.0
 - [env]
   - Uses https://github.com/SAP/btp-environment-variable-access (version 0.3.1), which supports access to service credentials provisioned by SAP BTP Service Operator. With that there is no service-manager longer required to distinguish by plan, if multiple xsuaa instances are bound.
+- [token-client]
+  - NPE bug fix for `UriUtil.replaceSubdomain(@Nonnull URI, @Nullable subdomain)` in cases when provided URI does not contain host(no http/s schema provided) #943
 
 ## 2.12.3
 [spring-xsuaa][spring-security-compatibility] 

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/util/UriUtil.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/util/UriUtil.java
@@ -51,7 +51,7 @@ public class UriUtil {
 	}
 
 	private static boolean hasSubdomain(URI uri) {
-		return uri.getHost().contains(".");
+		return uri.isAbsolute() && uri.getHost().contains(".");
 	}
 
 	private static boolean hasText(String string) {

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/util/UriUtilTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/util/UriUtilTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 
 public class UriUtilTest {
 
-	private URI tokenEndpointUri = URI.create("https://subdomain.myauth.com/mypath");
+	private final URI tokenEndpointUri = URI.create("https://subdomain.myauth.com/mypath");
 
 	@Test
 	public void replaceSubdomain_replacesNothingWhenSubdomainIsNull() {
@@ -38,5 +38,11 @@ public class UriUtilTest {
 	public void replaceSubdomain_replacesNothingWhenUrlContainsNoSubdomain() {
 		URI replacedURI = UriUtil.replaceSubdomain(URI.create("http://localhost"), "newsubdomain");
 		assertThat(replacedURI.toString(), is("http://localhost"));
+	}
+
+	@Test
+	public void replaceSubdomain_noUrlSchemaGiven() {
+		URI replacedURI = UriUtil.replaceSubdomain(URI.create("localhost"), "newsubdomain");
+		assertThat(replacedURI.toString(), is("localhost"));
 	}
 }


### PR DESCRIPTION
fixes #943

In cases when uri does not contain http/s schema URI instance's `host` class member would be `null` which would lead to NPE thrown in `UriUtil.replaceSubdomain()` method. 