### PR TITLE
fix: Use tenant-agnostic XSUAA token endpoint in DefaultXsuaaTokenExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 4.0.7
+
+- Fix multi-tenant XSUAA token exchange in `DefaultXsuaaTokenExtension`
+  - The IAS-to-XSUAA exchange used the provider subdomain endpoint, which caused XSUAA to resolve the provider tenant instead of the tenant carried in the `X-zid` header (`app_tid`)
+  - Token exchange now targets a tenant-agnostic endpoint built from the `uaadomain` binding property, so XSUAA resolves the tenant via `X-zid`
+  - For X.509 credentials the host's `authentication.` segment is replaced with `authentication.cert.` (analogous to the Node.js library), e.g. `authentication.eu10.hana.ondemand.com` → `authentication.cert.eu10.hana.ondemand.com`
+  - Falls back to the existing subdomain-bearing endpoint when `uaadomain` is missing, preserving behavior for legacy bindings
+
 ## 4.0.6
 
 - Update dependencies to address known vulnerabilities:

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultXsuaaTokenExtension.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultXsuaaTokenExtension.java
@@ -133,12 +133,26 @@ public class DefaultXsuaaTokenExtension implements XsuaaTokenExtension {
             .orElseThrow(() -> new IllegalStateException("IAS token missing 'app_tid'"));
     final Map<String, String> params = Map.of("token_format", "jwt");
     final XsuaaDefaultEndpoints endpoints = new XsuaaDefaultEndpoints(xsuaaConfig);
-    final URI tokenEndpoint = endpoints.getTokenEndpoint();
+    final URI tokenEndpoint = resolveTokenEndpoint(endpoints);
 
     return Token.create(
         tokenService
             .retrieveAccessTokenViaJwtBearerTokenGrant(
                 tokenEndpoint, xsuaaConfig.getClientIdentity(), idToken.getTokenValue(), params, false, zid)
             .getAccessToken());
+  }
+
+  /**
+   * Picks the {@code uaadomain}-based token endpoint when available so that XSUAA resolves the
+   * subscriber tenant via the {@code X-zid} header instead of the request subdomain. Falls back to
+   * the subdomain-bearing endpoint for bindings without {@code uaadomain}.
+   */
+  private static URI resolveTokenEndpoint(XsuaaDefaultEndpoints endpoints) {
+    final URI uaaDomainEndpoint = endpoints.getUaaDomainTokenEndpoint();
+    if (uaaDomainEndpoint != null) {
+      return uaaDomainEndpoint;
+    }
+    LOGGER.debug("XSUAA 'uaadomain' not present in configuration; falling back to subdomain-bearing token endpoint");
+    return endpoints.getTokenEndpoint();
   }
 }

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
@@ -107,7 +107,7 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 			return null;
 		}
 		String host = certificateBased ? uaaDomain.replace(AUTHENTICATION_HOST, AUTHENTICATION_CERT_HOST) : uaaDomain;
-		return URI.create("https://" + host + TOKEN_ENDPOINT);
+		return expandPath(URI.create("https://" + host), TOKEN_ENDPOINT);
 	}
 
 }

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
@@ -10,6 +10,7 @@ import static com.sap.cloud.security.xsuaa.util.UriUtil.expandPath;
 
 import com.sap.cloud.security.config.CredentialType;
 import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
+import com.sap.cloud.security.config.ServiceConstants;
 import java.net.URI;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -19,10 +20,13 @@ import org.slf4j.LoggerFactory;
 public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	private final URI baseUri;
 	private final URI certUri;
+	@Nullable
+	private final String uaaDomain;
   private Boolean certificateBased = false;
 	private static final String TOKEN_ENDPOINT = "/oauth/token";
 	private static final String AUTHORIZE_ENDPOINT = "/oauth/authorize";
 	private static final String KEYSET_ENDPOINT = "/token_keys";
+	private static final String CERT_HOST_PREFIX = "cert.";
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(XsuaaDefaultEndpoints.class);
 
