### PR TITLE
chore: Release 3.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The SAP Cloud Security Services Integration is published to maven central: https
         <dependency>
             <groupId>com.sap.cloud.security</groupId>
             <artifactId>java-bom</artifactId>
-            <version>3.7.3</version>
+            <version>3.7.4</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-bom</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
     <packaging>pom</packaging>
     <name>java-bom</name>
 

--- a/env/pom.xml
+++ b/env/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>3.7.3</version>
+        <version>3.7.4</version>
     </parent>
 
     <groupId>com.sap.cloud.security</groupId>

--- a/java-api/README.md
+++ b/java-api/README.md
@@ -5,6 +5,6 @@
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-api</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 ```

--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security-it/pom.xml
+++ b/java-security-it/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
-        <version>3.7.3</version>
+        <version>3.7.4</version>
     </parent>
 
     <artifactId>java-security-it</artifactId>

--- a/java-security-test/README.md
+++ b/java-security-test/README.md
@@ -40,7 +40,7 @@ It is pre-configured with a security filter that only accepts valid tokens. Furt
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
    <artifactId>java-security-test</artifactId>
-      <version>3.7.3</version>
+      <version>3.7.4</version>
    <scope>test</scope>
 </dependency>
 ```

--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -69,7 +69,7 @@ Since it requires the Tomcat 10 runtime, it needs to be deployed using the [SAP 
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-security</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>com.sap.cloud.security.xsuaa</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.7.3</version>
+	<version>3.7.4</version>
 	<packaging>pom</packaging>
 
 	<name>parent</name>

--- a/samples/java-security-usage-ias/pom.xml
+++ b/samples/java-security-usage-ias/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage-ias</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
     <packaging>war</packaging>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/samples/java-security-usage/pom.xml
+++ b/samples/java-security-usage/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
     <packaging>war</packaging>
 
     <!--profiles>

--- a/samples/java-tokenclient-usage/pom.xml
+++ b/samples/java-tokenclient-usage/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-tokenclient-usage</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
     <packaging>war</packaging>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/samples/sap-java-buildpack-api-usage/pom.xml
+++ b/samples/sap-java-buildpack-api-usage/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.cloud.security.xssec.samples</groupId>
 	<artifactId>sap-java-buildpack-api-usage</artifactId>
-	<version>3.7.3</version>
+	<version>3.7.4</version>
 	<packaging>war</packaging>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/samples/spring-security-basic-auth/pom.xml
+++ b/samples/spring-security-basic-auth/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<artifactId>spring-security-basic-auth</artifactId>
-	<version>3.7.3</version>
+	<version>3.7.4</version>
 	<name>spring-security-basic-auth</name>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>com.sap.cloud.security</groupId>
 			<artifactId>java-security-test</artifactId>
-			<version>3.7.3</version>
+			<version>3.7.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/samples/spring-security-hybrid-usage/pom.xml
+++ b/samples/spring-security-hybrid-usage/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-hybrid-usage</artifactId>
-	<version>3.7.3</version>
+	<version>3.7.4</version>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring security hybrid usage sample</description>
@@ -104,7 +104,7 @@
 		<dependency>
 			<groupId>com.sap.hcp.cf.logging</groupId>
 			<artifactId>cf-java-logging-support-servlet-jakarta</artifactId>
-			<version>3.7.3</version>
+			<version>3.7.4</version>
 		</dependency>
 
 		<!-- test dependencies-->

--- a/samples/spring-security-hybrid-usage/pom.xml
+++ b/samples/spring-security-hybrid-usage/pom.xml
@@ -104,7 +104,7 @@
 		<dependency>
 			<groupId>com.sap.hcp.cf.logging</groupId>
 			<artifactId>cf-java-logging-support-servlet-jakarta</artifactId>
-			<version>3.7.4</version>
+			<version>3.7.3</version>
 		</dependency>
 
 		<!-- test dependencies-->

--- a/samples/spring-security-xsuaa-usage/pom.xml
+++ b/samples/spring-security-xsuaa-usage/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-xsuaa-usage</artifactId>
-	<version>3.7.3</version>
+	<version>3.7.4</version>
 	<name>spring-security-xsuaa-usage</name>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/samples/spring-webflux-security-hybrid-usage/pom.xml
+++ b/samples/spring-webflux-security-hybrid-usage/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.sap.cloud.security.samples</groupId>
     <artifactId>spring-webflux-security-hybrid-usage</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
     <name>spring-webflux-security-hybrid-usage</name>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/spring-security-compatibility/pom.xml
+++ b/spring-security-compatibility/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>3.7.3</version>
+        <version>3.7.4</version>
     </parent>
 
     <groupId>com.sap.cloud.security.xsuaa</groupId>

--- a/spring-security-starter/pom.xml
+++ b/spring-security-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/spring-security/README.md
+++ b/spring-security/README.md
@@ -68,7 +68,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 ```
 

--- a/spring-security/pom.xml
+++ b/spring-security/pom.xml
@@ -9,14 +9,14 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>
 	<artifactId>spring-security</artifactId>
 	<name>spring-security</name>
 	<packaging>jar</packaging>
-	<version>3.7.3</version>
+	<version>3.7.4</version>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring security library</description>

--- a/spring-xsuaa-it/pom.xml
+++ b/spring-xsuaa-it/pom.xml
@@ -14,7 +14,7 @@
 
 	<artifactId>spring-xsuaa-it</artifactId>
 	<name>spring-xsuaa-it</name>
-	<version>3.7.3</version>
+	<version>3.7.4</version>
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring XSUAA IT library</description>
 

--- a/spring-xsuaa-starter/pom.xml
+++ b/spring-xsuaa-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<artifactId>xsuaa-spring-boot-starter</artifactId>

--- a/spring-xsuaa-test/README.md
+++ b/spring-xsuaa-test/README.md
@@ -31,7 +31,7 @@ This includes for example a `JwtGenerator` that generates JSON Web Tokens (JWT) 
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa-test</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
     <scope>test</scope>
 </dependency>
 

--- a/spring-xsuaa-test/pom.xml
+++ b/spring-xsuaa-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<artifactId>spring-xsuaa-test</artifactId>

--- a/spring-xsuaa/README.md
+++ b/spring-xsuaa/README.md
@@ -39,7 +39,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 <dependency> <!-- new with version 1.5.0 -->
     <groupId>org.apache.logging.log4j</groupId>
@@ -53,7 +53,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>xsuaa-spring-boot-starter</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 ```
 

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<artifactId>spring-xsuaa</artifactId>

--- a/token-client-core/README.md
+++ b/token-client-core/README.md
@@ -26,7 +26,7 @@ Use `token-client-core` if:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-core</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/token-client-core/pom.xml
+++ b/token-client-core/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<artifactId>token-client-core</artifactId>

--- a/token-client-core/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
+++ b/token-client-core/src/main/java/com/sap/cloud/security/xsuaa/client/XsuaaDefaultEndpoints.java
@@ -107,7 +107,7 @@ public class XsuaaDefaultEndpoints implements OAuth2ServiceEndpointsProvider {
 			return null;
 		}
 		String host = certificateBased ? uaaDomain.replace(AUTHENTICATION_HOST, AUTHENTICATION_CERT_HOST) : uaaDomain;
-		return URI.create("https://" + host + TOKEN_ENDPOINT);
+		return expandPath(URI.create("https://" + host), TOKEN_ENDPOINT);
 	}
 
 }

