### PR TITLE
feat: Add token-client-spring-3 module for Spring Boot 3.x compatibility

### DIFF
--- a/MIGRATION_4.0.md
+++ b/MIGRATION_4.0.md
@@ -344,7 +344,7 @@ If you use any of these classes, add the new dependency:
 
 **Solution:** Ensure all Spring Boot dependencies match your chosen version:
 - For Spring Boot 4.x: Use `resourceserver-security-spring-boot-starter`
-- For Spring Boot 3.x: Use `resourceserver-security-spring-boot-starter-legacy`
+- For Spring Boot 3.x: Use `resourceserver-security-spring-boot-3-starter`
 
 ### Test Failures After Migration
 
@@ -361,7 +361,7 @@ If you use any of these classes, add the new dependency:
 
 **Solution:** Ensure you're using the correct starter:
 - Spring Boot 4.x: `resourceserver-security-spring-boot-starter`
-- Spring Boot 3.x: `resourceserver-security-spring-boot-starter-legacy`
+- Spring Boot 3.x: `resourceserver-security-spring-boot-3-starter`
 
 ### Custom HTTP Client Not Used
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ In the table below you'll find links to detailed information.
 | Library                                   | Usage Examples                                                                                                                                                                                                                                         |
 |-------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [token-client](/token-client)             | [java-tokenclient-usage](samples/java-tokenclient-usage) demonstrates usage of token client library in Jakarta EE application<br/>[spring-security-hybrid-usage](samples/spring-security-hybrid-usage) demonstrates usage in Spring Boot application     |
-| [token-client-spring](/token-client-spring) | Spring-based implementations of OAuth2 token services. Required if you use `XsuaaOAuth2TokenService`, `SpringOAuth2TokenKeyService`, or `SpringOidcConfigurationService`.     |              
+| [token-client-spring](/token-client-spring) | Spring-based implementations of OAuth2 token services for **Spring Boot 4.x**. Required if you use `XsuaaOAuth2TokenService`, `SpringOAuth2TokenKeyService`, or `SpringOidcConfigurationService`.     |
+| [token-client-spring-3](/token-client-spring-3) | Spring-based implementations of OAuth2 token services for **Spring Boot 3.x**. Use this instead of `token-client-spring` if your application uses Spring Boot 3.x.     |              
 
 ### 2.3 Testing utilities
 For authentication/authorization flow testing purposes there is [java-security-test](/java-security-test) library at your disposal that can be used for unit and integration tests to test the Xsuaa or Identity service client functionality in the application. 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -96,6 +96,11 @@
                 <artifactId>token-client-spring</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>${xsuaa-groupId}</groupId>
+                <artifactId>token-client-spring-3</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
 		<module>env</module>
 		<module>token-client</module>
 		<module>token-client-spring</module>
+		<module>token-client-spring-3</module>
 		<module>java-security</module>
 		<module>spring-security</module>
 		<module>spring-security-3</module>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
 		<spring.security.version>7.0.3</spring.security.version>
 		<spring.security.oauth2.version>7.0.3</spring.security.oauth2.version>
 		<spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>
+		<!-- Spring Boot 3.x / Spring Framework 6.x compatibility versions for legacy modules -->
+		<legacy3.spring.boot.version>3.5.9</legacy3.spring.boot.version>
+		<legacy3.spring.core.version>6.2.15</legacy3.spring.core.version>
+		<legacy3.spring.security.version>6.5.7</legacy3.spring.security.version>
+		<legacy3.spring.security.oauth2.version>6.5.7</legacy3.spring.security.oauth2.version>
+		<legacy3.reactor.version>3.8.2</legacy3.reactor.version>
 		<org.eclipse.jetty.version>12.1.7</org.eclipse.jetty.version>
 		<reactor.version>3.8.3</reactor.version>
 		<log4j2.version>2.25.3</log4j2.version>

--- a/spring-security-3-starter/pom.xml
+++ b/spring-security-3-starter/pom.xml
@@ -58,9 +58,9 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		<!-- Override parent's Spring Boot 4.x with Spring Boot 3.x for legacy compatibility -->
-		<spring.boot.version>3.5.9</spring.boot.version>
-		<spring.security.version>6.5.7</spring.security.version>
-		<spring.security.oauth2.version>6.5.7</spring.security.oauth2.version>
+		<spring.boot.version>${legacy3.spring.boot.version}</spring.boot.version>
+		<spring.security.version>${legacy3.spring.security.version}</spring.security.version>
+		<spring.security.oauth2.version>${legacy3.spring.security.oauth2.version}</spring.security.oauth2.version>
 	</properties>
 
 	<dependencies>

--- a/spring-security-3/pom.xml
+++ b/spring-security-3/pom.xml
@@ -50,12 +50,12 @@
 
 	<properties>
 		<!-- Override parent's Spring Boot 4.x with Spring Boot 3.x for legacy compatibility -->
-		<spring.boot.version>3.5.9</spring.boot.version>
-		<spring.core.version>6.2.15</spring.core.version>
-		<spring.security.version>6.5.7</spring.security.version>
-		<spring.security.oauth2.version>6.5.7</spring.security.oauth2.version>
-		<reactor.version>3.8.2</reactor.version>
-		<reactor.test.version>3.8.2</reactor.test.version>
+		<spring.boot.version>${legacy3.spring.boot.version}</spring.boot.version>
+		<spring.core.version>${legacy3.spring.core.version}</spring.core.version>
+		<spring.security.version>${legacy3.spring.security.version}</spring.security.version>
+		<spring.security.oauth2.version>${legacy3.spring.security.oauth2.version}</spring.security.oauth2.version>
+		<reactor.version>${legacy3.reactor.version}</reactor.version>
+		<reactor.test.version>${legacy3.reactor.version}</reactor.test.version>
 	</properties>
 
 	<dependencies>
@@ -63,19 +63,19 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-jose</artifactId>
 			<scope>provided</scope>