@@ -40,6 +44,7 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 		LOGGER.debug("Xsuaa default service endpoint: base url = {}, (cert url = {})", baseUri, certUri);
 		this.baseUri = URI.create(baseUri);
 		this.certUri = certUri != null ? URI.create(certUri) : null;
+		this.uaaDomain = null;
 	}
 
 	/**
@@ -52,6 +57,7 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	public XsuaaDefaultEndpoints(@Nonnull OAuth2ServiceConfiguration config) {
 		assertNotNull(config, "OAuth2ServiceConfiguration must not be null.");
 		this.baseUri = config.getUrl();
+		this.uaaDomain = config.getProperty(ServiceConstants.XSUAA.UAA_DOMAIN);
 		final CredentialType credentialType = config.getCredentialType() != null ? config.getCredentialType() : CredentialType.BINDING_SECRET;
     this.certUri =
         switch (credentialType) {
@@ -81,6 +87,25 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	public URI getJwksUri() {
 		assertNotNull(baseUri, "XsuaaDefaultEndpoints.getJwksUri() requires baseUri not to be null.");
 		return expandPath(baseUri, KEYSET_ENDPOINT);
+	}
+
+	/**
+	 * Returns the token endpoint URI built from the XSUAA {@code uaadomain} property (i.e. without
+	 * any tenant subdomain). Use this when the request carries a tenant identifier via the
+	 * {@code X-zid} header so XSUAA can resolve the tenant server-side instead of via subdomain.
+	 * <p>
+	 * For X.509-based credentials the host is prefixed with {@code cert.}.
+	 *
+	 * @return the {@code uaadomain}-based token endpoint, or {@code null} if {@code uaadomain} is not
+	 * 		present in the configuration (e.g. for the legacy {@code (baseUri, certUri)} constructor).
+	 */
+	@Nullable
+	public URI getUaaDomainTokenEndpoint() {
+		if (uaaDomain == null || uaaDomain.isBlank()) {
+			return null;
+		}
+		String host = certificateBased ? CERT_HOST_PREFIX + uaaDomain : uaaDomain;
+		return URI.create("https://" + host + TOKEN_ENDPOINT);
 	}
 
 }

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
@@ -26,7 +26,8 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	private static final String TOKEN_ENDPOINT = "/oauth/token";
 	private static final String AUTHORIZE_ENDPOINT = "/oauth/authorize";
 	private static final String KEYSET_ENDPOINT = "/token_keys";
-	private static final String CERT_HOST_PREFIX = "cert.";
+	private static final String AUTHENTICATION_HOST = "authentication.";
+	private static final String AUTHENTICATION_CERT_HOST = "authentication.cert.";
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(XsuaaDefaultEndpoints.class);
 
@@ -94,7 +95,8 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 	 * any tenant subdomain). Use this when the request carries a tenant identifier via the
 	 * {@code X-zid} header so XSUAA can resolve the tenant server-side instead of via subdomain.
 	 * <p>
-	 * For X.509-based credentials the host is prefixed with {@code cert.}.
+	 * For X.509-based credentials the {@code authentication.} host segment is replaced with
+	 * {@code authentication.cert.}.
 	 *
 	 * @return the {@code uaadomain}-based token endpoint, or {@code null} if {@code uaadomain} is not
 	 * 		present in the configuration (e.g. for the legacy {@code (baseUri, certUri)} constructor).
@@ -104,7 +106,7 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 		if (uaaDomain == null || uaaDomain.isBlank()) {
 			return null;
 		}
-		String host = certificateBased ? CERT_HOST_PREFIX + uaaDomain : uaaDomain;
+		String host = certificateBased ? uaaDomain.replace(AUTHENTICATION_HOST, AUTHENTICATION_CERT_HOST) : uaaDomain;
 		return URI.create("https://" + host + TOKEN_ENDPOINT);
 	}
 

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultXsuaaTokenExtensionTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultXsuaaTokenExtensionTest.java
@@ -14,12 +14,14 @@ import com.sap.cloud.security.config.ClientCertificate;
 import com.sap.cloud.security.config.ClientCredentials;
 import com.sap.cloud.security.config.CredentialType;
 import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