--- a/token-client-spring/README.md
+++ b/token-client-spring/README.md
@@ -25,7 +25,7 @@ Use `token-client-spring` if:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-spring</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 <dependency>
     <groupId>org.springframework</groupId>
@@ -51,7 +51,7 @@ For Spring Boot applications, it's recommended to use the autoconfiguration prov
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 ```
 

--- a/token-client-spring/pom.xml
+++ b/token-client-spring/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<artifactId>token-client-spring</artifactId>

--- a/token-client/README.md
+++ b/token-client/README.md
@@ -43,7 +43,7 @@ Contains all core functionality without Spring dependencies:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-core</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Contains Spring-specific implementations:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-spring</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 ```
 
@@ -75,7 +75,7 @@ A convenience module that includes both `token-client-core` and `token-client-sp
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 ```
 
@@ -114,7 +114,7 @@ In context of a Spring Boot application you can leverage autoconfiguration provi
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 ```
 In context of Spring Applications you will need the following dependencies:
@@ -123,19 +123,19 @@ In context of Spring Applications you will need the following dependencies:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 
 <!-- Option 2: Use only what you need -->
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-core</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-spring</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 
 <!-- Apache HttpClient is still required -->
@@ -205,7 +205,7 @@ See the [OAuth2ServiceConfiguration](#oauth2serviceconfiguration) section and [H
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-core</artifactId>
-    <version>3.7.3</version>
+    <version>3.7.4</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/token-client/pom.xml
+++ b/token-client/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.3</version>
+		<version>3.7.4</version>
 	</parent>
 
 	<artifactId>token-client</artifactId>


### PR DESCRIPTION
## Summary

- Bump project version from 3.7.3 to 3.7.4 across all modules, READMEs and samples
- Includes the multi-tenant XSUAA token exchange fix from #1973: tenant-agnostic `uaadomain` endpoint in `DefaultXsuaaTokenExtension`, with `authentication.` → `authentication.cert.` host substitution for X.509 credentials (analogous to the Node.js library)

## Test plan

- [ ] CI pipeline green
- [ ] Maven validate / build passes locally
- [ ] Confirm bugfix PR #1973 is merged or this PR supersedes it
- [ ] Verify CHANGELOG.md entry for 3.7.4 is accurate