### PR TITLE
fix: Initialize SSLContext with explicit TrustManager (4.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## 4.0.7
 
+- Fix mTLS handshake regression introduced in 3.6.7 (`SSLContextFactory`)
+  - Restore `SunX509` as the preferred `KeyManagerFactory` algorithm and only fall back to the JVM default algorithm when `SunX509` is unavailable (FIPS providers like Bouncy Castle)
+  - Initialize the `SSLContext` with an explicit `TrustManagerFactory` backed by the system default trust store instead of passing `null`, fixing `(certificate_unknown) No X509TrustManager implementation available` failures observed on certain runtime configurations
 - Fix multi-tenant XSUAA token exchange in `DefaultXsuaaTokenExtension`
   - The IAS-to-XSUAA exchange used the provider subdomain endpoint, which caused XSUAA to resolve the provider tenant instead of the tenant carried in the `X-zid` header (`app_tid`)
   - Token exchange now targets a tenant-agnostic endpoint built from the `uaadomain` binding property, so XSUAA resolves the tenant via `X-zid`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## 4.0.7
 
-- Fix mTLS handshake regression introduced in 3.6.7 (`SSLContextFactory`)
-  - Restore `SunX509` as the preferred `KeyManagerFactory` algorithm and only fall back to the JVM default algorithm when `SunX509` is unavailable (FIPS providers like Bouncy Castle)
+- Fix mTLS handshake regression in `SSLContextFactory`
   - Initialize the `SSLContext` with an explicit `TrustManagerFactory` backed by the system default trust store instead of passing `null`, fixing `(certificate_unknown) No X509TrustManager implementation available` failures observed on certain runtime configurations
 - Fix multi-tenant XSUAA token exchange in `DefaultXsuaaTokenExtension`
   - The IAS-to-XSUAA exchange used the provider subdomain endpoint, which caused XSUAA to resolve the provider tenant instead of the tenant carried in the `X-zid` header (`app_tid`)

--- a/token-client/src/main/java/com/sap/cloud/security/mtls/SSLContextFactory.java
+++ b/token-client/src/main/java/com/sap/cloud/security/mtls/SSLContextFactory.java
@@ -94,7 +94,7 @@ public class SSLContextFactory {
 	 */
 	public SSLContext create(ClientIdentity clientIdentity) throws GeneralSecurityException, IOException {
 		KeyStore keystore = createKeyStore(clientIdentity);
-		KeyManagerFactory keyManagerFactory = createKeyManagerFactory();
+		KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
 		keyManagerFactory.init(keystore, noPassword);
 		TrustManagerFactory trustManagerFactory = TrustManagerFactory
 				.getInstance(TrustManagerFactory.getDefaultAlgorithm());
@@ -102,16 +102,6 @@ public class SSLContextFactory {
 		SSLContext sslContext = createDefaultSSLContext();
 		sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
 		return sslContext;
-	}
-
-	private KeyManagerFactory createKeyManagerFactory() throws NoSuchAlgorithmException {
-		try {
-			return KeyManagerFactory.getInstance("SunX509");
-		} catch (NoSuchAlgorithmException e) {
-			logger.debug("SunX509 KeyManagerFactory not available, falling back to default algorithm '{}'.",
-					KeyManagerFactory.getDefaultAlgorithm());
-			return KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-		}
 	}
 
 	private KeyStore initializeKeyStore(PrivateKey privateKey, Certificate[] certificateChain)

--- a/token-client/src/main/java/com/sap/cloud/security/mtls/SSLContextFactory.java
+++ b/token-client/src/main/java/com/sap/cloud/security/mtls/SSLContextFactory.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -93,11 +94,24 @@ public class SSLContextFactory {
 	 */
 	public SSLContext create(ClientIdentity clientIdentity) throws GeneralSecurityException, IOException {
 		KeyStore keystore = createKeyStore(clientIdentity);
-		KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+		KeyManagerFactory keyManagerFactory = createKeyManagerFactory();
 		keyManagerFactory.init(keystore, noPassword);
+		TrustManagerFactory trustManagerFactory = TrustManagerFactory
+				.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+		trustManagerFactory.init((KeyStore) null);
 		SSLContext sslContext = createDefaultSSLContext();
-		sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
+		sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
 		return sslContext;
+	}
+
+	private KeyManagerFactory createKeyManagerFactory() throws NoSuchAlgorithmException {
+		try {
+			return KeyManagerFactory.getInstance("SunX509");
+		} catch (NoSuchAlgorithmException e) {
+			logger.debug("SunX509 KeyManagerFactory not available, falling back to default algorithm '{}'.",
+					KeyManagerFactory.getDefaultAlgorithm());
+			return KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+		}
 	}
 
 	private KeyStore initializeKeyStore(PrivateKey privateKey, Certificate[] certificateChain)

--- a/token-client/src/test/java/com/sap/cloud/security/mtls/SSLContextFactoryTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/mtls/SSLContextFactoryTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
@@ -76,6 +78,17 @@ public class SSLContextFactoryTest {
 	public void create() throws GeneralSecurityException, IOException {
 		assertThat(cut.create(certificates, rsaPrivateKey)).isNotNull();
 		assertThat(cut.create(eccCertificate, eccPrivateKey)).isNotNull();
+	}
+
+	@Test
+	public void create_initializesTrustManagerAndKeyManager() throws GeneralSecurityException, IOException {
+		SSLContext sslContext = cut.create(certificates, rsaPrivateKey);
+
+		// SSLEngine creation triggers internal initialization of the trust/key managers and would
+		// fail with "No X509TrustManager implementation available" if the SSLContext was initialized
+		// without a working TrustManager.
+		SSLEngine engine = sslContext.createSSLEngine();
+		assertThat(engine).isNotNull();
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fix mTLS handshake regression: on certain runtime configurations the `SSLContext` produced by `SSLContextFactory.create()` failed to obtain a working `X509TrustManager`, producing:

```
javax.net.ssl.SSLException: (certificate_unknown) No X509TrustManager implementation available
```

## Changes

- **Initialize `SSLContext` with an explicit `TrustManagerFactory`** backed by the system default trust store (`cacerts`) instead of passing `null`. Relying on the `null`-TrustManager shortcut leaves the resolution to JSSE-internal behavior that is sensitive to provider configuration; instantiating the factory ourselves makes the `SSLContext` robust regardless of provider setup.
- The `KeyManagerFactory` continues to use `KeyManagerFactory.getDefaultAlgorithm()`, matching all released 4.x versions (4.0.0 already shipped with this).
- Added a regression test (`create_initializesTrustManagerAndKeyManager`) that exercises `SSLContext.createSSLEngine()`, which would surface a missing `X509TrustManager` at engine creation time.

## Difference vs. 3.x backport

The 3.x backport (#1979) additionally restores `SunX509` as the preferred `KeyManagerFactory` algorithm with a fallback to the default algorithm. That change recovers pre-3.6.7 behavior in the 3.x line, which had `SunX509` hardcoded for years. The 4.x line never used `SunX509` explicitly, so we keep the JVM default algorithm here.

## Companion PR

- 3.x backport: #1979

## Affected ticket

DINC0923631 — `odp-service` mTLS token requests fail on CF (eu12, preprod) with buildpack 2.63.0.

## Test plan

- [x] Unit tests pass locally (`mvn -pl token-client test`)
- [ ] Integration verification on the affected CF environment with the patched JAR