+import com.sap.cloud.security.config.ServiceConstants;
 import com.sap.cloud.security.token.SecurityContext;
 import com.sap.cloud.security.token.Token;
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -170,6 +172,75 @@ public class DefaultXsuaaTokenExtensionTest {
       Token result = cut.resolveXsuaaToken(xsuaaToken);
 
       assertThat(result).isNull();
+    }
+  }
+
+  @Test
+  public void exchangeToXsuaa_uaadomainPresent_callsTenantAgnosticEndpoint()
+      throws OAuth2ServiceException {
+    try (MockedStatic<Token> token = mockStatic(Token.class)) {
+      try (MockedStatic<SecurityContext> securityContext = mockStatic(SecurityContext.class)) {
+        securityContext.when(SecurityContext::getIdToken).thenReturn(idToken);
+        token.when(() -> Token.create("TOKEN")).thenReturn(xsuaaToken);
+        when(xsuaaConfig.getCredentialType()).thenReturn(CredentialType.BINDING_SECRET);
+        when(xsuaaConfig.getClientIdentity()).thenReturn(new ClientCredentials("CLIENT_ID", "SECRET"));
+        when(xsuaaConfig.getProperty(ServiceConstants.XSUAA.UAA_DOMAIN))
+            .thenReturn("authentication.eu10.hana.ondemand.com");
+
+        cut.resolveXsuaaToken(null);
+
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(tokenService, times(1))
+            .retrieveAccessTokenViaJwtBearerTokenGrant(
+                uriCaptor.capture(), any(), eq("TOKEN"), any(), eq(false), eq("APP_TID"));
+        assertThat(uriCaptor.getValue())
+            .isEqualTo(URI.create("https://authentication.eu10.hana.ondemand.com/oauth/token"));
+      }
+    }
+  }
+
+  @Test
+  public void exchangeToXsuaa_uaadomainPresentAndCertBased_usesCertHostPrefix()
+      throws OAuth2ServiceException {
+    try (MockedStatic<Token> token = mockStatic(Token.class)) {
+      try (MockedStatic<SecurityContext> securityContext = mockStatic(SecurityContext.class)) {
+        securityContext.when(SecurityContext::getIdToken).thenReturn(idToken);
+        token.when(() -> Token.create("TOKEN")).thenReturn(xsuaaToken);
+        when(xsuaaConfig.getCredentialType()).thenReturn(CredentialType.X509);
+        when(xsuaaConfig.getProperty(ServiceConstants.XSUAA.UAA_DOMAIN))
+            .thenReturn("authentication.eu10.hana.ondemand.com");
+
+        cut.resolveXsuaaToken(null);
+
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(tokenService, times(1))
+            .retrieveAccessTokenViaJwtBearerTokenGrant(
+                uriCaptor.capture(), any(ClientCertificate.class), eq("TOKEN"), any(), eq(false), eq("APP_TID"));
+        assertThat(uriCaptor.getValue())
+            .isEqualTo(URI.create("https://cert.authentication.eu10.hana.ondemand.com/oauth/token"));
+      }
+    }
+  }
+
+  @Test
+  public void exchangeToXsuaa_uaadomainBlank_fallsBackToSubdomainEndpoint()
+      throws OAuth2ServiceException {
+    try (MockedStatic<Token> token = mockStatic(Token.class)) {
+      try (MockedStatic<SecurityContext> securityContext = mockStatic(SecurityContext.class)) {
+        securityContext.when(SecurityContext::getIdToken).thenReturn(idToken);
+        token.when(() -> Token.create("TOKEN")).thenReturn(xsuaaToken);
+        when(xsuaaConfig.getCredentialType()).thenReturn(CredentialType.X509);
+        when(xsuaaConfig.getCertUrl()).thenReturn(URI.create("https://provider.cert.eu10.hana.ondemand.com"));
+        when(xsuaaConfig.getProperty(ServiceConstants.XSUAA.UAA_DOMAIN)).thenReturn("   ");
+
+        cut.resolveXsuaaToken(null);
+
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(tokenService, times(1))
+            .retrieveAccessTokenViaJwtBearerTokenGrant(
+                uriCaptor.capture(), any(ClientCertificate.class), eq("TOKEN"), any(), eq(false), eq("APP_TID"));
+        assertThat(uriCaptor.getValue().getHost()).isEqualTo("provider.cert.eu10.hana.ondemand.com");
+      }
     }
   }
 }