-			<version>6.5.7</version>
+			<version>${spring.security.oauth2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-resource-server</artifactId>
 			<scope>provided</scope>
-			<version>6.5.7</version>
+			<version>${spring.security.oauth2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure</artifactId>
 			<scope>provided</scope>
-			<version>3.5.9</version>
+			<version>${spring.boot.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.cloud.security</groupId>
@@ -156,7 +156,7 @@
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
-			<version>3.8.2</version>
+			<version>${reactor.version}</version>
 		</dependency>
 
 		<!-- test utilities -->
@@ -182,19 +182,19 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
-			<version>3.5.9</version>
+			<version>${spring.boot.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-tomcat</artifactId>
 			<scope>test</scope>
-			<version>3.5.9</version>
+			<version>${spring.boot.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
-			<version>3.8.2</version>
+			<version>${reactor.test.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/token-client-spring-3/README.md
+++ b/token-client-spring-3/README.md
@@ -1,0 +1,54 @@
+# Token Client Spring 3
+
+This module provides Spring-based implementations of the OAuth2 token service interfaces from the [token-client](../token-client) module, compiled against **Spring Framework 6.x** for **Spring Boot 3.x** compatibility.
+
+## Overview
+
+This module is the Spring Boot 3.x compatible version of [token-client-spring](../token-client-spring). Use this module if your application uses Spring Boot 3.x (Spring Framework 6.x).
+
+| Module | Spring Boot | Spring Framework |
+|--------|-------------|------------------|
+| `token-client-spring` | 4.x | 7.x |
+| `token-client-spring-3` | 3.x | 6.x |
+
+## Classes
+
+| Class | Description |
+|-------|-------------|
+| `XsuaaOAuth2TokenService` | Spring RestOperations-based implementation of `OAuth2TokenService` for token retrieval |
+| `SpringOAuth2TokenKeyService` | Spring RestOperations-based implementation of `OAuth2TokenKeyService` for token key retrieval |
+| `SpringOidcConfigurationService` | Spring RestOperations-based implementation of `OidcConfigurationService` for OIDC discovery |
+
+## Maven Dependency
+
+```xml
+<dependency>
+    <groupId>com.sap.cloud.security.xsuaa</groupId>
+    <artifactId>token-client-spring-3</artifactId>
+    <version>4.0.1</version>
+</dependency>
+```
+
+**Note:** This module has `spring-web` (6.x) as a `provided` dependency. Your application must include Spring Web in its classpath.
+
+## Usage
+
+These classes require a Spring `RestOperations` instance (e.g., `RestTemplate`):
+
+```java
+import com.sap.cloud.security.xsuaa.client.XsuaaOAuth2TokenService;
+import org.springframework.web.client.RestTemplate;
+
+RestTemplate restTemplate = new RestTemplate();
+XsuaaOAuth2TokenService tokenService = new XsuaaOAuth2TokenService(restTemplate);
+```
+
+## When to Use
+
+Use this module if:
+- Your application uses **Spring Boot 3.x** (not 4.x)
+- You need Spring RestOperations integration for token flows
+
+For Spring Boot 4.x applications, use [token-client-spring](../token-client-spring) instead.
+
+For most use cases, the default `DefaultOAuth2TokenService` from `token-client` (using Java 11 HttpClient) is recommended as it has no external dependencies.

--- a/token-client-spring-3/pom.xml
+++ b/token-client-spring-3/pom.xml
@@ -48,7 +48,7 @@
 
 	<properties>
 		<!-- Override parent's Spring Boot 4.x with Spring Boot 3.x for legacy compatibility -->
-		<spring.core.version>6.2.15</spring.core.version>
+		<spring.core.version>${legacy3.spring.core.version}</spring.core.version>
 	</properties>
 
 	<dependencies>

--- a/token-client-spring-3/pom.xml
+++ b/token-client-spring-3/pom.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.1 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.sap.cloud.security.xsuaa</groupId>
+		<artifactId>parent</artifactId>
+		<version>4.0.1</version>
+	</parent>
+
+	<artifactId>token-client-spring-3</artifactId>
+	<name>token-client-spring-3</name>
+	<packaging>jar</packaging>
+
+	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
+	<description>Spring-based Token Client implementations for OAuth2 token services (Spring Boot 3.x compatibility)</description>
+
+	<organization>
+		<name>SAP SE</name>
+		<url>https://www.sap.com</url>
+	</organization>
+
+	<licenses>
+		<license>
+			<name>The Apache Software License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>Identity Service Development</name>
+			<email>xsuaa-development@sap.com</email>
+			<organization>SAP SE</organization>
+			<organizationUrl>https://www.sap.com</organizationUrl>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:git://github.com/SAP/cloud-security-xsuaa-integration.git</connection>
+		<developerConnection>scm:git:ssh//github.com/SAP/cloud-security-xsuaa-integration.git</developerConnection>
+		<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
+	</scm>
+
+	<properties>
+		<!-- Override parent's Spring Boot 4.x with Spring Boot 3.x for legacy compatibility -->
+		<spring.core.version>6.2.15</spring.core.version>
+	</properties>
+
+	<dependencies>
+		<!-- Depends on token-client for interfaces and base classes -->
+		<dependency>
+			<groupId>com.sap.cloud.security.xsuaa</groupId>
+			<artifactId>token-client</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.annotation</groupId>
+			<artifactId>jakarta.annotation-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<!-- Spring Web - provided scope, using Spring 6.x for Spring Boot 3.x compatibility -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+			<scope>provided</scope>
+			<version>${spring.core.version}</version>
+		</dependency>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+			<version>${junit-jupiter.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<scope>test</scope>
+			<version>${junit-jupiter.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-all</artifactId>
+			<scope>test</scope>
+			<version>${hamcrest.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+			<version>${mockito.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+			<version>${assertj.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.4.14</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-core</artifactId>
+			<version>1.5.25</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock-standalone</artifactId>
+			<scope>test</scope>
+			<version>${wiremock.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>${commons.io.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>${maven.source.plugin.version}</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/token-client-spring-3/src/main/java/com/sap/cloud/security/xsuaa/client/SpringOAuth2TokenKeyService.java
+++ b/token-client-spring-3/src/main/java/com/sap/cloud/security/xsuaa/client/SpringOAuth2TokenKeyService.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client
+ * Java contributors
+ *
+ * <p>SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.client;
+
+import static org.springframework.http.HttpMethod.GET;
+
+import com.sap.cloud.security.client.DefaultTokenClientConfiguration;
+import com.sap.cloud.security.util.LogSanitizer;
+import com.sap.cloud.security.xsuaa.Assertions;
+import com.sap.cloud.security.xsuaa.util.HttpClientUtil;
+import jakarta.annotation.Nonnull;
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestOperations;
+
+public class SpringOAuth2TokenKeyService implements OAuth2TokenKeyService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SpringOAuth2TokenKeyService.class);
+  private final DefaultTokenClientConfiguration config;
+  private final RestOperations restOperations;
+
+  public SpringOAuth2TokenKeyService(@Nonnull final RestOperations restOperations) {
+    Assertions.assertNotNull(restOperations, "restOperations must not be null!");
+    this.restOperations = restOperations;
+    this.config = DefaultTokenClientConfiguration.getInstance();
+  }
+
+  @Override
+  public String retrieveTokenKeys(
+      @Nonnull final URI tokenKeysEndpointUri, final Map<String, String> params)
+      throws OAuth2ServiceException {
+    Assertions.assertNotNull(tokenKeysEndpointUri, "Token key endpoint must not be null!");
+    validateUri(tokenKeysEndpointUri);
+    return executeRequest(
+        tokenKeysEndpointUri, params, config.isRetryEnabled() ? config.getMaxRetryAttempts() : 0);
+  }
+
+  private void validateUri(final URI uri) throws OAuth2ServiceException {
+    String scheme = uri.getScheme();
+    if (scheme == null || (!scheme.equalsIgnoreCase("https") && !scheme.equalsIgnoreCase("http"))) {
+      throw OAuth2ServiceException.builder("Invalid URI scheme. Only HTTP/HTTPS are allowed.")
+          .withUri(uri)
+          .build();
+    }
+
+    String host = uri.getHost();
+    if (host == null || host.isEmpty()) {
+      throw OAuth2ServiceException.builder("Invalid URI: missing host.")
+          .withUri(uri)
+          .build();
+    }
+  }
+
+  private String executeRequest(
+      final URI tokenKeysEndpointUri, final Map<String, String> params, final int attemptsLeft)
+      throws OAuth2ServiceException {
+    final HttpHeaders headers = getHttpHeaders(params);
+    LOGGER.debug(
+        "Requesting access token from url='{}' with headers={} and {} retries left",
+        LogSanitizer.sanitize(tokenKeysEndpointUri),
+        LogSanitizer.sanitize(headers.toSingleValueMap()),
+        attemptsLeft);
+    try {
+      final ResponseEntity<String> responseEntity =
+          restOperations.exchange(
+              tokenKeysEndpointUri, GET, new HttpEntity<>(headers), String.class);
+      final int statusCode = responseEntity.getStatusCode().value();
+      LOGGER.debug("Received statusCode {}", statusCode);
+      if (HttpStatus.OK.value() == statusCode) {
+        LOGGER.debug(
+            "Successfully retrieved token keys from {} for params '{}'",
+            LogSanitizer.sanitize(tokenKeysEndpointUri),
+            LogSanitizer.sanitize(params));
+        return responseEntity.getBody();
+      } else if (attemptsLeft > 0 && config.getRetryStatusCodes().contains(statusCode)) {
+        LOGGER.warn("Request failed with status {} but is retryable. Retrying...", statusCode);
+        pauseBeforeNextAttempt(config.getRetryDelayTime());
+        return executeRequest(tokenKeysEndpointUri, params, attemptsLeft - 1);
+      }
+      throw OAuth2ServiceException.builder("Error retrieving token keys.")
+          .withUri(tokenKeysEndpointUri)
+          .withRequestHeaders(getHeadersAsStringArray(headers))
+          .withResponseHeaders(getHeadersAsStringArray(responseEntity.getHeaders()))
+          .withStatusCode(responseEntity.getStatusCode().value())
+          .withResponseBody(responseEntity.getBody())
+          .build();
+    } catch (final HttpStatusCodeException ex) {
+      throw OAuth2ServiceException.builder("Error retrieving token keys.")
+          .withUri(tokenKeysEndpointUri)
+          .withRequestHeaders(getHeadersAsStringArray(headers))
+          .withStatusCode(ex.getStatusCode().value())
+          .withResponseBody(ex.getResponseBodyAsString())
+          .build();
+    } catch (final Exception e) {
+      if (e instanceof final OAuth2ServiceException oAuth2ServiceException) {
+        throw oAuth2ServiceException;
+      } else {
+        throw OAuth2ServiceException.builder("Unexpected error retrieving token keys!")
+            .withUri(tokenKeysEndpointUri)
+            .withRequestHeaders(getHeadersAsStringArray(headers))
+            .withResponseBody(e.getMessage())
+            .build();
+      }
+    }
+  }
+
+  private static String[] getHeadersAsStringArray(
+      final HttpHeaders headers) {
+    if (headers == null) {
+      return new String[0];
+    }
+    return headers.toSingleValueMap().entrySet().stream()
+        .map(e -> e.getKey() + ": " + e.getValue())
+        .toArray(String[]::new);
+  }
+
+  private HttpHeaders getHttpHeaders(final Map<String, String> params) {
+    final HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+    headers.set(HttpHeaders.USER_AGENT, HttpClientUtil.getUserAgent());
+    for (final Map.Entry<String, String> p : params.entrySet()) {
+      headers.set(p.getKey(), p.getValue());
+    }
+    return headers;
+  }
+
+  private void pauseBeforeNextAttempt(final long sleepTime) {
+    try {
+      LOGGER.info("Retry again in {} ms", sleepTime);
+      Thread.sleep(sleepTime);
+    } catch (final InterruptedException e) {
+      LOGGER.warn("Thread.sleep has been interrupted. Retry starts now.");
+    }
+  }
+}

--- a/token-client-spring-3/src/main/java/com/sap/cloud/security/xsuaa/client/SpringOidcConfigurationService.java
+++ b/token-client-spring-3/src/main/java/com/sap/cloud/security/xsuaa/client/SpringOidcConfigurationService.java
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client
+ * Java contributors
+ *
+ * <p>SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.client;
+
+import com.sap.cloud.security.client.DefaultTokenClientConfiguration;
+import com.sap.cloud.security.xsuaa.Assertions;
+import com.sap.cloud.security.xsuaa.util.HttpClientUtil;
+import jakarta.annotation.Nonnull;
+import java.net.URI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.*;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestOperations;
+
+public class SpringOidcConfigurationService implements OidcConfigurationService {
+  private final RestOperations restOperations;
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(SpringOidcConfigurationService.class);
+  private final DefaultTokenClientConfiguration config;
+
+  public SpringOidcConfigurationService(@Nonnull final RestOperations restOperations) {
+    Assertions.assertNotNull(restOperations, "restOperations must not be null!");
+    this.restOperations = restOperations;
+    this.config = DefaultTokenClientConfiguration.getInstance();
+  }
+
+  @Override
+  public OAuth2ServiceEndpointsProvider retrieveEndpoints(@Nonnull final URI discoveryEndpointUri)
+      throws OAuth2ServiceException {
+    Assertions.assertNotNull(discoveryEndpointUri, "discoveryEndpointUri must not be null!");
+    return executeRequest(
+        discoveryEndpointUri, config.isRetryEnabled() ? config.getMaxRetryAttempts() : 0);
+  }
+
+  private OAuth2ServiceEndpointsProvider executeRequest(
+      final URI discoveryEndpointUri, final int attemptsLeft) throws OAuth2ServiceException {
+    final HttpHeaders headers = new HttpHeaders();
+    headers.set(HttpHeaders.USER_AGENT, HttpClientUtil.getUserAgent());
+    LOGGER.debug(
+        "Retrieving configured oidc endpoints: {} with headers {} and {} retries left",
+        discoveryEndpointUri,
+        headers,
+        attemptsLeft);
+    try {
+      final ResponseEntity<String> responseEntity =
+          restOperations.exchange(
+              discoveryEndpointUri, HttpMethod.GET, new HttpEntity(headers), String.class);
+      final int statusCode = responseEntity.getStatusCode().value();
+      LOGGER.debug("Received statusCode {}", statusCode);
+      if (HttpStatus.OK.value() == statusCode) {
+        LOGGER.debug(
+            "Successfully retrieved configured oidc endpoints from {}", discoveryEndpointUri);
+        return new DefaultOidcConfigurationService.OidcEndpointsProvider(responseEntity.getBody());
+      } else if (attemptsLeft > 0 && config.getRetryStatusCodes().contains(statusCode)) {
+        LOGGER.warn("Request failed with status {} but is retryable. Retrying...", statusCode);
+        pauseBeforeNextAttempt(config.getRetryDelayTime());
+        return executeRequest(discoveryEndpointUri, attemptsLeft - 1);
+      }
+      throw OAuth2ServiceException.builder("Error retrieving configured oidc endpoints")
+          .withUri(discoveryEndpointUri)
+          .withRequestHeaders(getHeadersAsStringArray(headers))
+          .withResponseHeaders(getHeadersAsStringArray(responseEntity.getHeaders()))
+          .withStatusCode(statusCode)
+          .withResponseBody(responseEntity.getBody())
+          .build();
+    } catch (final HttpClientErrorException ex) {
+      throw OAuth2ServiceException.builder("Error retrieving configured oidc endpoints")
+          .withUri(discoveryEndpointUri)
+          .withRequestHeaders(getHeadersAsStringArray(headers))
+          .withResponseBody(ex.getResponseBodyAsString())
+          .withStatusCode(ex.getStatusCode().value())
+          .build();
+    }
+  }
+
+  private void pauseBeforeNextAttempt(final long sleepTime) {
+    try {
+      LOGGER.info("Retry again in {} ms", sleepTime);
+      Thread.sleep(sleepTime);
+    } catch (final InterruptedException e) {
+      LOGGER.warn("Thread.sleep has been interrupted. Retry starts now.");
+    }
+  }
+
+  private static String[] getHeadersAsStringArray(
+      final HttpHeaders headers) {
+    if (headers == null) {
+      return new String[0];
+    }
+    return headers.toSingleValueMap().entrySet().stream()
+        .map(e -> e.getKey() + ": " + e.getValue())
+        .toArray(String[]::new);
+  }
+}

--- a/token-client-spring-3/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenService.java
+++ b/token-client-spring-3/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenService.java
@@ -1,0 +1,195 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client
+ * Java contributors
+ *
+ * <p>SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.client;
+
+import static com.sap.cloud.security.xsuaa.Assertions.assertNotNull;
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
+
+import com.sap.cloud.security.client.DefaultTokenClientConfiguration;
+import com.sap.cloud.security.servlet.MDCHelper;
+import com.sap.cloud.security.xsuaa.http.HttpHeaders;
+import com.sap.cloud.security.xsuaa.tokenflows.TokenCacheConfiguration;
+import com.sap.cloud.security.xsuaa.util.HttpClientUtil;
+import jakarta.annotation.Nonnull;
+import java.net.URI;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/** Implementation for Spring applications, that uses {@link RestOperations}. */
+public class XsuaaOAuth2TokenService extends AbstractOAuth2TokenService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(XsuaaOAuth2TokenService.class);
+  private final RestOperations restOperations;
+  private final DefaultTokenClientConfiguration config;
+
+  public XsuaaOAuth2TokenService(@Nonnull final RestOperations restOperations) {
+    this(restOperations, TokenCacheConfiguration.defaultConfiguration());
+  }
+
+  public XsuaaOAuth2TokenService(
+      @Nonnull final RestOperations restOperations,
+      @Nonnull final TokenCacheConfiguration tokenCacheConfiguration) {
+    super(tokenCacheConfiguration);
+    assertNotNull(restOperations, "restOperations is required");
+    this.restOperations = restOperations;
+    this.config = DefaultTokenClientConfiguration.getInstance();
+  }
+
+  @Override
+  protected OAuth2TokenResponse requestAccessToken(
+      @Nonnull final URI tokenEndpointUri,
+      final HttpHeaders headers,
+      final Map<String, String> parameters)
+      throws OAuth2ServiceException {
+    assertNotNull(tokenEndpointUri, "Token endpoint URI must not be null!");
+    return executeRequest(
+        tokenEndpointUri,
+        headers,
+        parameters,
+        config.isRetryEnabled() ? config.getMaxRetryAttempts() : 0);
+  }
+
+  private OAuth2TokenResponse executeRequest(
+      final URI tokenEndpointUri,
+      final HttpHeaders headers,
+      final Map<String, String> parameters,
+      final int attemptsLeft)
+      throws OAuth2ServiceException {
+
+    final URI requestUri = createRequestUri(tokenEndpointUri);
+    final org.springframework.http.HttpHeaders springHeaders = createSpringHeaders(headers);
+    final HttpEntity<MultiValueMap<String, String>> requestEntity =
+        new HttpEntity<>(copyIntoForm(parameters), springHeaders);
+    LOGGER.debug(
+        "Requesting access token from url='{}' with headers={} and {} retries left",
+        requestUri,
+        springHeaders,
+        attemptsLeft);
+    try {
+      final ResponseEntity<Map> responseEntity =
+          restOperations.postForEntity(requestUri, requestEntity, Map.class);
+      final int statusCode = responseEntity.getStatusCode().value();
+      LOGGER.debug("Received statusCode {}", statusCode);
+      @SuppressWarnings("unchecked")
+      final Map<String, String> accessTokenMap = responseEntity.getBody();
+      if (HttpStatus.OK.value() == statusCode && accessTokenMap != null) {
+        LOGGER.debug(
+            "Successfully retrieved access token from url='{}'with params {}.",
+            requestUri,
+            parameters);
+        return processResponseBody(accessTokenMap);
+      } else if (attemptsLeft > 0 && config.getRetryStatusCodes().contains(statusCode)) {
+        LOGGER.warn("Request failed with status {} but is retryable. Retrying...", statusCode);
+        pauseBeforeNextAttempt(config.getRetryDelayTime());
+        return executeRequest(tokenEndpointUri, headers, parameters, attemptsLeft - 1);
+      }
+      throw OAuth2ServiceException.builder("Server error while obtaining access token from XSUAA!")
+          .withUri(requestUri)
+          .withRequestHeaders(getHeadersAsStringArray(springHeaders))
+          .withResponseHeaders(getHeadersAsStringArray(requestEntity.getHeaders()))
+          .withStatusCode(statusCode)
+          .withResponseBody(accessTokenMap != null ? accessTokenMap.toString() : null)
+          .build();
+    } catch (final HttpClientErrorException clientEx) {
+      throw OAuth2ServiceException.builder(
+              "Client error retrieving JWT token. Call to XSUAA was not successful!")
+          .withUri(requestUri)
+          .withRequestHeaders(getHeadersAsStringArray(springHeaders))
+          .withStatusCode(clientEx.getStatusCode().value())
+          .withResponseBody(clientEx.getResponseBodyAsString())
+          .build();
+    } catch (final HttpServerErrorException serverEx) {
+      throw OAuth2ServiceException.builder("Server error while obtaining access token from XSUAA!")
+          .withUri(requestUri)
+          .withRequestHeaders(getHeadersAsStringArray(springHeaders))
+          .withStatusCode(serverEx.getStatusCode().value())
+          .withResponseBody(serverEx.getResponseBodyAsString())
+          .build();
+    } catch (final ResourceAccessException resourceEx) {
+      throw OAuth2ServiceException.builder(
+              "RestClient isn't configured properly - Error while obtaining access token from XSUAA!")
+          .withUri(requestUri)
+          .withRequestHeaders(getHeadersAsStringArray(springHeaders))
+          .withResponseBody(resourceEx.getLocalizedMessage())
+          .build();
+    }
+  }
+
+  private static String[] getHeadersAsStringArray(
+      final org.springframework.http.HttpHeaders headers) {
+    if (headers == null) {
+      return new String[0];
+    }
+    return headers.toSingleValueMap().entrySet().stream()
+        .map(e -> e.getKey() + ": " + e.getValue())
+        .toArray(String[]::new);
+  }
+
+  /**
+   * Creates a copy of the given map or a new empty map of type MultiValueMap.
+   *
+   * @return a new @link{MultiValueMap} that contains all entries of the optional map.
+   */
+  private MultiValueMap<String, String> copyIntoForm(final Map<String, String> parameters) {
+    final MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+    if (parameters != null) {
+      parameters.forEach(formData::add);
+    }
+    return formData;
+  }
+
+  private OAuth2TokenResponse processResponseBody(final Map<String, String> accessTokenMap)
+      throws OAuth2ServiceException {
+    final String accessToken = accessTokenMap.get(ACCESS_TOKEN);
+    final long expiresIn;
+    try {
+      expiresIn = Long.parseLong(String.valueOf(accessTokenMap.get(EXPIRES_IN)));
+    } catch (final NumberFormatException e) {
+      LOGGER.error("Invalid expires_in value: {}", accessTokenMap.get(EXPIRES_IN), e);
+      throw OAuth2ServiceException.builder("Invalid expires_in value")
+          .withResponseBody(e.getLocalizedMessage())
+          .build();
+    }
+    final String refreshToken = accessTokenMap.get(REFRESH_TOKEN);
+    final String tokenType = accessTokenMap.get(TOKEN_TYPE);
+    return new OAuth2TokenResponse(accessToken, expiresIn, refreshToken, tokenType);
+  }
+
+  private URI createRequestUri(final URI tokenEndpointUri) {
+    return UriComponentsBuilder.fromUri(tokenEndpointUri).build().encode().toUri();
+  }
+
+  private org.springframework.http.HttpHeaders createSpringHeaders(final HttpHeaders headers) {
+    final org.springframework.http.HttpHeaders springHeaders =
+        new org.springframework.http.HttpHeaders();
+    headers.getHeaders().forEach(h -> springHeaders.add(h.getName(), h.getValue()));
+    springHeaders.add(MDCHelper.CORRELATION_HEADER, MDCHelper.getOrCreateCorrelationId());
+    springHeaders.add(
+        org.springframework.http.HttpHeaders.USER_AGENT, HttpClientUtil.getUserAgent());
+    return springHeaders;
+  }
+
+  private void pauseBeforeNextAttempt(final long sleepTime) {
+    try {
+      LOGGER.info("Retry again in {} ms", sleepTime);
+      Thread.sleep(sleepTime);
+    } catch (final InterruptedException e) {
+      LOGGER.warn("Thread.sleep has been interrupted. Retry starts now.");
+    }
+  }
+}

--- a/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/SpringOAuth2TokenKeyServiceTest.java
+++ b/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/SpringOAuth2TokenKeyServiceTest.java
@@ -1,0 +1,317 @@
+package com.sap.cloud.security.xsuaa.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.GET;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.sap.cloud.security.client.DefaultTokenClientConfiguration;
+import com.sap.cloud.security.xsuaa.http.HttpHeaders;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestOperations;
+
+public class SpringOAuth2TokenKeyServiceTest {
+
+  public static final URI TOKEN_KEYS_ENDPOINT_URI =
+      URI.create("https://token.endpoint.io/token_keys");
+  public static final String APP_TID = "92768714-4c2e-4b79-bc1b-009a4127ee3c";
+  public static final String CLIENT_ID = "client-id";
+  public static final String AZP = "azp";
+  public static final String ERROR_MESSAGE = "useful error message";
+  private static final Map<String, String> PARAMS =
+      Map.of(
+          HttpHeaders.X_APP_TID, APP_TID,
+          HttpHeaders.X_CLIENT_ID, CLIENT_ID,
+          HttpHeaders.X_AZP, AZP);
+  private final String jsonWebKeysAsString;
+  private RestOperations restOperationsMock;
+  private SpringOAuth2TokenKeyService cut;
+
+  public SpringOAuth2TokenKeyServiceTest() throws IOException {
+    jsonWebKeysAsString =
+        IOUtils.resourceToString("/jsonWebTokenKeys.json", StandardCharsets.UTF_8);
+  }
+
+  @BeforeEach
+  public void setUp() {
+    restOperationsMock = Mockito.mock(RestOperations.class);
+    cut = new SpringOAuth2TokenKeyService(restOperationsMock);
+  }
+
+  @Test
+  public void retrieveTokenKeys_restOperationsIsNull_throwsException() {
+    assertThatThrownBy(() -> new SpringOAuth2TokenKeyService(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void retrieveTokenKeys_tokenEndpointUriIsNull_throwsException() {
+    assertThatThrownBy(() -> cut.retrieveTokenKeys(null, PARAMS))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void retrieveTokenKeys_responseNotOk_throwsException() {
+    mockResponse(ERROR_MESSAGE, 500);
+    setConfigurationValues(0, Set.of());
+
+    assertThatThrownBy(() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("Error retrieving token keys");
+  }
+
+  @Test
+  public void retrieveTokenKeys_httpStatusCodeExceptionOccurs_throwsServiceException() {
+    when(restOperationsMock.exchange(
+            eq(TOKEN_KEYS_ENDPOINT_URI), eq(GET), any(HttpEntity.class), eq(String.class)))
+        .thenThrow(new HttpStatusCodeException(HttpStatus.BAD_REQUEST) {});
+
+    assertThatThrownBy(() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining("Error retrieving token keys")
+        .hasMessageContaining("Request Headers [")
+        .hasMessageNotContaining("Response Headers [")
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Http status code 400");
+  }
+
+  @Test
+  public void retrieveTokenKeys_errorOccurs_throwsServiceException() {
+    when(restOperationsMock.exchange(
+            eq(TOKEN_KEYS_ENDPOINT_URI), eq(GET), any(HttpEntity.class), eq(String.class)))
+        .thenThrow(new RuntimeException("IO Exception"));
+
+    assertThatThrownBy(() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageNotContaining("Response Headers [")
+        .hasMessageContaining("IO Exception");
+  }
+
+  @Test
+  public void retrieveTokenKeys_badResponse_throwsException() {
+    mockResponse(ERROR_MESSAGE, 400);
+
+    assertThatThrownBy(() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("x-app_tid: 92768714-4c2e-4b79-bc1b-009a4127ee3c")
+        .hasMessageContaining("x-client_id: client-id")
+        .hasMessageContaining("x-azp: azp")
+        .hasMessageContaining("Error retrieving token keys")
+        .hasMessageContaining("Http status code 400");
+  }
+
+  @Test
+  public void retrieveTokenKeys_errorOccursDuringRetry_throwsServiceException() {
+    mockResponse(ERROR_MESSAGE, 500, 400);
+    setConfigurationValues(10, Set.of(500));
+
+    assertThatThrownBy(() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("x-app_tid: 92768714-4c2e-4b79-bc1b-009a4127ee3c")
+        .hasMessageContaining("x-client_id: client-id")
+        .hasMessageContaining("x-azp: azp")
+        .hasMessageContaining("Error retrieving token keys")
+        .hasMessageContaining("Http status code 400");
+    Mockito.verify(restOperationsMock, times(2))
+        .exchange(eq(TOKEN_KEYS_ENDPOINT_URI), eq(GET), any(), eq(String.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_executesCorrectHttpGetRequest() throws OAuth2ServiceException {
+    mockResponse(jsonWebKeysAsString, 200);
+
+    cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS);
+
+    Mockito.verify(restOperationsMock, times(1))
+        .exchange(
+            eq(TOKEN_KEYS_ENDPOINT_URI),
+            eq(GET),
+            argThat(httpEntityContainsMandatoryHeaders()),
+            eq(String.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_withEmptyParams_executesSuccessfully()
+      throws OAuth2ServiceException {
+    mockResponse(jsonWebKeysAsString, 200);
+
+    final Map<String, String> emptyParams = Map.of();
+    final String result = cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, emptyParams);
+
+    assertThat(result).isNotEmpty();
+    Mockito.verify(restOperationsMock, times(1))
+        .exchange(eq(TOKEN_KEYS_ENDPOINT_URI), eq(GET), any(HttpEntity.class), eq(String.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_responseNotOk_retry_executesRetrySuccessfully() throws IOException {
+    mockResponse(ERROR_MESSAGE, 500, 200);
+    setConfigurationValues(1, Set.of(500));
+
+    final String result = cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS);
+
+    Mockito.verify(restOperationsMock, times(2))
+        .exchange(eq(TOKEN_KEYS_ENDPOINT_URI), eq(GET), any(), eq(String.class));
+    assertThat(result).isNotEmpty();
+  }
+
+  @Test
+  public void retrieveTokenKeys_allRetryableStatusCodes_executesRetrySuccessfullyWithBadResponse() {
+    mockResponse(ERROR_MESSAGE, 408, 429, 500, 502, 503, 504, 400);
+    setConfigurationValues(10, Set.of(408, 429, 500, 502, 503, 504));
+
+    assertThatThrownBy(() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("x-app_tid: 92768714-4c2e-4b79-bc1b-009a4127ee3c")
+        .hasMessageContaining("x-client_id: client-id")
+        .hasMessageContaining("x-azp: azp")
+        .hasMessageContaining("Error retrieving token keys")
+        .hasMessageContaining("Http status code 400");
+    Mockito.verify(restOperationsMock, times(7))
+        .exchange(eq(TOKEN_KEYS_ENDPOINT_URI), eq(GET), any(), eq(String.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_noRetryableStatusCodesSet_executesNoRetry() {
+    mockResponse(ERROR_MESSAGE, 500);
+    setConfigurationValues(10, Set.of());
+
+    assertThatThrownBy(() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("x-app_tid: 92768714-4c2e-4b79-bc1b-009a4127ee3c")
+        .hasMessageContaining("x-client_id: client-id")
+        .hasMessageContaining("x-azp: azp")
+        .hasMessageContaining("Error retrieving token keys")
+        .hasMessageContaining("Http status code 500");
+    Mockito.verify(restOperationsMock, times(1))
+        .exchange(eq(TOKEN_KEYS_ENDPOINT_URI), eq(GET), any(), eq(String.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_retryLogic_maxAttemptsReached_throwsException() {
+    mockResponse(ERROR_MESSAGE, 500, 500, 500, 500);
+    setConfigurationValues(2, Set.of(500));
+
+    assertThatThrownBy(() -> cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("Error retrieving token keys");
+    Mockito.verify(restOperationsMock, times(3))
+        .exchange(eq(TOKEN_KEYS_ENDPOINT_URI), eq(GET), any(), eq(String.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_interruptedExceptionDuringRetry_logsWarning()
+      throws OAuth2ServiceException {
+    mockResponse(ERROR_MESSAGE, 500, 200);
+    setConfigurationValues(1, Set.of(500));
+
+    // Set up log capturing
+    final Logger logger = (Logger) LoggerFactory.getLogger(SpringOAuth2TokenKeyService.class);
+    final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    logger.addAppender(listAppender);
+
+    Thread.currentThread().interrupt(); // Simulate InterruptedException
+
+    cut.retrieveTokenKeys(TOKEN_KEYS_ENDPOINT_URI, PARAMS);
+
+    final List<ILoggingEvent> logsList = listAppender.list;
+    assertThat(logsList).extracting(ILoggingEvent::getLevel).contains(Level.WARN);
+    assertThat(logsList)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .contains("Thread.sleep has been interrupted. Retry starts now.");
+    logger.detachAppender(listAppender);
+    Mockito.verify(restOperationsMock, times(2))
+        .exchange(eq(TOKEN_KEYS_ENDPOINT_URI), eq(GET), any(), eq(String.class));
+  }
+
+  private void mockResponse(final String responseAsString, final Integer... statusCodes) {
+    final MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+    headers.add("Content-Type", "application/json");
+    final List<ResponseEntity<String>> responses =
+        Arrays.stream(statusCodes)
+            .map(statusCode -> new ResponseEntity<>(responseAsString, headers, statusCode))
+            .toList();
+    final AtomicInteger index = new AtomicInteger(0);
+    when(restOperationsMock.exchange(
+            eq(TOKEN_KEYS_ENDPOINT_URI), eq(GET), any(HttpEntity.class), eq(String.class)))
+        .thenAnswer(
+            invocation -> {
+              final int currentIndex = index.getAndIncrement();
+              return responses.get(currentIndex);
+            });
+  }
+
+  private static void setConfigurationValues(
+      final int maxRetryAttempts, final Set<Integer> retryStatusCodes) {
+    final DefaultTokenClientConfiguration config = DefaultTokenClientConfiguration.getInstance();
+    config.setRetryEnabled(true);
+    config.setMaxRetryAttempts(maxRetryAttempts);
+    config.setRetryStatusCodes(retryStatusCodes);
+    config.setRetryDelayTime(0L);
+  }
+
+  private ArgumentMatcher<HttpEntity> httpEntityContainsMandatoryHeaders() {
+    return (httpGet) -> {
+      final boolean correctClientId =
+          httpGet.getHeaders().get(HttpHeaders.X_CLIENT_ID).get(0).equals(CLIENT_ID);
+      final boolean correctAppTid =
+          httpGet.getHeaders().get(HttpHeaders.X_APP_TID).get(0).equals(APP_TID);
+      final boolean correctAzp = httpGet.getHeaders().get(HttpHeaders.X_AZP).get(0).equals(AZP);
+      return correctAppTid && correctClientId && correctAzp;
+    };
+  }
+}

--- a/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/SpringOidcConfigurationServiceTest.java
+++ b/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/SpringOidcConfigurationServiceTest.java
@@ -1,0 +1,266 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client
+ * Java contributors
+ *
+ * <p>SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.client;
+
+import static com.sap.cloud.security.xsuaa.client.OidcConfigurationService.DISCOVERY_ENDPOINT_DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.sap.cloud.security.client.DefaultTokenClientConfiguration;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestOperations;
+
+public class SpringOidcConfigurationServiceTest {
+  public static final URI CONFIG_ENDPOINT_URI =
+      URI.create("https://sub.myauth.com" + DISCOVERY_ENDPOINT_DEFAULT);
+  private static final String ERROR_MESSAGE = "Error message";
+  private RestOperations restOperationsMock;
+  private SpringOidcConfigurationService cut;
+
+  private final String jsonOidcConfiguration;
+
+  public SpringOidcConfigurationServiceTest() throws IOException {
+    jsonOidcConfiguration =
+        IOUtils.resourceToString("/oidcConfiguration.json", StandardCharsets.UTF_8);
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    restOperationsMock = mock(RestOperations.class);
+    cut = new SpringOidcConfigurationService(restOperationsMock);
+  }
+
+  @Test
+  public void retrieveEndpoints_restOperationsIsNull_throwsException() {
+    assertThatThrownBy(() -> new SpringOidcConfigurationService(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void retrieveEndpoints_parameterIsNull_throwsException() {
+    assertThatThrownBy(() -> retrieveEndpoints(null)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void retrieveEndpoints_badRequest_throwsException() {
+    mockResponse(ERROR_MESSAGE, 400);
+
+    assertThatThrownBy(this::retrieveEndpoints)
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(CONFIG_ENDPOINT_URI.toString())
+        .hasMessageContaining("Http status code 400")
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("Error retrieving configured oidc endpoints");
+  }
+
+  @Test
+  public void retrieveEndpoints_executesHttpGetRequestWithCorrectURI()
+      throws OAuth2ServiceException {
+    mockResponse();
+
+    retrieveEndpoints();
+
+    Mockito.verify(restOperationsMock, times(1))
+        .exchange(eq(CONFIG_ENDPOINT_URI), eq(HttpMethod.GET), any(), eq(String.class));
+  }
+
+  @Test
+  public void retrieveEndpoints_httpClientErrorOccurs_throwsServiceException() {
+    when(restOperationsMock.exchange(
+            eq(CONFIG_ENDPOINT_URI), eq(HttpMethod.GET), any(), eq(String.class)))
+        .thenThrow(new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+    assertThatThrownBy(this::retrieveEndpoints)
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining("Request Headers [")
+        .hasMessageNotContaining("Response Headers [")
+        .extracting(OAuth2ServiceException.class::cast)
+        .extracting(OAuth2ServiceException::getHttpStatusCode)
+        .isEqualTo(500);
+  }
+
+  @Test
+  public void retrieveTokenKeys_errorOccursDuringRetry_throwsServiceException() {
+    mockResponse(ERROR_MESSAGE, 500, 400);
+    setConfigurationValues(1, Set.of(500));
+
+    assertThatThrownBy(this::retrieveEndpoints)
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(CONFIG_ENDPOINT_URI.toString())
+        .hasMessageContaining("Http status code 400")
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("Error retrieving configured oidc endpoints");
+    Mockito.verify(restOperationsMock, times(2))
+        .exchange(eq(CONFIG_ENDPOINT_URI), eq(HttpMethod.GET), any(), eq(String.class));
+  }
+
+  @Test
+  public void retrieveEndpoints_containsBothKeys() throws OAuth2ServiceException {
+    mockResponse();
+
+    final OAuth2ServiceEndpointsProvider result = retrieveEndpoints();
+
+    assertThat(result.getTokenEndpoint()).hasToString("http://localhost/oauth/token");
+    assertThat(result.getJwksUri()).hasToString("http://localhost/token_keys");
+    assertThat(result.getAuthorizeEndpoint()).hasToString("http://localhost/oauth/authorize");
+  }
+
+  @Test
+  public void retrieveTokenKeys_firstResponseNotOk_executesRetrySuccessfullyWithOKResponse()
+      throws OAuth2ServiceException {
+    mockResponse(jsonOidcConfiguration, 500, 200);
+    setConfigurationValues(1, Set.of(500));
+
+    final OAuth2ServiceEndpointsProvider result = retrieveEndpoints();
+
+    Mockito.verify(restOperationsMock, times(2))
+        .exchange(eq(CONFIG_ENDPOINT_URI), eq(HttpMethod.GET), any(), eq(String.class));
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  public void retrieveTokenKeys_allRetryableStatusCodes_executesRetrySuccessfullyWithBadResponse() {
+    mockResponse(ERROR_MESSAGE, 408, 429, 500, 502, 503, 504, 400);
+    setConfigurationValues(10, Set.of(408, 429, 500, 502, 503, 504));
+
+    assertThatThrownBy(this::retrieveEndpoints)
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(CONFIG_ENDPOINT_URI.toString())
+        .hasMessageContaining("Error retrieving configured oidc endpoints")
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("Http status code 400");
+    Mockito.verify(restOperationsMock, times(7))
+        .exchange(eq(CONFIG_ENDPOINT_URI), eq(HttpMethod.GET), any(), eq(String.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_noRetryableStatusCodesSet_executesNoRetry() {
+    mockResponse(ERROR_MESSAGE, 500);
+    setConfigurationValues(10, Set.of());
+
+    assertThatThrownBy(this::retrieveEndpoints)
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(CONFIG_ENDPOINT_URI.toString())
+        .hasMessageContaining("Error retrieving configured oidc endpoints")
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("Http status code 500");
+    Mockito.verify(restOperationsMock, times(1))
+        .exchange(eq(CONFIG_ENDPOINT_URI), eq(HttpMethod.GET), any(), eq(String.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_retryLogic_maxAttemptsReached_throwsException() {
+    mockResponse(ERROR_MESSAGE, 500, 500, 500, 500);
+    setConfigurationValues(2, Set.of(500));
+
+    assertThatThrownBy(this::retrieveEndpoints)
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(ERROR_MESSAGE)
+        .hasMessageContaining(CONFIG_ENDPOINT_URI.toString())
+        .hasMessageContaining("Error retrieving configured oidc endpoints")
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("Http status code 500");
+    Mockito.verify(restOperationsMock, times(3))
+        .exchange(eq(CONFIG_ENDPOINT_URI), eq(HttpMethod.GET), any(), eq(String.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_interruptedExceptionDuringRetry_logsWarning()
+      throws OAuth2ServiceException {
+    mockResponse(jsonOidcConfiguration, 500, 200);
+    setConfigurationValues(1, Set.of(500));
+
+    // Set up log capturing
+    final Logger logger = (Logger) LoggerFactory.getLogger(SpringOidcConfigurationService.class);
+    final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    logger.addAppender(listAppender);
+
+    Thread.currentThread().interrupt(); // Simulate InterruptedException
+
+    retrieveEndpoints();
+
+    final List<ILoggingEvent> logsList = listAppender.list;
+    assertThat(logsList).extracting(ILoggingEvent::getLevel).contains(Level.WARN);
+    assertThat(logsList)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .contains("Thread.sleep has been interrupted. Retry starts now.");
+    logger.detachAppender(listAppender);
+    Mockito.verify(restOperationsMock, times(2))
+        .exchange(eq(CONFIG_ENDPOINT_URI), eq(HttpMethod.GET), any(), eq(String.class));
+  }
+
+  private void mockResponse() {
+    mockResponse(jsonOidcConfiguration, HttpStatus.OK.value());
+  }
+
+  private void mockResponse(final String responseAsString, final Integer... statusCodes) {
+    final List<ResponseEntity<String>> responses =
+        Arrays.stream(statusCodes)
+            .map(
+                statusCode ->
+                    new ResponseEntity<>(responseAsString, HttpStatusCode.valueOf(statusCode)))
+            .toList();
+    final AtomicInteger index = new AtomicInteger(0);
+    when(restOperationsMock.exchange(any(URI.class), eq(HttpMethod.GET), any(), eq(String.class)))
+        .thenAnswer(
+            invocation -> {
+              final int currentIndex = index.getAndIncrement();
+              return responses.get(currentIndex);
+            });
+  }
+
+  private void setConfigurationValues(
+      final int maxRetryAttempts, final Set<Integer> retryStatusCodes) {
+    final DefaultTokenClientConfiguration config = DefaultTokenClientConfiguration.getInstance();
+    config.setRetryEnabled(true);
+    config.setMaxRetryAttempts(maxRetryAttempts);
+    config.setRetryStatusCodes(retryStatusCodes);
+    config.setRetryDelayTime(0L);
+  }
+
+  private OAuth2ServiceEndpointsProvider retrieveEndpoints() throws OAuth2ServiceException {
+    return retrieveEndpoints(CONFIG_ENDPOINT_URI);
+  }
+
+  private OAuth2ServiceEndpointsProvider retrieveEndpoints(final URI endpointsEndpointUri)
+      throws OAuth2ServiceException {
+    return cut.retrieveEndpoints(endpointsEndpointUri);
+  }
+}

--- a/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/TokenServiceHttpEntityMatcher.java
+++ b/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/TokenServiceHttpEntityMatcher.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.client;
+
+import com.sap.cloud.security.config.ClientIdentity;
+import org.mockito.ArgumentMatcher;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
+
+public class TokenServiceHttpEntityMatcher implements ArgumentMatcher<HttpEntity> {
+
+	private Map<String, String> expectedParameters = new HashMap<>();
+
+	public void setGrantType(String grantType) {
+		expectedParameters.put(GRANT_TYPE, grantType);
+	}
+
+	public void setClientCredentials(ClientIdentity clientIdentity) {
+		expectedParameters.put(CLIENT_ID, clientIdentity.getId());
+		expectedParameters.put(CLIENT_SECRET, clientIdentity.getSecret());
+	}
+
+	public void addParameters(Map<String, String> additionalParameters) {
+		expectedParameters.putAll(additionalParameters);
+	}
+
+	public void addParameter(String parameterKey, String parameterValue) {
+		expectedParameters.put(parameterKey, parameterValue);
+	}
+
+	@Override
+	public boolean matches(HttpEntity actual) {
+		boolean headerMatches = false;
+		boolean bodyMatches = false;
+		HttpHeaders actualHeaders = actual.getHeaders();
+		Map<String, String> actualBodyParameters = convertMultiToRegularMap((MultiValueMap) actual.getBody());
+
+		if (actualHeaders.getAccept().contains(MediaType.APPLICATION_JSON)
+				&& actualHeaders.getContentType().equals(MediaType.APPLICATION_FORM_URLENCODED)) {
+			headerMatches = true;
+		}
+		if (actualBodyParameters.size() == expectedParameters.size()) {
+			for (Map.Entry<String, String> expectedParam : expectedParameters.entrySet()) {
+				if (!actualBodyParameters.get(expectedParam.getKey()).equals(expectedParam.getValue())) {
+					return false;
+				}
+			}
+			bodyMatches = true;
+		}
+		return headerMatches && bodyMatches;
+	}
+
+	private Map<String, String> convertMultiToRegularMap(MultiValueMap<String, String> multiValueMap) {
+		Map<String, String> map = new HashMap();
+		if (multiValueMap == null) {
+			return map;
+		}
+		for (Entry<String, List<String>> entry : multiValueMap.entrySet()) {
+			String entryValues = String.join(",", entry.getValue());
+			map.put(entry.getKey(), entryValues);
+		}
+		return map;
+	}
+}

--- a/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServiceClientCredentialsTest.java
+++ b/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServiceClientCredentialsTest.java
@@ -1,0 +1,207 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client
+ * Java contributors
+ *
+ * <p>SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.client;
+
+import static com.sap.cloud.security.servlet.MDCHelper.CORRELATION_ID;
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.sap.cloud.security.config.ClientCredentials;
+import com.sap.cloud.security.config.ClientIdentity;
+import com.sap.cloud.security.servlet.MDCHelper;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestOperations;
+
+@ExtendWith(MockitoExtension.class)
+public class XsuaaOAuth2TokenServiceClientCredentialsTest {
+
+  OAuth2TokenService cut;
+  ClientIdentity clientIdentity;
+  URI tokenEndpoint;
+  Map<String, String> responseMap;
+
+  @Mock RestOperations mockRestOperations;
+
+  @BeforeEach
+  public void setup() {
+    cut = new XsuaaOAuth2TokenService(mockRestOperations);
+    clientIdentity = new ClientCredentials("clientid", "mysecretpassword");
+    tokenEndpoint = URI.create("https://subdomain.myauth.server.com/oauth/token");
+
+    responseMap = new HashMap<>();
+    responseMap.putIfAbsent(ACCESS_TOKEN, "f529.dd6e30.d454677322aaabb0");
+    responseMap.putIfAbsent(EXPIRES_IN, "43199");
+    responseMap.putIfAbsent(TOKEN_TYPE, "bearer");
+  }
+
+  @Test
+  public void retrieveToken_throwsOnNullValues() {
+    assertThatThrownBy(
+            () ->
+                cut.retrieveAccessTokenViaClientCredentialsGrant(
+                    null, clientIdentity, null, null, null, false))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("tokenEndpointUri");
+
+    assertThatThrownBy(
+            () ->
+                cut.retrieveAccessTokenViaClientCredentialsGrant(
+                    tokenEndpoint, null, null, null, null, false))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("clientIdentity");
+  }
+
+  @Test
+  public void retrieveToken_throwsIfHttpStatusUnauthorized() {
+    Mockito.when(
+            mockRestOperations.postForEntity(any(URI.class), any(HttpEntity.class), eq(Map.class)))
+        .thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+    assertThatThrownBy(() -> cut.retrieveAccessTokenViaClientCredentialsGrant(
+        tokenEndpoint, clientIdentity, null, null, null, false))
+        .isInstanceOf(OAuth2ServiceException.class);
+  }
+
+  @Test
+  public void retrieveToken_throwsIfHttpStatusNotOk() {
+    Mockito.when(
+            mockRestOperations.postForEntity(any(URI.class), any(HttpEntity.class), eq(Map.class)))
+        .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+    assertThatThrownBy(() -> cut.retrieveAccessTokenViaClientCredentialsGrant(
+        tokenEndpoint, clientIdentity, null, null, null, false))
+        .isInstanceOf(OAuth2ServiceException.class);
+  }
+
+  @Test
+  public void retrieveToken() throws OAuth2ServiceException {
+    final TokenServiceHttpEntityMatcher tokenHttpEntityMatcher =
+        new TokenServiceHttpEntityMatcher();
+    tokenHttpEntityMatcher.setClientCredentials(clientIdentity);
+    tokenHttpEntityMatcher.setGrantType(GRANT_TYPE_CLIENT_CREDENTIALS);
+
+    Mockito.when(
+            mockRestOperations.postForEntity(
+                eq(tokenEndpoint), argThat(tokenHttpEntityMatcher), eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(responseMap, HttpStatus.OK));
+
+    final OAuth2TokenResponse accessToken =
+        cut.retrieveAccessTokenViaClientCredentialsGrant(
+            tokenEndpoint, clientIdentity, null, null, null, false);
+    assertThat(accessToken.getAccessToken()).isEqualTo(responseMap.get(ACCESS_TOKEN));
+    assertThat(accessToken.getTokenType()).isEqualTo(responseMap.get(TOKEN_TYPE));
+    assertThat(accessToken.getExpiredAt()).isNotNull();
+  }
+
+  @Test
+  public void retrieveToken_withOptionalParamaters() throws OAuth2ServiceException {
+    final Map<String, String> additionalParameters = new HashMap<>();
+    additionalParameters.put("add-param-1", "value1");
+    additionalParameters.put("add-param-2", "value2");
+
+    final TokenServiceHttpEntityMatcher tokenHttpEntityMatcher =
+        new TokenServiceHttpEntityMatcher();
+    tokenHttpEntityMatcher.setClientCredentials(clientIdentity);
+    tokenHttpEntityMatcher.setGrantType(GRANT_TYPE_CLIENT_CREDENTIALS);
+    tokenHttpEntityMatcher.addParameters(additionalParameters);
+
+    Mockito.when(
+            mockRestOperations.postForEntity(
+                eq(tokenEndpoint), argThat(tokenHttpEntityMatcher), eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(responseMap, HttpStatus.OK));
+
+    final OAuth2TokenResponse accessToken =
+        cut.retrieveAccessTokenViaClientCredentialsGrant(
+            tokenEndpoint, clientIdentity, null, null, additionalParameters, false);
+    assertThat(accessToken.getAccessToken()).isEqualTo(responseMap.get(ACCESS_TOKEN));
+  }
+
+  @Test
+  public void retrieveToken_requiredParametersCanNotBeOverwritten() throws OAuth2ServiceException {
+    final TokenServiceHttpEntityMatcher tokenHttpEntityMatcher =
+        new TokenServiceHttpEntityMatcher();
+    tokenHttpEntityMatcher.setClientCredentials(clientIdentity);
+    tokenHttpEntityMatcher.setGrantType(GRANT_TYPE_CLIENT_CREDENTIALS);
+
+    Mockito.when(
+            mockRestOperations.postForEntity(
+                eq(tokenEndpoint), argThat(tokenHttpEntityMatcher), eq(Map.class)))
+        .thenReturn(new ResponseEntity<>(responseMap, HttpStatus.OK));
+
+    final Map<String, String> overwrittenGrantType = new HashMap<>();
+    overwrittenGrantType.put(GRANT_TYPE, "overwrite-obligatory-param");
+
+    final OAuth2TokenResponse accessToken =
+        cut.retrieveAccessTokenViaClientCredentialsGrant(
+            tokenEndpoint, clientIdentity, null, null, overwrittenGrantType, false);
+    assertThat(accessToken.getAccessToken()).isEqualTo(responseMap.get(ACCESS_TOKEN));
+  }
+
+  @Test
+  public void retrieveToken_testCache() throws IOException {
+    when(mockRestOperations.postForEntity(any(), any(), any()))
+        .thenReturn(new ResponseEntity<>(responseMap, HttpStatus.OK));
+
+    cut.retrieveAccessTokenViaClientCredentialsGrant(
+        tokenEndpoint, clientIdentity, null, null, emptyMap(), false);
+    cut.retrieveAccessTokenViaClientCredentialsGrant(
+        tokenEndpoint, clientIdentity, null, null, emptyMap(), false);
+
+    verify(mockRestOperations, times(1)).postForEntity(any(), any(), any());
+  }
+
+  @Test
+  public void correlationIdProvisioning() throws IOException {
+    when(mockRestOperations.postForEntity(any(), any(), any()))
+        .thenReturn(new ResponseEntity<>(responseMap, HttpStatus.OK));
+
+    final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    final Logger logger = (Logger) LoggerFactory.getLogger(MDCHelper.class);
+    logger.setLevel(Level.DEBUG);
+    listAppender.start();
+    logger.addAppender(listAppender);
+
+    cut.retrieveAccessTokenViaClientCredentialsGrant(
+        tokenEndpoint, clientIdentity, null, null, Collections.emptyMap(), false);
+    Assertions.assertThat(listAppender.list.get(0).getLevel()).isEqualTo(Level.INFO);
+    Assertions.assertThat(listAppender.list.get(0).getMessage())
+        .contains("was not found in the MDC");
+
+    MDC.put(CORRELATION_ID, "my-correlation-id");
+    cut.retrieveAccessTokenViaClientCredentialsGrant(
+        tokenEndpoint, clientIdentity, "zone", null, Collections.emptyMap(), false);
+    Assertions.assertThat(listAppender.list.get(1).getLevel()).isEqualTo(Level.DEBUG);
+    Assertions.assertThat(listAppender.list.get(1).getArgumentArray()[1])
+        .isEqualTo(("my-correlation-id"));
+    MDC.clear();
+  }
+}

--- a/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServiceJwtBearerTokenTest.java
+++ b/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServiceJwtBearerTokenTest.java
@@ -1,0 +1,224 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.client;
+
+import com.sap.cloud.security.config.ClientCredentials;
+import org.junit.jupiter.api.Test;
+import com.sap.cloud.security.config.ClientIdentity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.MultiValueMap;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpClientErrorException;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestOperations;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
+import org.junit.jupiter.api.Test;
+import static java.util.Collections.emptyMap;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.eq;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+import org.junit.jupiter.api.Test;
+
+@ExtendWith(MockitoExtension.class)
+public class XsuaaOAuth2TokenServiceJwtBearerTokenTest {
+
+	private OAuth2TokenService cut;
+
+	private final String jwtToken = "jwtToken";
+	private final String subdomain = "subdomain";
+	private final ClientIdentity clientIdentity = new ClientCredentials("theClientId", "test321");
+	private final URI tokenEndpoint = URI.create("https://subdomain.myauth.server.com/oauth/token");
+	private Map<String, String> optionalParameters;
+	private Map<String, String> response;
+
+	@Mock
+	private RestOperations mockRestOperations;
+
+	@BeforeEach
+	public void setup() {
+		response = new HashMap<>();
+		response.putIfAbsent(ACCESS_TOKEN, "f529.dd6e30.d454677322aaabb0");
+		response.putIfAbsent(EXPIRES_IN, "43199");
+		response.putIfAbsent(TOKEN_TYPE, "bearer");
+		lenient().when(mockRestOperations.postForEntity(any(), any(), any()))
+				.thenReturn(ResponseEntity.status(200).body(response));
+		optionalParameters = new HashMap<>();
+		cut = new XsuaaOAuth2TokenService(mockRestOperations);
+	}
+
+	@Test
+	public void retrieveToken_httpStatusUnauthorized_throwsException() {
+		throwExceptionOnPost(HttpStatus.UNAUTHORIZED);
+
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity,
+				jwtToken, null, null, false))
+				.isInstanceOf(OAuth2ServiceException.class);
+	}
+
+	@Test
+	public void retrieveToken_httpStatusNotOk_throwsException() {
+		throwExceptionOnPost(HttpStatus.BAD_REQUEST);
+
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity,
+				jwtToken, null, null, false))
+				.isInstanceOf(OAuth2ServiceException.class);
+	}
+
+	@Test
+	public void retrieveToken_requiredParametersMissing_throwsException() {
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaJwtBearerTokenGrant(null, clientIdentity,
+				jwtToken, subdomain, optionalParameters, false)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, null,
+				jwtToken, subdomain, optionalParameters, false)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity,
+				null, subdomain, optionalParameters, false)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void retrieveToken_callsTokenEndpoint() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity,
+				jwtToken, null, null, false);
+
+		Mockito.verify(mockRestOperations, times(1))
+				.postForEntity(eq(tokenEndpoint), any(), any());
+	}
+
+	@Test
+	public void retrieveToken_setsCorrectGrantType() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity,
+				jwtToken, null, null, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+
+		String actualGrantType = valueOfParameter(GRANT_TYPE, requestEntityCaptor);
+		assertThat(actualGrantType).isEqualTo(GRANT_TYPE_JWT_BEARER);
+	}
+
+	@Test
+	public void retrieveToken_setsToken() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity,
+				jwtToken, null, null, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+
+		assertThat(valueOfParameter(ASSERTION, requestEntityCaptor)).isEqualTo(jwtToken);
+	}
+
+	@Test
+	public void retrieveToken_setsClientCredentials() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity,
+				jwtToken, null, null, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+
+		assertThat(valueOfParameter(CLIENT_ID, requestEntityCaptor)).isEqualTo(clientIdentity.getId());
+		assertThat(valueOfParameter(CLIENT_SECRET, requestEntityCaptor)).isEqualTo(clientIdentity.getSecret());
+	}
+
+	@Test
+	public void retrieveToken_setsOptionalParameters() throws OAuth2ServiceException {
+		String tokenFormatParameterName = "token_format";
+		String tokenFormat = "opaque";
+		String responseTypeParameterName = "response_type";
+		String loginHint = "token";
+
+		optionalParameters.put(tokenFormatParameterName, tokenFormat);
+		optionalParameters.put(responseTypeParameterName, loginHint);
+
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity,
+				jwtToken, null, optionalParameters, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+		assertThat(valueOfParameter(tokenFormatParameterName, requestEntityCaptor)).isEqualTo(tokenFormat);
+		assertThat(valueOfParameter(responseTypeParameterName, requestEntityCaptor)).isEqualTo(loginHint);
+	}
+
+	@Test
+	public void retrieveToken_setsCorrectHeaders() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity,
+				jwtToken, null, optionalParameters, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+		HttpHeaders headers = requestEntityCaptor.getValue().getHeaders();
+
+		assertThat(headers.getAccept()).containsExactly(MediaType.APPLICATION_JSON);
+		assertThat(headers.getContentType()).isEqualTo(MediaType.APPLICATION_FORM_URLENCODED);
+	}
+
+	@Test
+	public void retrieveToken() throws OAuth2ServiceException {
+		OAuth2TokenResponse actualResponse = cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint,
+				clientIdentity,
+				jwtToken, null, null, false);
+
+		assertThat(actualResponse.getAccessToken()).isEqualTo(response.get(ACCESS_TOKEN));
+		assertThat(actualResponse.getTokenType()).isEqualTo(response.get(TOKEN_TYPE));
+		assertThat(actualResponse.getExpiredAt()).isNotNull();
+	}
+
+	@Test
+	public void retrieveToken_testCache() throws IOException {
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity, jwtToken, null, emptyMap(), false);
+		cut.retrieveAccessTokenViaJwtBearerTokenGrant(tokenEndpoint, clientIdentity, jwtToken, null, emptyMap(), false);
+
+		verify(mockRestOperations, times(1)).postForEntity(any(), any(), any());
+	}
+
+	private ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> captureRequestEntity() {
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = ArgumentCaptor
+				.forClass(HttpEntity.class);
+		Mockito.verify(mockRestOperations, times(1))
+				.postForEntity(
+						eq(tokenEndpoint),
+						requestEntityCaptor.capture(),
+						eq(Map.class));
+		return requestEntityCaptor;
+	}
+
+	private String valueOfParameter(
+			String parameterKey, ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor) {
+		MultiValueMap<String, String> body = requestEntityCaptor.getValue().getBody();
+		return body.getFirst(parameterKey);
+	}
+
+	private void throwExceptionOnPost(HttpStatus unauthorized) {
+		when(mockRestOperations.postForEntity(any(), any(), any()))
+				.thenThrow(new HttpClientErrorException(unauthorized));
+	}
+
+}

--- a/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServicePasswordTest.java
+++ b/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServicePasswordTest.java
@@ -1,0 +1,240 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.client;
+
+import com.sap.cloud.security.config.ClientCredentials;
+import org.junit.jupiter.api.Test;
+import com.sap.cloud.security.config.ClientIdentity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.MultiValueMap;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.HttpClientErrorException;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestOperations;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
+import org.junit.jupiter.api.Test;
+import static java.util.Collections.emptyMap;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.eq;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+import org.junit.jupiter.api.Test;
+
+@ExtendWith(MockitoExtension.class)
+public class XsuaaOAuth2TokenServicePasswordTest {
+
+	private OAuth2TokenService cut;
+
+	private final String clientSecret = "test321";
+	private final String clientId = "theClientId";
+	private final String password = "test123";
+	private final String username = "bob";
+	private final String subdomain = "subdomain";
+	private final ClientIdentity clientIdentity = new ClientCredentials(clientId, clientSecret);
+	private final URI tokenEndpoint = URI.create("https://subdomain.myauth.server.com/oauth/token");
+	private Map<String, String> optionalParameters;
+	private Map<String, String> response;
+
+	@Mock
+	private RestOperations mockRestOperations;
+
+	@BeforeEach
+	public void setup() {
+		response = new HashMap();
+		response.putIfAbsent(ACCESS_TOKEN, "f529.dd6e30.d454677322aaabb0");
+		response.putIfAbsent(EXPIRES_IN, "43199");
+		response.putIfAbsent(TOKEN_TYPE, "bearer");
+		lenient().when(mockRestOperations.postForEntity(any(), any(), any()))
+				.thenReturn(ResponseEntity.status(200).body(response));
+		optionalParameters = new HashMap<>();
+		cut = new XsuaaOAuth2TokenService(mockRestOperations);
+	}
+
+	@Test
+	public void retrieveToken_httpStatusUnauthorized_throwsException() {
+		throwExceptionOnPost(HttpStatus.UNAUTHORIZED);
+
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, password, null, null, false))
+				.isInstanceOf(OAuth2ServiceException.class);
+	}
+
+	@Test
+	public void retrieveToken_httpStatusNotOk_throwsException() {
+		throwExceptionOnPost(HttpStatus.BAD_REQUEST);
+
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, password, null, null, false))
+				.isInstanceOf(OAuth2ServiceException.class);
+	}
+
+	@Test
+	public void retrieveToken_requiredParametersMissing_throwsException() {
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaPasswordGrant(null, clientIdentity,
+				username, password, subdomain, optionalParameters, false)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, null,
+				username, password, subdomain, optionalParameters, false)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				null, password, subdomain, optionalParameters, false)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, null, subdomain, optionalParameters, false)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void retrieveToken_callsTokenEndpoint() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, password, null, null, false);
+
+		Mockito.verify(mockRestOperations, times(1))
+				.postForEntity(eq(tokenEndpoint), any(), any());
+	}
+
+	@Test
+	public void retrieveToken_setsCorrectGrantType() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, password, null, null, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+
+		String actualGrantType = valueOfParameter(GRANT_TYPE, requestEntityCaptor);
+		assertThat(actualGrantType).isEqualTo(GRANT_TYPE_PASSWORD);
+	}
+
+	@Test
+	public void retrieveToken_setsUsername() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, password, null, null, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+
+		assertThat(valueOfParameter(USERNAME, requestEntityCaptor)).isEqualTo(username);
+	}
+
+	@Test
+	public void retrieveToken_setsPassword() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, password, null, null, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+
+		assertThat(valueOfParameter(PASSWORD, requestEntityCaptor)).isEqualTo(password);
+	}
+
+	@Test
+	public void retrieveToken_setsClientCredentials() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, password, null, null, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+
+		assertThat(valueOfParameter(CLIENT_ID, requestEntityCaptor)).isEqualTo(clientIdentity.getId());
+		assertThat(valueOfParameter(CLIENT_SECRET, requestEntityCaptor)).isEqualTo(clientIdentity.getSecret());
+	}
+
+	@Test
+	public void retrieveToken_setsOptionalParameters() throws OAuth2ServiceException {
+		String tokenFormatParameterKey = "token_format";
+		String tokenFormat = "opaque";
+		String loginHintParameterKey = "login_hint";
+		String loginHint = "origin";
+
+		optionalParameters.put(tokenFormatParameterKey, tokenFormat);
+		optionalParameters.put(loginHintParameterKey, loginHint);
+
+		cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, password, null, optionalParameters, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+		assertThat(valueOfParameter(tokenFormatParameterKey, requestEntityCaptor)).isEqualTo(tokenFormat);
+		assertThat(valueOfParameter(loginHintParameterKey, requestEntityCaptor)).isEqualTo(loginHint);
+	}
+
+	@Test
+	public void retrieveToken_setsCorrectHeaders() throws OAuth2ServiceException {
+		cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, password, null, optionalParameters, false);
+
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = captureRequestEntity();
+		HttpHeaders headers = requestEntityCaptor.getValue().getHeaders();
+
+		assertThat(headers.getAccept()).containsExactly(MediaType.APPLICATION_JSON);
+		assertThat(headers.getContentType()).isEqualTo(MediaType.APPLICATION_FORM_URLENCODED);
+	}
+
+	@Test
+	public void retrieveToken() throws OAuth2ServiceException {
+		OAuth2TokenResponse actualResponse = cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity,
+				username, password, null, null, false);
+
+		assertThat(actualResponse.getAccessToken()).isEqualTo(response.get(ACCESS_TOKEN));
+		assertThat(actualResponse.getTokenType()).isEqualTo(response.get(TOKEN_TYPE));
+		assertThat(actualResponse.getExpiredAt()).isNotNull();
+	}
+
+	@Test
+	public void retrieveToken_testCache() throws IOException {
+		cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity, username, password, null, emptyMap(),
+				false);
+		cut.retrieveAccessTokenViaPasswordGrant(tokenEndpoint, clientIdentity, username, password, null, emptyMap(),
+				false);
+
+		verify(mockRestOperations, times(1)).postForEntity(any(), any(), any());
+	}
+
+	private ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> captureRequestEntity() {
+		ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor = ArgumentCaptor
+				.forClass(HttpEntity.class);
+		Mockito.verify(mockRestOperations, times(1))
+				.postForEntity(
+						eq(tokenEndpoint),
+						requestEntityCaptor.capture(),
+						eq(Map.class));
+		return requestEntityCaptor;
+	}
+
+	private String valueOfParameter(
+			String parameterKey, ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestEntityCaptor) {
+		MultiValueMap<String, String> body = requestEntityCaptor.getValue().getBody();
+		return body.getFirst(parameterKey);
+	}
+
+	private void throwExceptionOnPost(HttpStatus unauthorized) {
+		lenient().when(mockRestOperations.postForEntity(any(), any(), any()))
+				.thenThrow(new HttpClientErrorException(unauthorized));
+	}
+
+}

--- a/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServiceRefreshTokenTest.java
+++ b/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServiceRefreshTokenTest.java
@@ -1,0 +1,113 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.client;
+
+import com.sap.cloud.security.config.ClientCredentials;
+import com.sap.cloud.security.config.ClientIdentity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestOperations;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+
+@ExtendWith(MockitoExtension.class)
+public class XsuaaOAuth2TokenServiceRefreshTokenTest {
+
+	private static final String refreshToken = "d2faefe7ea834ba895d20730f106128c-r";
+
+	OAuth2TokenService cut;
+	ClientIdentity clientIdentity;
+	URI tokenEndpoint;
+	Map<String, String> responseMap;
+
+	@Mock
+	RestOperations mockRestOperations;
+
+	@BeforeEach
+	public void setup() {
+		cut = new XsuaaOAuth2TokenService(mockRestOperations);
+		clientIdentity = new ClientCredentials("clientid", "mysecretpassword");
+		tokenEndpoint = URI.create("https://subdomain.myauth.server.com/oauth/token");
+
+		responseMap = new HashMap<>();
+		responseMap.put(REFRESH_TOKEN, "2170b564228448c6aed8b1ddfdb8bf53-r");
+		responseMap.put(ACCESS_TOKEN, "f529.dd6e30.d454677322aaabb0");
+		responseMap.put(EXPIRES_IN, "43199");
+		responseMap.put(TOKEN_TYPE, "bearer");
+	}
+
+	@Test
+	public void retrieveToken_throwsOnNullValues() {
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaRefreshToken(null, clientIdentity, refreshToken, null, true))
+				.isInstanceOf(IllegalArgumentException.class).hasMessageStartingWith("tokenEndpointUri");
+
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaRefreshToken(tokenEndpoint, null, refreshToken, null, true))
+				.isInstanceOf(IllegalArgumentException.class).hasMessageStartingWith("clientIdentity");
+
+		assertThatThrownBy(
+				() -> cut.retrieveAccessTokenViaRefreshToken(tokenEndpoint, clientIdentity, null, null, true))
+				.isInstanceOf(IllegalArgumentException.class).hasMessageStartingWith("refreshToken");
+	}
+
+	@Test
+	public void retrieveToken_throwsIfHttpStatusUnauthorized() {
+		Mockito.when(mockRestOperations.postForEntity(eq(tokenEndpoint), any(HttpEntity.class), eq(Map.class)))
+				.thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
+
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaRefreshToken(tokenEndpoint, clientIdentity,
+				refreshToken, null, true))
+				.isInstanceOf(OAuth2ServiceException.class);
+	}
+
+	@Test
+	public void retrieveToken_throwsIfHttpStatusNotOk() {
+		Mockito.when(mockRestOperations.postForEntity(eq(tokenEndpoint), any(HttpEntity.class), eq(Map.class)))
+				.thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+		assertThatThrownBy(() -> cut.retrieveAccessTokenViaRefreshToken(tokenEndpoint, clientIdentity,
+				refreshToken, null, true))
+				.isInstanceOf(OAuth2ServiceException.class);
+	}
+
+	@Test
+	public void retrieveToken() throws OAuth2ServiceException {
+		TokenServiceHttpEntityMatcher tokenHttpEntityMatcher = new TokenServiceHttpEntityMatcher();
+		tokenHttpEntityMatcher.setClientCredentials(clientIdentity);
+		tokenHttpEntityMatcher.setGrantType(GRANT_TYPE_REFRESH_TOKEN);
+		tokenHttpEntityMatcher.addParameter(REFRESH_TOKEN, refreshToken);
+
+		Mockito.when(mockRestOperations
+						.postForEntity(
+								eq(tokenEndpoint),
+								argThat(tokenHttpEntityMatcher),
+								eq(Map.class)))
+				.thenReturn(new ResponseEntity<>(responseMap, HttpStatus.OK));
+
+		OAuth2TokenResponse accessToken = cut.retrieveAccessTokenViaRefreshToken(tokenEndpoint, clientIdentity,
+				refreshToken, null, true);
+		assertThat(accessToken.getRefreshToken()).isEqualTo(responseMap.get(REFRESH_TOKEN));
+		assertThat(accessToken.getAccessToken()).isEqualTo(responseMap.get(ACCESS_TOKEN));
+		assertThat(accessToken.getTokenType()).isEqualTo(responseMap.get(TOKEN_TYPE));
+		assertThat(accessToken.getExpiredAt()).isNotNull();
+	}
+}

--- a/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServiceTest.java
+++ b/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/client/XsuaaOAuth2TokenServiceTest.java
@@ -1,0 +1,382 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client
+ * Java contributors
+ *
+ * <p>SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.client;
+
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.ACCESS_TOKEN;
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.EXPIRES_IN;
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.REFRESH_TOKEN;
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.TOKEN_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.sap.cloud.security.client.DefaultTokenClientConfiguration;
+import com.sap.cloud.security.servlet.MDCHelper;
+import com.sap.cloud.security.xsuaa.http.HttpHeaders;
+import com.sap.cloud.security.xsuaa.tokenflows.TokenCacheConfiguration;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestOperations;
+
+class XsuaaOAuth2TokenServiceTest {
+    
+  public static final URI TOKEN_KEYS_ENDPOINT_URI =
+      URI.create("https://token.endpoint.io/token_keys");
+  public static final String APP_TID = "92768714-4c2e-4b79-bc1b-009a4127ee3c";
+  public static final String CLIENT_ID = "client-id";
+  public static final String AZP = "azp";
+  public static final String TEST_ACCESS_TOKEN = "Valid Access token";
+  public static final String TEST_REFRESH_TOKEN = "Valid Refresh token";
+  public static final String TEST_EXPIRATION_TIME = "1000";
+  public static final String TEST_TOKEN_TYPE = "TOKEN TYPE";
+  private static final Map<String, String> PARAMS =
+      Map.of(
+          HttpHeaders.X_APP_TID, APP_TID,
+          HttpHeaders.X_CLIENT_ID, CLIENT_ID,
+          HttpHeaders.X_AZP, AZP);
+  private static final Map<String, String> responseBody =
+      Map.of(
+          ACCESS_TOKEN, TEST_ACCESS_TOKEN,
+          EXPIRES_IN, TEST_EXPIRATION_TIME,
+          REFRESH_TOKEN, TEST_REFRESH_TOKEN,
+          TOKEN_TYPE, TEST_TOKEN_TYPE);
+  private RestOperations restOperationsMock;
+  private XsuaaOAuth2TokenService cut;
+  private HttpHeaders headers;
+
+  @BeforeEach
+  public void setUp() {
+    restOperationsMock = Mockito.mock(RestOperations.class);
+    cut = new XsuaaOAuth2TokenService(restOperationsMock);
+    headers = new HttpHeaders();
+  }
+
+  @Test
+  void initialize_throwsIfRestOperationsIsNull() {
+    assertThatThrownBy(
+            () -> new XsuaaOAuth2TokenService(null, TokenCacheConfiguration.cacheDisabled()))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void initialize_throwsIfCacheConfigurationIsNull() {
+    assertThatThrownBy(() -> new XsuaaOAuth2TokenService(Mockito.mock(RestOperations.class), null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void retrieveTokenKeys_responseNotOk_throwsException() {
+    mockResponse(responseBody, 500);
+    setConfigurationValues(0, Set.of());
+
+    assertThatThrownBy(() -> cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("User-Agent: token-client/")
+        .hasMessageContaining("expires_in=1000")
+        .hasMessageContaining("access_token=Valid Access token")
+        .hasMessageContaining("token_type=TOKEN TYPE")
+        .hasMessageContaining("Server error while obtaining access token from XSUAA!")
+        .hasMessageContaining("Http status code 500");
+  }
+
+  @Test
+  public void retrieveTokenKeys_httpClientExceptionOccurs_throwsServiceException() {
+    when(restOperationsMock.postForEntity(eq(TOKEN_KEYS_ENDPOINT_URI), any(), eq(Map.class)))
+        .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST) {});
+
+    assertThatThrownBy(() -> cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(
+            "Client error retrieving JWT token. Call to XSUAA was not successful!")
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageNotContaining("Response Headers [")
+        .hasMessageContaining("Http status code 400");
+  }
+
+  @Test
+  public void retrieveTokenKeys_httpServerErrorExceptionOccurs_throwsServiceException() {
+    when(restOperationsMock.postForEntity(eq(TOKEN_KEYS_ENDPOINT_URI), any(), eq(Map.class)))
+        .thenThrow(new HttpServerErrorException(HttpStatus.BAD_REQUEST) {});
+
+    assertThatThrownBy(() -> cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining("Server error while obtaining access token from XSUAA!")
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageNotContaining("Response Headers [")
+        .hasMessageContaining("Http status code 400");
+  }
+
+  @Test
+  public void retrieveTokenKeys_resourceAccessExceptionOccurs_throwsServiceException() {
+    when(restOperationsMock.postForEntity(eq(TOKEN_KEYS_ENDPOINT_URI), any(), eq(Map.class)))
+        .thenThrow(new ResourceAccessException("Error accessing resource!") {});
+
+    assertThatThrownBy(() -> cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining("Error accessing resource!")
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageNotContaining("Response Headers [")
+        .hasMessageContaining(
+            "RestClient isn't configured properly - Error while obtaining access token from XSUAA!");
+  }
+
+  @Test
+  public void retrieveTokenKeys_errorOccursDuringRetry_throwsServiceException() {
+    mockResponse(responseBody, 500, 400);
+    setConfigurationValues(10, Set.of(500));
+
+    assertThatThrownBy(() -> cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("User-Agent: token-client/")
+        .hasMessageContaining("expires_in=1000")
+        .hasMessageContaining("access_token=Valid Access token")
+        .hasMessageContaining("token_type=TOKEN TYPE")
+        .hasMessageContaining("Server error while obtaining access token from XSUAA!")
+        .hasMessageContaining("Http status code 400");
+
+    Mockito.verify(restOperationsMock, times(2))
+        .postForEntity(eq(TOKEN_KEYS_ENDPOINT_URI), any(), eq(Map.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_executesCorrectHttpGetRequest() throws OAuth2ServiceException {
+    mockResponse(responseBody, 200);
+
+    cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS);
+
+    Mockito.verify(restOperationsMock, times(1))
+        .postForEntity(
+            eq(TOKEN_KEYS_ENDPOINT_URI),
+            argThat(httpEntityContainsMandatoryHeadersAndBody()),
+            eq(Map.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_withEmptyParams_executesSuccessfully()
+      throws OAuth2ServiceException {
+    mockResponse(responseBody, 200);
+
+    final Map<String, String> emptyParams = Map.of();
+    final OAuth2TokenResponse result =
+        cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, emptyParams);
+
+    assertThat(result).isNotNull();
+    Mockito.verify(restOperationsMock, times(1))
+        .postForEntity(eq(TOKEN_KEYS_ENDPOINT_URI), any(), eq(Map.class));
+  }
+
+  @Test
+  void requestAccessToken_successfulResponse_returnsTokenResponse() throws OAuth2ServiceException {
+    mockResponse(responseBody, 200);
+
+    final OAuth2TokenResponse result =
+        cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAccessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+    assertThat(result.getRefreshToken()).isEqualTo(TEST_REFRESH_TOKEN);
+    assertThat(result.getTokenType()).isEqualTo(TEST_TOKEN_TYPE);
+    assertThat(result.getExpiredAt()).isAfter(Instant.now());
+  }
+
+  @Test
+  public void
+      retrieveTokenKeys_numberFormatExceptionWhileParsingExpiresIn_throwsServiceException() {
+    mockResponse(Map.of(ACCESS_TOKEN, TEST_ACCESS_TOKEN, EXPIRES_IN, "STRING"), 200);
+
+    assertThatThrownBy(() -> cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining("Invalid expires_in value")
+        .hasMessageNotContaining("Request Headers [")
+        .hasMessageNotContaining("Response Headers [")
+        .hasMessageContaining("Response body 'For input string: \"STRING\"'");
+  }
+
+  @Test
+  void retrieveTokenKeys_responseNotOk_retry_executesRetrySuccessfully() throws IOException {
+    mockResponse(responseBody, 500, 200);
+    setConfigurationValues(1, Set.of(500));
+
+    final OAuth2TokenResponse result =
+        cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS);
+
+    Mockito.verify(restOperationsMock, times(2))
+        .postForEntity(eq(TOKEN_KEYS_ENDPOINT_URI), any(), eq(Map.class));
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  void retrieveTokenKeys_allRetryableStatusCodes_executesRetrySuccessfullyWithBadResponse() {
+    mockResponse(responseBody, 408, 429, 500, 502, 503, 504, 400);
+    setConfigurationValues(10, Set.of(408, 429, 500, 502, 503, 504));
+
+    assertThatThrownBy(() -> cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("User-Agent: token-client/")
+        .hasMessageContaining("expires_in=1000")
+        .hasMessageContaining("access_token=Valid Access token")
+        .hasMessageContaining("token_type=TOKEN TYPE")
+        .hasMessageContaining("Server error while obtaining access token from XSUAA!")
+        .hasMessageContaining("Http status code 400");
+    Mockito.verify(restOperationsMock, times(7))
+        .postForEntity(eq(TOKEN_KEYS_ENDPOINT_URI), any(), eq(Map.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_noRetryableStatusCodesSet_executesNoRetry() {
+    mockResponse(responseBody, 500);
+    setConfigurationValues(10, Set.of());
+
+    assertThatThrownBy(() -> cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("User-Agent: token-client/")
+        .hasMessageContaining("expires_in=1000")
+        .hasMessageContaining("access_token=Valid Access token")
+        .hasMessageContaining("token_type=TOKEN TYPE")
+        .hasMessageContaining("Server error while obtaining access token from XSUAA!")
+        .hasMessageContaining("Http status code 500");
+    Mockito.verify(restOperationsMock, times(1))
+        .postForEntity(eq(TOKEN_KEYS_ENDPOINT_URI), any(), eq(Map.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_retryLogic_maxAttemptsReached_throwsException() {
+    mockResponse(responseBody, 500, 500, 500, 500);
+    setConfigurationValues(2, Set.of(500));
+
+    assertThatThrownBy(() -> cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS))
+        .isInstanceOf(OAuth2ServiceException.class)
+        .hasMessageContaining(TOKEN_KEYS_ENDPOINT_URI.toString())
+        .hasMessageContaining("Request Headers [")
+        .hasMessageContaining("Response Headers [")
+        .hasMessageContaining("User-Agent: token-client/")
+        .hasMessageContaining("expires_in=1000")
+        .hasMessageContaining("access_token=Valid Access token")
+        .hasMessageContaining("token_type=TOKEN TYPE")
+        .hasMessageContaining("Server error while obtaining access token from XSUAA!")
+        .hasMessageContaining("Http status code 500");
+    Mockito.verify(restOperationsMock, times(3))
+        .postForEntity(eq(TOKEN_KEYS_ENDPOINT_URI), any(), eq(Map.class));
+  }
+
+  @Test
+  public void retrieveTokenKeys_interruptedExceptionDuringRetry_logsWarning()
+      throws OAuth2ServiceException {
+    mockResponse(responseBody, 500, 200);
+    setConfigurationValues(1, Set.of(500));
+
+    // Set up log capturing
+    final Logger logger = (Logger) LoggerFactory.getLogger(XsuaaOAuth2TokenService.class);
+    final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    logger.addAppender(listAppender);
+
+    Thread.currentThread().interrupt(); // Simulate InterruptedException
+
+    cut.requestAccessToken(TOKEN_KEYS_ENDPOINT_URI, headers, PARAMS);
+
+    final List<ILoggingEvent> logsList = listAppender.list;
+    assertThat(logsList).extracting(ILoggingEvent::getLevel).contains(Level.WARN);
+    assertThat(logsList)
+        .extracting(ILoggingEvent::getFormattedMessage)
+        .contains("Thread.sleep has been interrupted. Retry starts now.");
+    logger.detachAppender(listAppender);
+    Mockito.verify(restOperationsMock, times(2))
+        .postForEntity(eq(TOKEN_KEYS_ENDPOINT_URI), any(), eq(Map.class));
+  }
+
+  private void mockResponse(final Map<String, String> responseMap, final Integer... statusCodes) {
+    final MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+    headers.add("Content-Type", "application/json");
+    final List<ResponseEntity<Map<String, String>>> responses =
+        Arrays.stream(statusCodes)
+            .map(
+                statusCode ->
+                    new ResponseEntity<>(responseMap, headers, HttpStatus.valueOf(statusCode)))
+            .toList();
+    final AtomicInteger index = new AtomicInteger(0);
+    when(restOperationsMock.postForEntity(
+            eq(TOKEN_KEYS_ENDPOINT_URI), any(HttpEntity.class), eq(Map.class)))
+        .thenAnswer(
+            invocation -> {
+              final int currentIndex = index.getAndIncrement();
+              return responses.get(currentIndex);
+            });
+  }
+
+  private static void setConfigurationValues(
+      final int maxRetryAttempts, final Set<Integer> retryStatusCodes) {
+    final DefaultTokenClientConfiguration config = DefaultTokenClientConfiguration.getInstance();
+    config.setRetryEnabled(true);
+    config.setMaxRetryAttempts(maxRetryAttempts);
+    config.setRetryStatusCodes(retryStatusCodes);
+    config.setRetryDelayTime(0L);
+  }
+
+  private ArgumentMatcher<HttpEntity> httpEntityContainsMandatoryHeadersAndBody() {
+    return (httpGet) -> {
+      final boolean correctClientId = httpGet.getBody().toString().contains(CLIENT_ID);
+      final boolean correctAppTid = httpGet.getBody().toString().contains(APP_TID);
+      final boolean correctAzp = httpGet.getBody().toString().contains(AZP);
+      final boolean correctCorrelationID =
+          !httpGet.getHeaders().get(MDCHelper.CORRELATION_HEADER).get(0).isBlank();
+      final boolean correctUserAgent =
+          !httpGet
+              .getHeaders()
+              .get(org.springframework.http.HttpHeaders.USER_AGENT)
+              .get(0)
+              .isBlank();
+      return correctAppTid
+          && correctClientId
+          && correctAzp
+          && correctCorrelationID
+          && correctUserAgent;
+    };
+  }
+}

--- a/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/tokenflows/TestConstants.java
+++ b/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/tokenflows/TestConstants.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.tokenflows;
+
+import com.sap.cloud.security.config.ClientCredentials;
+
+import java.net.URI;
+
+//@formatter:off
+interface TestConstants {
+	URI XSUAA_BASE_URI = URI.create("https://subdomain.authentication.eu10.hana.ondemand.com/");
+	URI TOKEN_ENDPOINT_URI = URI.create("https://subdomain.authentication.eu10.hana.ondemand.com/oauth/token");
+	ClientCredentials CLIENT_CREDENTIALS = new ClientCredentials("sb-spring-netflix-demo!t12291",
+			"2Tc2Xz7DNy4KiACwvunulmxF32w=");
+	String USERNAME = "Bob";
+	String PASSWORD = "qwerty";
+	String ACCESS_TOKEN = "8fea5fdea005417d8c7104a5a4165da2";
+	String REFRESH_TOKEN = "c9336d3de6b7450b8b14cc61362d595d";
+	String JWT_BEARER_TOKEN = "cabb9a945e43f5d9d7eb5aa7c";
+	long EXPIRED_IN = 4223;
+}
+//@formatter:on

--- a/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/tokenflows/XsuaaTokenFlowsTest.java
+++ b/token-client-spring-3/src/test/java/com/sap/cloud/security/xsuaa/tokenflows/XsuaaTokenFlowsTest.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.xsuaa.tokenflows;
+
+import com.sap.cloud.security.config.ClientCredentials;
+import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
+import com.sap.cloud.security.xsuaa.client.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
+import static com.sap.cloud.security.xsuaa.tokenflows.TestConstants.CLIENT_CREDENTIALS;
+import static com.sap.cloud.security.xsuaa.tokenflows.TestConstants.XSUAA_BASE_URI;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+@ExtendWith(MockitoExtension.class)
+public class XsuaaTokenFlowsTest {
+
+	private static OAuth2ServiceConfiguration oAuth2ServiceConfiguration;
+	private XsuaaTokenFlows cut;
+	private OAuth2ServiceEndpointsProvider endpointsProvider;
+	private OAuth2TokenService oAuth2TokenService;
+	private RestOperations restOperations;
+
+	@BeforeEach
+	public void setup() {
+		oAuth2ServiceConfiguration = Mockito.mock(OAuth2ServiceConfiguration.class);
+		Mockito.when(oAuth2ServiceConfiguration.getUrl()).thenReturn(XSUAA_BASE_URI);
+		this.endpointsProvider = new XsuaaDefaultEndpoints(oAuth2ServiceConfiguration);
+		this.restOperations = Mockito.mock(RestTemplate.class);
+		Map responseMap = new HashMap<>();
+		responseMap.put(ACCESS_TOKEN, "f529.dd6e30.d454677322aaabb0");
+		responseMap.put(EXPIRES_IN, "43199");
+		responseMap.put(TOKEN_TYPE, "bearer");
+		Mockito.lenient().when(restOperations.postForEntity(any(URI.class), any(HttpEntity.class), eq(Map.class)))
+				.thenReturn(new ResponseEntity<>(responseMap, HttpStatus.OK));
+		this.oAuth2TokenService = new XsuaaOAuth2TokenService(restOperations);
+		cut = new XsuaaTokenFlows(oAuth2TokenService, this.endpointsProvider, CLIENT_CREDENTIALS);
+	}
+
+	@Test
+	public void constructor_throwsOnNullValues() {
+		assertThatThrownBy(() -> {
+			new XsuaaTokenFlows(null, endpointsProvider, CLIENT_CREDENTIALS);
+		}).isInstanceOf(IllegalArgumentException.class).hasMessageStartingWith("OAuth2TokenService");
+
+		assertThatThrownBy(() -> {
+			new XsuaaTokenFlows(oAuth2TokenService, null, CLIENT_CREDENTIALS);
+		}).isInstanceOf(IllegalArgumentException.class).hasMessageStartingWith("OAuth2ServiceEndpointsProvider");
+
+		assertThatThrownBy(() -> {
+			new XsuaaTokenFlows(oAuth2TokenService, endpointsProvider, null);
+		}).isInstanceOf(IllegalArgumentException.class).hasMessageStartingWith("ClientIdentity");
+
+	}
+
+	@Test
+	public void startRefreshTokenFlow() {
+		RefreshTokenFlow flow = cut.refreshTokenFlow();
+		assertThat(flow).isNotNull();
+	}
+
+	@Test
+	public void startClientCredentialsFlow() {
+		ClientCredentialsTokenFlow flow = cut.clientCredentialsTokenFlow();
+		assertThat(flow).isNotNull();
+	}
+
+	@Test
+	public void startPasswordTokenFlow() {
+		PasswordTokenFlow flow = cut.passwordTokenFlow();
+		assertThat(flow).isNotNull();
+	}
+
+	@Test
+	public void versionMismatch() throws TokenFlowException {
+		cut = new XsuaaTokenFlows(oAuth2TokenService, this.endpointsProvider,
+				new ClientCredentials("sb-spring-netflix-demo!t12291",
+						"2Tc2Xz7DNy4KiACwvunulmxF32w="));
+		cut.clientCredentialsTokenFlow().execute();
+	}
+
+	@Test
+	public void disableCaching() throws TokenFlowException {
+		OAuth2TokenService tokenService = new XsuaaOAuth2TokenService(restOperations,
+				TokenCacheConfiguration.cacheDisabled());
+		XsuaaTokenFlows tokenFlows = new XsuaaTokenFlows(tokenService,
+				this.endpointsProvider, CLIENT_CREDENTIALS);
+		OAuth2TokenResponse response = tokenFlows.clientCredentialsTokenFlow().execute();
+		assertThat(response).isNotNull();
+		assertThat(response).isNotEqualTo(tokenFlows.clientCredentialsTokenFlow().execute());
+	}
+
+	@Test
+	public void disableCacheOnce() throws TokenFlowException {
+		OAuth2TokenService tokenService = new XsuaaOAuth2TokenService(restOperations);
+		XsuaaTokenFlows tokenFlows = new XsuaaTokenFlows(tokenService,
+				this.endpointsProvider, CLIENT_CREDENTIALS);
+		OAuth2TokenResponse response = tokenFlows.clientCredentialsTokenFlow().execute();
+		assertThat(response).isNotNull();
+		assertThat(response).isNotEqualTo(tokenFlows.clientCredentialsTokenFlow()
+				.disableCache(true).execute());
+	}
+
+	@Test
+	public void clearCacheOnDemand() throws TokenFlowException {
+		AbstractOAuth2TokenService tokenService = new XsuaaOAuth2TokenService(restOperations);
+		XsuaaTokenFlows tokenFlows = new XsuaaTokenFlows(tokenService,
+				this.endpointsProvider, CLIENT_CREDENTIALS);
+		OAuth2TokenResponse response = tokenFlows.clientCredentialsTokenFlow().execute();
+		assertThat(response).isNotNull();
+		tokenService.clearCache();
+		assertThat(response).isNotEqualTo(tokenFlows.clientCredentialsTokenFlow().execute());
+	}
+}

--- a/token-client-spring-3/src/test/resources/META-INF/services/com.sap.cloud.security.client.HttpClientFactory
+++ b/token-client-spring-3/src/test/resources/META-INF/services/com.sap.cloud.security.client.HttpClientFactory
@@ -1,0 +1,2 @@
+com.sap.cloud.security.client.DefaultHttpClientFactory
+com.sap.cloud.security.client.TestHttpClientFactory

--- a/token-client-spring-3/src/test/resources/META-INF/services/com.sap.cloud.security.client.SecurityHttpClientFactory
+++ b/token-client-spring-3/src/test/resources/META-INF/services/com.sap.cloud.security.client.SecurityHttpClientFactory
@@ -1,0 +1,1 @@
+com.sap.cloud.security.client.TestSecurityHttpClientFactory

--- a/token-client-spring-3/src/test/resources/jsonWebTokenKeys.json
+++ b/token-client-spring-3/src/test/resources/jsonWebTokenKeys.json
@@ -1,0 +1,22 @@
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "key-id-0",
+      "alg": "RS256",
+      "value": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmNM3OXfZS0Uu8eYZXCgG\nWFgVWQX6MHnadYk3zHZ5PIPeDY3ApaSGpMEiVwn1cT6KUVHMLHcmz1gsNy74pCnm\nCa22W7J3BoZulzR0A37ayMVrRHh3nffgySk8u581l02bvbcpab3e3EotSN5LixGT\n1VWZvDbalXf6n5kq459NWL6ZzkEs20MrOEk5cLdnsigTQUHSKIQ5TpldyDkJMm2z\nwOlrB2R984+QdlDFmoVH7Yaujxr2g0Z96u7W9Imik6wTiFc8W7eUXfhPGn7reVLq\n1/5o2Nz0Jx0ejFHDwTGncs+k1RBS6DbpTOMr9tkJEc3ZsX3Ft4OtqCkRXI5hUma+\nHwIDAQAB\n-----END PUBLIC KEY-----",
+      "n": "AJjTNzl32UtFLvHmGVwoBlhYFVkF-jB52nWJN8x2eTyD3g2NwKWkhqTBIlcJ9XE-ilFRzCx3Js9YLDcu-KQp5gmttluydwaGbpc0dAN-2sjFa0R4d5334MkpPLufNZdNm723KWm93txKLUjeS4sRk9VVmbw22pV3-p-ZKuOfTVi-mc5BLNtDKzhJOXC3Z7IoE0FB0iiEOU6ZXcg5CTJts8DpawdkffOPkHZQxZqFR-2Gro8a9oNGferu1vSJopOsE4hXPFu3lF34Txp-63lS6tf-aNjc9CcdHoxRw8Exp3LPpNUQUug26UzjK_bZCRHN2bF9xbeDragpEVyOYVJmvh8"
+    },
+    {
+      "kty": "RSA",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "key-id-1",
+      "alg": "RS256",
+      "value": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmNM3OXfZS0Uu8eYZXCgG\nWFgVWQX6MHnadYk3zHZ5PIPeDY3ApaSGpMEiVwn1cT6KUVHMLHcmz1gsNy74pCnm\nCa22W7J3BoZulzR0A37ayMVrRHh3nffgySk8u581l02bvbcpab3e3EotSN5LixGT\n1VWZvDbalXf6n5kq459NWL6ZzkEs20MrOEk5cLdnsigTQUHSKIQ5TpldyDkJMm2z\nwOlrB2R984+QdlDFmoVH7Yaujxr2g0Z96u7W9Imik6wTiFc8W7eUXfhPGn7reVLq\n1/5o2Nz0Jx0ejFHDwTGncs+k1RBS6DbpTOMr9tkJEc3ZsX3Ft4OtqCkRXI5hUma+\nHwIDAQAB\n-----END PUBLIC KEY-----",
+      "n": "AJjTNzl32UtFLvHmGVwoBlhYFVkF-jB52nWJN8x2eTyD3g2NwKWkhqTBIlcJ9XE-ilFRzCx3Js9YLDcu-KQp5gmttluydwaGbpc0dAN-2sjFa0R4d5334MkpPLufNZdNm723KWm93txKLUjeS4sRk9VVmbw22pV3-p-ZKuOfTVi-mc5BLNtDKzhJOXC3Z7IoE0FB0iiEOU6ZXcg5CTJts8DpawdkffOPkHZQxZqFR-2Gro8a9oNGferu1vSJopOsE4hXPFu3lF34Txp-63lS6tf-aNjc9CcdHoxRw8Exp3LPpNUQUug26UzjK_bZCRHN2bF9xbeDragpEVyOYVJmvh8"
+    }
+  ]
+}

--- a/token-client-spring-3/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/token-client-spring-3/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/token-client-spring-3/src/test/resources/oidcConfiguration.json
+++ b/token-client-spring-3/src/test/resources/oidcConfiguration.json
@@ -1,0 +1,19 @@
+{
+  "issuer" : "http://localhost:8080/uaa/oauth/token",
+  "authorization_endpoint" : "http://localhost/oauth/authorize",
+  "token_endpoint" : "http://localhost/oauth/token",
+  "token_endpoint_auth_methods_supported" : [ "client_secret_basic", "client_secret_post" ],
+  "token_endpoint_auth_signing_alg_values_supported" : [ "RS256", "HS256" ],
+  "userinfo_endpoint" : "http://localhost/userinfo",
+  "jwks_uri" : "http://localhost/token_keys",
+  "scopes_supported" : [ "openid", "profile", "email", "phone", "roles", "user_attributes" ],
+  "response_types_supported" : [ "code", "code id_token", "id_token", "token id_token" ],
+  "subject_types_supported" : [ "public" ],
+  "id_token_signing_alg_values_supported" : [ "RS256", "HS256" ],
+  "id_token_encryption_alg_values_supported" : [ "none" ],
+  "claim_types_supported" : [ "normal" ],
+  "claims_supported" : [ "sub", "user_name", "origin", "iss", "auth_time", "amr", "acr", "client_id", "aud", "zid", "grant_type", "user_id", "azp", "scope", "exp", "iat", "jti", "rev_sig", "cid", "given_name", "family_name", "phone_number", "email" ],
+  "claims_parameter_supported" : false,
+  "service_documentation" : "http://docs.cloudfoundry.org/api/uaa/",
+  "ui_locales_supported" : [ "en-US" ]
+}

--- a/token-client-spring/README.md
+++ b/token-client-spring/README.md
@@ -1,10 +1,17 @@
 # Token Client Spring
 
-This module provides Spring-based implementations of the OAuth2 token service interfaces from the [token-client](../token-client) module.
+This module provides Spring-based implementations of the OAuth2 token service interfaces from the [token-client](../token-client) module, compiled against **Spring Framework 7.x** for **Spring Boot 4.x**.
 
 ## Overview
 
-Starting with version 4.0.1, Spring-specific implementations have been moved to this separate module to avoid classloader issues when `token-client` is used in environments where Spring is not available (e.g., SAP Java Buildpack's Tomcat lib folder).
+Starting with version 4.0.0, Spring-specific implementations have been moved to this separate module to avoid classloader issues when `token-client` is used in environments where Spring is not available (e.g., SAP Java Buildpack's Tomcat lib folder).
+
+**Important:** This module is compiled against Spring Framework 7.x (Spring Boot 4.x). For Spring Boot 3.x compatibility, use [token-client-spring-3](../token-client-spring-3) instead.
+
+| Module | Spring Boot | Spring Framework |
+|--------|-------------|------------------|
+| `token-client-spring` | 4.x | 7.x |
+| `token-client-spring-3` | 3.x | 6.x |
 
 ## Classes
 
@@ -41,8 +48,11 @@ XsuaaOAuth2TokenService tokenService = new XsuaaOAuth2TokenService(restTemplate)
 ## When to Use
 
 Use this module if:
+- Your application uses **Spring Boot 4.x** (Spring Framework 7.x)
 - You need Spring RestOperations integration for token flows
 - Your application already uses Spring and you want to reuse existing `RestTemplate` configuration
+
+For Spring Boot 3.x applications, use [token-client-spring-3](../token-client-spring-3) instead.
 
 For most use cases, the default `DefaultOAuth2TokenService` from `token-client` (using Java 11 HttpClient) is recommended as it has no external dependencies.
 


### PR DESCRIPTION
## Summary

- Add new `token-client-spring-3` module compiled against Spring Framework 6.x for Spring Boot 3.x compatibility
- Centralize Spring Boot 3.x versions in parent POM using `legacy3.spring.*` properties
- Update migration guide with correct Spring Boot 3.x starter module name

## Background

The `token-client-spring` module is compiled against Spring Framework 7.x (Spring Boot 4.x), which introduces a new `HttpEntity` constructor signature. When used with Spring Boot 3.x applications, this causes `NoSuchMethodError` at runtime because Spring 6.x doesn't have the same constructor.

This PR adds a separate module (`token-client-spring-3`) that is compiled against Spring 6.x, ensuring bytecode compatibility with Spring Boot 3.x applications.

## Changes

| File | Change |
|------|--------|
| `pom.xml` | Add `legacy3.spring.*` properties and new module |
| `token-client-spring-3/` | New module (same source as token-client-spring, compiled against Spring 6.x) |
| `spring-security-3/pom.xml` | Use centralized `legacy3.*` properties |
| `spring-security-3-starter/pom.xml` | Use centralized `legacy3.*` properties |
| `bom/pom.xml` | Add new artifact |
| `MIGRATION_4.0.md` | Update module name references |

## Test plan

- [x] `mvn clean install -pl token-client-spring-3` builds successfully
- [x] All tests pass in token-client-spring-3 module
- [x] Verified bytecode uses Spring 6.x compatible `HttpEntity` constructor
- [x] Full build passes