### PR TITLE
Add missing no-arg constructor to DefaultOAuth2TokenService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## 4.0.7
 
+- Add missing no-arg constructor to `DefaultOAuth2TokenService`
+  - The class lacked the no-arg constructor that the migration documentation (`token-client/CUSTOM_HTTPCLIENT.md`) advertised
+  - The sibling services `DefaultOAuth2TokenKeyService` and `DefaultOidcConfigurationService` already had it; this restores symmetry
+  - The new constructor obtains a `SecurityHttpClient` via `SecurityHttpClientProvider.createClient(null)` and delegates to the existing `(SecurityHttpClient)` constructor
 - Fix multi-tenant XSUAA token exchange in `DefaultXsuaaTokenExtension`
   - The IAS-to-XSUAA exchange used the provider subdomain endpoint, which caused XSUAA to resolve the provider tenant instead of the tenant carried in the `X-zid` header (`app_tid`)
   - Token exchange now targets a tenant-agnostic endpoint built from the `uaadomain` binding property, so XSUAA resolves the tenant via `X-zid`

--- a/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenService.java
+++ b/token-client/src/main/java/com/sap/cloud/security/xsuaa/client/DefaultOAuth2TokenService.java
@@ -11,7 +11,9 @@ import static com.sap.cloud.security.xsuaa.client.OAuth2TokenServiceConstants.*;
 import com.sap.cloud.security.client.ApacheHttpClient4Executor;
 import com.sap.cloud.security.client.CustomHttpClientAdapter;
 import com.sap.cloud.security.client.DefaultTokenClientConfiguration;
+import com.sap.cloud.security.client.HttpClientException;
 import com.sap.cloud.security.client.SecurityHttpClient;
+import com.sap.cloud.security.client.SecurityHttpClientProvider;
 import com.sap.cloud.security.client.SecurityHttpRequest;
 import com.sap.cloud.security.client.SecurityHttpResponse;
 import com.sap.cloud.security.servlet.MDCHelper;
@@ -40,6 +42,10 @@ public class DefaultOAuth2TokenService extends AbstractOAuth2TokenService {
   private final SecurityHttpClient httpClient;
   private final DefaultTokenClientConfiguration config =
       DefaultTokenClientConfiguration.getInstance();
+
+  public DefaultOAuth2TokenService() throws HttpClientException {
+    this(SecurityHttpClientProvider.createClient(null));
+  }
 
   public DefaultOAuth2TokenService(@Nonnull final SecurityHttpClient httpClient) {
     this(httpClient, TokenCacheConfiguration.defaultConfiguration());


### PR DESCRIPTION
## Summary

`DefaultOAuth2TokenService` lacked the no-arg constructor that [`token-client/CUSTOM_HTTPCLIENT.md`](https://github.com/SAP/cloud-security-services-integration-library/blob/main/token-client/CUSTOM_HTTPCLIENT.md) documents and that the sibling services `DefaultOAuth2TokenKeyService` and `DefaultOidcConfigurationService` already provide.

The constructor was omitted when token-client services were migrated to the `SecurityHttpClient` abstraction in the v4 line — the sibling services received it in the same commit, this one was missed.

## Change

```java
public DefaultOAuth2TokenService() throws HttpClientException {
  this(SecurityHttpClientProvider.createClient(null));
}
```

Symmetric with the existing no-arg constructors of `DefaultOAuth2TokenKeyService` and `DefaultOidcConfigurationService` — same provider call, same delegation pattern.

## Test plan

- [x] `mvn -pl token-client -am test-compile` succeeds
- [ ] Existing token-client tests pass
- [ ] Verify `new DefaultOAuth2TokenService()` works in a sample/IT against the default Java 11 HttpClient