--- a/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultXsuaaTokenExtensionTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/xsuaa/client/DefaultXsuaaTokenExtensionTest.java
@@ -217,7 +217,7 @@ public class DefaultXsuaaTokenExtensionTest {
             .retrieveAccessTokenViaJwtBearerTokenGrant(
                 uriCaptor.capture(), any(ClientCertificate.class), eq("TOKEN"), any(), eq(false), eq("APP_TID"));
         assertThat(uriCaptor.getValue())
-            .isEqualTo(URI.create("https://cert.authentication.eu10.hana.ondemand.com/oauth/token"));
+            .isEqualTo(URI.create("https://authentication.cert.eu10.hana.ondemand.com/oauth/token"));
       }
     }
   }


### PR DESCRIPTION
## Summary

`DefaultXsuaaTokenExtension` always built its token endpoint with `XsuaaDefaultEndpoints#getTokenEndpoint()`, which returns the URL **including the provider's subdomain** (taken from `config.getUrl()`).

In multi-tenant setups this is wrong: when exchanging an IAS token for an XSUAA token on behalf of a subscriber tenant (carried in `app_tid` → `X-zid` header), XSUAA needs a tenant-agnostic host so it can resolve the tenant from the header. If the request hits the provider subdomain, XSUAA resolves to the *provider* tenant instead of the subscriber, and the `X-zid` is effectively ignored.

## Fix

- Add `XsuaaDefaultEndpoints#getTenantAgnosticTokenEndpoint()` that builds the token endpoint from the `uaadomain` binding property (no subdomain). For X.509 credentials the host is prefixed with `cert.` to match how the rest of the library builds cert URLs.
- `DefaultXsuaaTokenExtension` prefers the tenant-agnostic endpoint when available, falling back to `getTokenEndpoint()` if `uaadomain` is missing/blank — preserves current behavior for legacy bindings.
- The legacy `XsuaaDefaultEndpoints(baseUri, certUri)` constructor returns `null` from the new getter (no `uaadomain` available), so its callers stay on the existing path.

## Why this approach (vs. `UriUtil.replaceSubdomain`)

`AbstractOAuth2TokenService` uses `UriUtil.replaceSubdomain` because callers there can supply the subscriber subdomain explicitly. In the IAS→XSUAA exchange path we only have `app_tid`, not a subdomain — and XSUAA accepts either subdomain *or* `X-zid` for tenant resolution (subdomain wins when both are set). So building a domain-only URL and letting `X-zid` do the routing is the natural fit and avoids needing an additional `app_tid → subdomain` lookup.

Long-term we should consider deprecating the subdomain-replace path entirely in favor of binding-derived endpoints, but that's out of scope for this bugfix.

## Test plan

- [x] New unit tests in `DefaultXsuaaTokenExtensionTest`:
  - `uaadomain` set, secret-based → request hits `https://{uaadomain}/oauth/token`
  - `uaadomain` set, cert-based → request hits `https://cert.{uaadomain}/oauth/token`
  - `uaadomain` blank → falls back to existing subdomain-bearing endpoint
- [x] All 182 `token-client` tests still pass
- [ ] Verify against a real multi-tenant IAS↔XSUAA setup that subscriber resolution works correctly