### PR TITLE
fix: Correct token exchange logic for App2App flows in DefaultIdToken…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 3.6.9
+
+- Fix token exchange logic in `DefaultIdTokenExtension` to correctly identify App2App tokens that require exchange (where `aud` contains a single audience different from `azp`)
+
 ## 3.6.8
 
 - Fix hybrid authentication issue where IAS Configuration was incorrectly used for XSUAA token exchange instead of XSUAA Configuration in `HybridIdentityServicesAutoConfiguration`

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The SAP Cloud Security Services Integration is published to maven central: https
         <dependency>
             <groupId>com.sap.cloud.security</groupId>
             <artifactId>java-bom</artifactId>
-            <version>3.6.8</version>
+            <version>3.6.9</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-bom</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
     <packaging>pom</packaging>
     <name>java-bom</name>
 

--- a/env/pom.xml
+++ b/env/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>3.6.8</version>
+        <version>3.6.9</version>
     </parent>
 
     <groupId>com.sap.cloud.security</groupId>

--- a/java-api/README.md
+++ b/java-api/README.md
@@ -5,6 +5,6 @@
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-api</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
 </dependency>
 ```

--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.8</version>
+		<version>3.6.9</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security-it/pom.xml
+++ b/java-security-it/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
-        <version>3.6.8</version>
+        <version>3.6.9</version>
     </parent>
 
     <artifactId>java-security-it</artifactId>

--- a/java-security-test/README.md
+++ b/java-security-test/README.md
@@ -40,7 +40,7 @@ It is pre-configured with a security filter that only accepts valid tokens. Furt
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
    <artifactId>java-security-test</artifactId>
-      <version>3.6.8</version>
+      <version>3.6.9</version>
    <scope>test</scope>
 </dependency>
 ```

