### PR TITLE
chore: Remove unused NVD_API_KEY secret from CI workflow

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -3,9 +3,6 @@
 ---
 name: Maven Build main
 
-env:
-  NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-
 on:
   push:
     branches: [ main ]
@@ -29,9 +26,9 @@ jobs:
         uses: actions/cache@v5.0.5
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-owasp-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            ${{ runner.os }}-owasp-
+            ${{ runner.os }}-maven-
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v5.2.0
         with:


### PR DESCRIPTION
## Summary
- Removes the `NVD_API_KEY` environment variable from `maven-build.yml` — it has been unused since the `dependency-check-maven` plugin was removed in #1670
- Renames the cache key from `owasp-` to `maven-` since it caches `~/.m2/repository` generally, not OWASP-specific data

## Context
Security finding flagged the long-lived secret reference. The OWASP dependency-check was replaced by Dependabot in Nov 2024 but the env variable and cache key naming were not cleaned up.

## Test plan
- [ ] CI workflow still runs successfully (cache will rebuild once due to key rename)