### PR TITLE
Workaround for malformed verificationkey in xsuaa configuration

### DIFF
--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
@@ -40,8 +40,8 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 	private final XsuaaServiceConfiguration xsuaaServiceConfiguration;
 
 	Cache<String, JwtDecoder> cache;
-	private OAuth2TokenValidator<Jwt> tokenValidators;
-	private Collection<PostValidationAction> postValidationActions;
+	private final OAuth2TokenValidator<Jwt> tokenValidators;
+	private final Collection<PostValidationAction> postValidationActions;
 	private TokenInfoExtractor tokenInfoExtractor;
 	private RestOperations restOperations;
 
@@ -188,12 +188,13 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 
 	private Jwt verifyWithVerificationKey(String token, String verificationKey) {
 		try {
-			RSAPublicKey verficationKey = createPublicKey(verificationKey);
-			NimbusJwtDecoder decoder = NimbusJwtDecoder.withPublicKey(verficationKey).build();
+			RSAPublicKey rsaPublicKey = createPublicKey(verificationKey);
+			NimbusJwtDecoder decoder = NimbusJwtDecoder.withPublicKey(rsaPublicKey).build();
 			decoder.setJwtValidator(tokenValidators);
 			return decoder.decode(token);
-		} catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-			throw new BadJwtException(e.getMessage());
+		} catch (NoSuchAlgorithmException | IllegalArgumentException | InvalidKeySpecException e) {
+			logger.debug("Jwt signature validation with fallback verificationkey failed: {}", e.getMessage());
+			throw new BadJwtException("Jwt validation with fallback verificationkey failed");
 		}
 	}
 

--- a/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
+++ b/spring-xsuaa/src/main/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoder.java
@@ -109,8 +109,12 @@ public class XsuaaJwtDecoder implements JwtDecoder {
 			String kid = tokenInfoExtractor.getKid(jwt);
 			String uaaDomain = tokenInfoExtractor.getUaaDomain(jwt);
 			return verifyToken(jwt.getParsedString(), jku, kid, uaaDomain);
-		} catch (JwtException e) {
-			return tryToVerifyWithVerificationKey(jwt.getParsedString(), e);
+		} catch (BadJwtException e) {
+			if (e.getMessage().contains("Couldn't retrieve remote JWK set") || e.getMessage().contains("Cannot verify with online token key, uaadomain is")) {
+				return tryToVerifyWithVerificationKey(jwt.getParsedString(), e);
+			} else {
+				throw e;
+			}
 		}
 	}
 

--- a/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderTest.java
+++ b/spring-xsuaa/src/test/java/com/sap/cloud/security/xsuaa/token/authentication/XsuaaJwtDecoderTest.java
@@ -14,6 +14,7 @@ import com.sap.cloud.security.xsuaa.token.TokenClaims;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -47,6 +48,18 @@ public class XsuaaJwtDecoderTest {
 		jwt.getClaimAsString("zid");
 
 		assertThat(jwt.getClaimAsString(TokenClaims.CLAIM_CLIENT_ID)).isEqualTo("sb-clientId!t0815");
+	}
+
+	@Test
+	public void decode_withInvalidVerificationKey() throws IOException {
+		XsuaaServiceConfiguration config = Mockito.mock(XsuaaServiceConfiguration.class);
+		Mockito.when(config.getVerificationKey()).thenReturn("xsuaa.verificationkey=-----BEGIN PUBLIC KEY-----MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm1QaZzMjtEfHdimrHP3/2Yr+1z685eiOUlwybRVG9i8wsgOUh+PUGuQL8hgulLZWXU5MbwBLTECAEMQbcRTNVTolkq4i67EP6JesHJIFADbK1Ni0KuMcPuiyOLvDKiDEMnYG1XP3X3WCNfsCVT9YoU+lWIrZr/ZsIvQri8jczr4RkynbTBsPaAOygPUlipqDrpadMO1momNCbea/o6GPn38LxEw609ItfgDGhL6f/yVid5pFzZQWb+9l6mCuJww0hnhO6gt6Rv98OWDty9G0frWAPyEfuIW9B+mR/2vGhyU9IbbWpvFXiy9RVbbsM538TCjd5JF2dJvxy24addC4oQIDAQAB-----END PUBLIC KEY-----");
+
+		String token = IOUtils.resourceToString("/accessTokenRSA256WithVerificationKey.txt", StandardCharsets.UTF_8);
+		final JwtDecoder cut = new XsuaaJwtDecoderBuilder(config).build();
+
+		assertThatThrownBy(() -> cut.decode(token)).isInstanceOf(JwtException.class)
+				.hasMessageContaining("Jwt validation with fallback verificationkey failed");
 	}
 
 	@Test


### PR DESCRIPTION
- As a workaround for cases when xsuaa service configuration `verificationkey` attribute is malformed and throws `IllegalArgumentException` when decoding RSA public key, `XsuaaJwtDecoder` will catch `IllegalArgumentException` to avoid 500 error to be thrown by it. 
>RC of such malformed `verificationkey` remains unclear as the affected user could not provide service configuration details, therefore this is a workaround not an actual fix

- introduce stricter rule for fallback verificationkey validation