### PR TITLE
fix: Restore mTLS handshake by initializing SSLContext with explicit TrustManager (3.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## 3.7.4
 
+- Fix mTLS handshake regression introduced in 3.6.7 (`SSLContextFactory`)
+  - Restore `SunX509` as the preferred `KeyManagerFactory` algorithm and only fall back to the JVM default algorithm when `SunX509` is unavailable (FIPS providers like Bouncy Castle)
+  - Initialize the `SSLContext` with an explicit `TrustManagerFactory` backed by the system default trust store instead of passing `null`, fixing `(certificate_unknown) No X509TrustManager implementation available` failures observed on certain runtime configurations
 - Fix multi-tenant XSUAA token exchange in `DefaultXsuaaTokenExtension`
   - The IAS-to-XSUAA exchange used the provider subdomain endpoint, which caused XSUAA to resolve the provider tenant instead of the tenant carried in the `X-zid` header (`app_tid`)
   - Token exchange now targets a tenant-agnostic endpoint built from the `uaadomain` binding property, so XSUAA resolves the tenant via `X-zid`

--- a/token-client-core/src/main/java/com/sap/cloud/security/mtls/SSLContextFactory.java
+++ b/token-client-core/src/main/java/com/sap/cloud/security/mtls/SSLContextFactory.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -93,11 +94,24 @@ public class SSLContextFactory {
 	 */
 	public SSLContext create(ClientIdentity clientIdentity) throws GeneralSecurityException, IOException {
 		KeyStore keystore = createKeyStore(clientIdentity);
-		KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+		KeyManagerFactory keyManagerFactory = createKeyManagerFactory();
 		keyManagerFactory.init(keystore, noPassword);
+		TrustManagerFactory trustManagerFactory = TrustManagerFactory
+				.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+		trustManagerFactory.init((KeyStore) null);
 		SSLContext sslContext = createDefaultSSLContext();
-		sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
+		sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
 		return sslContext;
+	}
+
+	private KeyManagerFactory createKeyManagerFactory() throws NoSuchAlgorithmException {
+		try {
+			return KeyManagerFactory.getInstance("SunX509");
+		} catch (NoSuchAlgorithmException e) {
+			logger.debug("SunX509 KeyManagerFactory not available, falling back to default algorithm '{}'.",
+					KeyManagerFactory.getDefaultAlgorithm());
+			return KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+		}
 	}
 
 	private KeyStore initializeKeyStore(PrivateKey privateKey, Certificate[] certificateChain)

--- a/token-client-core/src/test/java/com/sap/cloud/security/mtls/SSLContextFactoryTest.java
+++ b/token-client-core/src/test/java/com/sap/cloud/security/mtls/SSLContextFactoryTest.java
@@ -11,6 +11,8 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
@@ -70,6 +72,17 @@ public class SSLContextFactoryTest {
 	public void create() throws GeneralSecurityException, IOException {
 		assertThat(cut.create(certificates, rsaPrivateKey), is(notNullValue()));
 		assertThat(cut.create(eccCertificate, eccPrivateKey), is(notNullValue()));
+	}
+
+	@Test
+	public void create_initializesTrustManagerAndKeyManager() throws GeneralSecurityException, IOException {
+		SSLContext sslContext = cut.create(certificates, rsaPrivateKey);
+
+		// SSLEngine creation triggers internal initialization of the trust/key managers and would
+		// fail with "No X509TrustManager implementation available" if the SSLContext was initialized
+		// without a working TrustManager.
+		SSLEngine engine = sslContext.createSSLEngine();
+		assertThat(engine, is(notNullValue()));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fix mTLS handshake regression introduced in 3.6.7 (commit `c9061a3d` "Fix FIPS compatibility by using default KeyManagerFactory algorithm"). On certain runtime configurations the resulting `SSLContext` failed to obtain a working `X509TrustManager`, producing:

```
javax.net.ssl.SSLException: (certificate_unknown) No X509TrustManager implementation available
```

`SSLContextFactory.create()` is the only relevant change to the mTLS code path between 3.6.0 (works) and 3.7.3 (fails) — all subsequent changes (including the module split in 3.6.13/3.7.0) were pure file moves with `similarity index 100%`.

## Changes

- **Restore `SunX509` as the preferred `KeyManagerFactory` algorithm** and only fall back to the JVM default algorithm when `SunX509` is unavailable. This recovers the pre-3.6.7 behavior on standard JVMs while still supporting FIPS-compliant providers (Bouncy Castle) that do not register `SunX509`.
- **Initialize `SSLContext` with an explicit `TrustManagerFactory`** backed by the system default trust store (`cacerts`) instead of passing `null`. This directly addresses the observed error message — the explicit initialization makes the `SSLContext` robust regardless of the underlying default algorithm or provider configuration.
- Added a regression test (`create_initializesTrustManagerAndKeyManager`) that exercises `SSLContext.createSSLEngine()`, which would surface a missing `X509TrustManager` at engine creation time.

## Affected ticket

DINC0923631 — `odp-service` mTLS token requests fail on CF (eu12, preprod) with buildpack 2.63.0.

## Test plan

- [x] Unit tests pass locally (`mvn -pl token-client-core test`)
- [ ] Integration verification on the affected CF environment with the patched JAR