--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.8</version>
+		<version>3.6.9</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -69,7 +69,7 @@ Since it requires the Tomcat 10 runtime, it needs to be deployed using the [SAP 
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-security</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.8</version>
+		<version>3.6.9</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/src/main/java/com/sap/cloud/security/token/DefaultIdTokenExtension.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/DefaultIdTokenExtension.java
@@ -111,7 +111,7 @@ public class DefaultIdTokenExtension implements IdTokenExtension {
    */
   private boolean isAccessToken(Token token) {
     final List<String> audiences = token.getClaimAsStringList("aud");
-    return audiences.size() == 1 && audiences.get(0).equals(token.getClientId());
+    return audiences.size() == 1 && !audiences.get(0).equals(token.getClientId());
   }
 
   /**

--- a/java-security/src/test/java/com/sap/cloud/security/token/DefaultIdTokenExtensionTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/DefaultIdTokenExtensionTest.java
@@ -58,7 +58,7 @@ public class DefaultIdTokenExtensionTest {
     String audience = "audience";
     when(idToken.getClaimAsStringList("aud")).thenReturn(List.of(audience, clientId));
     when(idToken.getClientId()).thenReturn(clientId);
-    when(accessToken.getClaimAsStringList("aud")).thenReturn(List.of(clientId));
+    when(accessToken.getClaimAsStringList("aud")).thenReturn(List.of(audience));
     when(accessToken.getClientId()).thenReturn(clientId);
     when(technicalUserToken.getClaimAsString("sub")).thenReturn(clientId);
     when(technicalUserToken.getClientId()).thenReturn(clientId);

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>com.sap.cloud.security.xsuaa</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.6.8</version>
+	<version>3.6.9</version>
 	<packaging>pom</packaging>
 
 	<name>parent</name>

--- a/samples/java-security-usage-ias/pom.xml
+++ b/samples/java-security-usage-ias/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage-ias</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
     <packaging>war</packaging>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -42,7 +42,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <sap.cloud.security.version>3.6.8</sap.cloud.security.version>
+        <sap.cloud.security.version>3.6.9</sap.cloud.security.version>
         <slf4j.api.version>2.0.5</slf4j.api.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>

--- a/samples/java-security-usage/pom.xml
+++ b/samples/java-security-usage/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
     <packaging>war</packaging>
 
     <!--profiles>
@@ -57,7 +57,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <sap.cloud.security.version>3.6.8</sap.cloud.security.version>
+        <sap.cloud.security.version>3.6.9</sap.cloud.security.version>
         <slf4j.api.version>2.0.5</slf4j.api.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>

--- a/samples/java-tokenclient-usage/pom.xml
+++ b/samples/java-tokenclient-usage/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-tokenclient-usage</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
     <packaging>war</packaging>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -41,7 +41,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <sap.cloud.security.version>3.6.8</sap.cloud.security.version>
+        <sap.cloud.security.version>3.6.9</sap.cloud.security.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
         <slf4j.api.version>2.0.5</slf4j.api.version>

--- a/samples/sap-java-buildpack-api-usage/pom.xml
+++ b/samples/sap-java-buildpack-api-usage/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.cloud.security.xssec.samples</groupId>
 	<artifactId>sap-java-buildpack-api-usage</artifactId>
-	<version>3.6.8</version>
+	<version>3.6.9</version>
 	<packaging>war</packaging>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/samples/spring-security-basic-auth/pom.xml
+++ b/samples/spring-security-basic-auth/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<artifactId>spring-security-basic-auth</artifactId>
-	<version>3.6.8</version>
+	<version>3.6.9</version>
 	<name>spring-security-basic-auth</name>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -50,7 +50,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.6.8</sap.cloud.security.version>
+		<sap.cloud.security.version>3.6.9</sap.cloud.security.version>
 		<spring.boot.version>3.5.3</spring.boot.version>
 	</properties>
 
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>com.sap.cloud.security</groupId>
 			<artifactId>java-security-test</artifactId>
-			<version>3.6.8</version>
+			<version>3.6.9</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/samples/spring-security-hybrid-usage/pom.xml
+++ b/samples/spring-security-hybrid-usage/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-hybrid-usage</artifactId>
-	<version>3.6.8</version>
+	<version>3.6.9</version>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring security hybrid usage sample</description>
@@ -57,7 +57,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.6.8</sap.cloud.security.version>
+		<sap.cloud.security.version>3.6.9</sap.cloud.security.version>
 		<apache.httpclient.version>4.5.14</apache.httpclient.version>
 		<spring.boot.version>3.5.3</spring.boot.version>
 	</properties>

--- a/samples/spring-security-xsuaa-usage/pom.xml
+++ b/samples/spring-security-xsuaa-usage/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-xsuaa-usage</artifactId>
-	<version>3.6.8</version>
+	<version>3.6.9</version>
 	<name>spring-security-xsuaa-usage</name>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -58,7 +58,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<sap.cloud.security.version>3.6.8</sap.cloud.security.version>
+		<sap.cloud.security.version>3.6.9</sap.cloud.security.version>
 		<http.client5>5.2.1</http.client5>
 		<spring.boot.version>3.5.3</spring.boot.version>
 	</properties>

--- a/samples/spring-webflux-security-hybrid-usage/pom.xml
+++ b/samples/spring-webflux-security-hybrid-usage/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.sap.cloud.security.samples</groupId>
     <artifactId>spring-webflux-security-hybrid-usage</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
     <name>spring-webflux-security-hybrid-usage</name>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -49,7 +49,7 @@
     </scm>
     <properties>
         <java.version>17</java.version>
-        <sap.cloud.security.version>3.6.8</sap.cloud.security.version>
+        <sap.cloud.security.version>3.6.9</sap.cloud.security.version>
         <spring.boot.version>3.5.3</spring.boot.version>
         <junit.version>4.13.2</junit.version>
     </properties>

--- a/spring-security-compatibility/pom.xml
+++ b/spring-security-compatibility/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>3.6.8</version>
+        <version>3.6.9</version>
     </parent>
 
     <groupId>com.sap.cloud.security.xsuaa</groupId>

--- a/spring-security-starter/pom.xml
+++ b/spring-security-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.8</version>
+		<version>3.6.9</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/spring-security/Migration_SpringXsuaaProjects.md
+++ b/spring-security/Migration_SpringXsuaaProjects.md
@@ -157,7 +157,7 @@ It is provided in an extra module. This maven dependency needs to be provided ad
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-security-compatibility</artifactId>
-  <version>3.6.8</version>
+  <version>3.6.9</version>
 </dependency>
 ```
 

--- a/spring-security/README.md
+++ b/spring-security/README.md
@@ -68,7 +68,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
 </dependency>
 ```
 

--- a/spring-security/pom.xml
+++ b/spring-security/pom.xml
@@ -9,14 +9,14 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.8</version>
+		<version>3.6.9</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>
 	<artifactId>spring-security</artifactId>
 	<name>spring-security</name>
 	<packaging>jar</packaging>
-	<version>3.6.8</version>
+	<version>3.6.9</version>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring security library</description>

--- a/spring-xsuaa-it/pom.xml
+++ b/spring-xsuaa-it/pom.xml
@@ -14,7 +14,7 @@
 
 	<artifactId>spring-xsuaa-it</artifactId>
 	<name>spring-xsuaa-it</name>
-	<version>3.6.8</version>
+	<version>3.6.9</version>
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring XSUAA IT library</description>
 

--- a/spring-xsuaa-starter/pom.xml
+++ b/spring-xsuaa-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.8</version>
+		<version>3.6.9</version>
 	</parent>
 
 	<artifactId>xsuaa-spring-boot-starter</artifactId>

--- a/spring-xsuaa-test/README.md
+++ b/spring-xsuaa-test/README.md
@@ -31,7 +31,7 @@ This includes for example a `JwtGenerator` that generates JSON Web Tokens (JWT) 
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa-test</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
     <scope>test</scope>
 </dependency>
 

--- a/spring-xsuaa-test/pom.xml
+++ b/spring-xsuaa-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.8</version>
+		<version>3.6.9</version>
 	</parent>
 
 	<artifactId>spring-xsuaa-test</artifactId>

--- a/spring-xsuaa/README.md
+++ b/spring-xsuaa/README.md
@@ -39,7 +39,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
 </dependency>
 <dependency> <!-- new with version 1.5.0 -->
     <groupId>org.apache.logging.log4j</groupId>
@@ -53,7 +53,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>xsuaa-spring-boot-starter</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
 </dependency>
 ```
 

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.8</version>
+		<version>3.6.9</version>
 	</parent>
 
 	<artifactId>spring-xsuaa</artifactId>

--- a/token-client/README.md
+++ b/token-client/README.md
@@ -52,7 +52,7 @@ In context of a Spring Boot application you can leverage autoconfiguration provi
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
 </dependency>
 ```
 In context of Spring Applications you will need the following dependencies:
@@ -60,7 +60,7 @@ In context of Spring Applications you will need the following dependencies:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>
@@ -127,7 +127,7 @@ See the [OAuth2ServiceConfiguration](#oauth2serviceconfiguration) section and [H
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>3.6.8</version>
+    <version>3.6.9</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/token-client/pom.xml
+++ b/token-client/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.6.8</version>
+		<version>3.6.9</version>
 	</parent>
 
 	<artifactId>token-client</artifactId>


### PR DESCRIPTION
…Extension

The isAccessToken() method had inverted logic that prevented proper token exchange for App2App scenarios. Tokens with a single audience different from the client ID (aud != azp) now correctly trigger token exchange, while internal tokens (aud == azp) are properly recognized and skip exchange.

This fixes scenarios where App2App access tokens were incorrectly treated as ID tokens and bypassed the necessary exchange flow.

Version bumped to 3.6.9 for bugfix release.