### PR TITLE
feat: Expose sap_id_type claim via SapIdToken#getIdType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 4.1.0
+
+- Expose the `sap_id_type` claim on `SapIdToken`
+  - New `SapIdToken#getIdType()` returning a typed `SapIdType` enum (`USER`, `APP`); resolves to `null` if the claim is absent or carries an unknown value
+  - New `TokenClaims.SAP_ID_TYPE` constant
+  - `DefaultIdTokenExtension#isTechnicalUser` now prefers the `sap_id_type` claim and falls back to the `sub == azp` heuristic for tokens issued before the claim was introduced
+
 ## 4.0.7
 
 - Fix mTLS handshake regression in `SSLContextFactory`

--- a/java-api/src/main/java/com/sap/cloud/security/token/SapIdType.java
+++ b/java-api/src/main/java/com/sap/cloud/security/token/SapIdType.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.token;
+
+import jakarta.annotation.Nullable;
+
+/**
+ * Type of the principal an IAS-issued token belongs to. Mirrors the {@code sap_id_type} JWT claim
+ * issued by SAP Cloud Identity Service.
+ */
+public enum SapIdType {
+	/** Human end-user principal. */
+	USER("user"),
+	/** Technical / application principal. */
+	APP("app");
+
+	private final String claimValue;
+
+	SapIdType(String claimValue) {
+		this.claimValue = claimValue;
+	}
+
+	/**
+	 * Returns the raw claim value used on the wire.
+	 *
+	 * @return the raw claim value as it appears in the JWT (e.g. {@code "user"} or {@code "app"}).
+	 */
+	public String claimValue() {
+		return claimValue;
+	}
+
+	/**
+	 * Resolves a {@link SapIdType} from a raw {@code sap_id_type} claim value.
+	 *
+	 * @param value the claim value, may be {@code null}
+	 * @return the matching {@link SapIdType}, or {@code null} if {@code value} is {@code null} or
+	 * 		does not match a known type (forward-compatibility for future values)
+	 */
+	@Nullable
+	public static SapIdType fromClaimValue(@Nullable String value) {
+		if (value == null) {
+			return null;
+		}
+		for (SapIdType t : values()) {
+			if (t.claimValue.equals(value)) {
+				return t;
+			}
+		}
+		return null;
+	}
+}

--- a/java-api/src/main/java/com/sap/cloud/security/token/SapIdType.java
+++ b/java-api/src/main/java/com/sap/cloud/security/token/SapIdType.java
@@ -5,50 +5,22 @@
  */
 package com.sap.cloud.security.token;
 
-import jakarta.annotation.Nullable;
-
 /**
- * Type of the principal an IAS-issued token belongs to. Mirrors the {@code sap_id_type} JWT claim
- * issued by SAP Cloud Identity Service.
+ * Known values of the {@code sap_id_type} JWT claim issued by SAP Cloud Identity Service.
+ *
+ * <p>Exposed as string constants rather than an enum so that consumers remain forward-compatible
+ * with values introduced by future IAS versions: {@link SapIdToken#getIdType()} returns the raw
+ * claim string, and callers can compare against the constants defined here for the values known
+ * today.
  */
-public enum SapIdType {
+public final class SapIdType {
+
 	/** Human end-user principal. */
-	USER("user"),
+	public static final String USER = "user";
+
 	/** Technical / application principal. */
-	APP("app");
+	public static final String APP = "app";
 
-	private final String claimValue;
-
-	SapIdType(String claimValue) {
-		this.claimValue = claimValue;
-	}
-
-	/**
-	 * Returns the raw claim value used on the wire.
-	 *
-	 * @return the raw claim value as it appears in the JWT (e.g. {@code "user"} or {@code "app"}).
-	 */
-	public String claimValue() {
-		return claimValue;
-	}
-
-	/**
-	 * Resolves a {@link SapIdType} from a raw {@code sap_id_type} claim value.
-	 *
-	 * @param value the claim value, may be {@code null}
-	 * @return the matching {@link SapIdType}, or {@code null} if {@code value} is {@code null} or
-	 * 		does not match a known type (forward-compatibility for future values)
-	 */
-	@Nullable
-	public static SapIdType fromClaimValue(@Nullable String value) {
-		if (value == null) {
-			return null;
-		}
-		for (SapIdType t : values()) {
-			if (t.claimValue.equals(value)) {
-				return t;
-			}
-		}
-		return null;
+	private SapIdType() {
 	}
 }

--- a/java-api/src/main/java/com/sap/cloud/security/token/TokenClaims.java
+++ b/java-api/src/main/java/com/sap/cloud/security/token/TokenClaims.java
@@ -43,6 +43,13 @@ public final class TokenClaims {
 	public static final String SAP_GLOBAL_ZONE_ID = "zone_uuid"; // legacy claim
 	public static final String SAP_GLOBAL_APP_TID = "app_tid"; // tenant GUID
 
+	/**
+	 * Indicates the type of the token principal. Issued by SAP Cloud Identity Service. Values
+	 * are {@code "user"} for human end-users and {@code "app"} for technical/application
+	 * principals. See {@link SapIdType} for the typed accessor.
+	 */
+	public static final String SAP_ID_TYPE = "sap_id_type";
+
 	public static final String GROUPS = "groups"; // scim groups
 	public static final String AUTHORIZATION_PARTY = "azp"; // Authorization party contains OAuth client identifier
 	public static final String CNF = "cnf"; // X509 certificate ("cnf" (confirmation)) claim

--- a/java-security/src/main/java/com/sap/cloud/security/token/DefaultIdTokenExtension.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/DefaultIdTokenExtension.java
@@ -27,7 +27,8 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>If cached ID Token is still valid, it is returned as is
  *   <li>If the current token is already an ID token, it is returned as-is.
- *   <li>If the token belongs to a technical user (where {@code sub == azp}), an exception is
+ *   <li>If the token belongs to a technical user (claim {@code sap_id_type} = {@code "app"}, or
+ *       {@code sub == azp} for pre-{@code sap_id_type} tokens), an exception is
  *       thrown.
  *   <li>If the token is an access token, it will be exchanged for an ID token using the configured
  *       IAS service credentials.
@@ -115,14 +116,21 @@ public class DefaultIdTokenExtension implements IdTokenExtension {
   /**
    * Determines whether the token represents a technical user.
    *
-   * <p>A token is considered to belong to a technical user if the {@code sub} (subject) claim
-   * equals the {@code azp} (authorized party / client ID) claim.
+   * <p>Prefers the {@code sap_id_type} claim ({@link SapIdType#APP}) when present. For tokens
+   * issued before the claim was introduced, falls back to comparing {@code sub} with
+   * {@code azp}.
    *
    * @param token the token to inspect
    * @return {@code true} if the token belongs to a technical user
    */
   private boolean isTechnicalUser(Token token) {
-    String subject = token.getClaimAsString("sub");
+    if (token instanceof SapIdToken idToken) {
+      SapIdType idType = idToken.getIdType();
+      if (idType != null) {
+        return idType == SapIdType.APP;
+      }
+    }
+    String subject = token.getClaimAsString(TokenClaims.SUBJECT);
     String azp = token.getClientId();
     if (subject == null || azp == null || subject.isBlank() || azp.isBlank()) {
       return false;

--- a/java-security/src/main/java/com/sap/cloud/security/token/DefaultIdTokenExtension.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/DefaultIdTokenExtension.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>If cached ID Token is still valid, it is returned as is
  *   <li>If the current token is already an ID token, it is returned as-is.
- *   <li>If the token belongs to a technical user (claim {@code sap_id_type} = {@code "app"}, or
+ *   <li>If the token belongs to a technical user (claim {@code sap_id_type} != {@code "user"}, or
  *       {@code sub == azp} for pre-{@code sap_id_type} tokens), an exception is
  *       thrown.
  *   <li>If the token is an access token, it will be exchanged for an ID token using the configured
@@ -116,18 +116,23 @@ public class DefaultIdTokenExtension implements IdTokenExtension {
   /**
    * Determines whether the token represents a technical user.
    *
-   * <p>Prefers the {@code sap_id_type} claim ({@link SapIdType#APP}) when present. For tokens
-   * issued before the claim was introduced, falls back to comparing {@code sub} with
-   * {@code azp}.
+   * <p>When the {@code sap_id_type} claim is present, only the explicit value
+   * {@link SapIdType#USER} is treated as a human end-user; every other value (including future
+   * IAS values this library does not yet know about, e.g. {@code "agent"}) is treated as
+   * technical. This is deliberately conservative: refusing an ID-token exchange for a new
+   * principal type is safer than performing one that was never intended.
+   *
+   * <p>For tokens issued before {@code sap_id_type} existed, falls back to comparing {@code sub}
+   * with {@code azp}.
    *
    * @param token the token to inspect
    * @return {@code true} if the token belongs to a technical user
    */
   private boolean isTechnicalUser(Token token) {
     if (token instanceof SapIdToken idToken) {
-      SapIdType idType = idToken.getIdType();
+      String idType = idToken.getIdType();
       if (idType != null) {
-        return idType == SapIdType.APP;
+        return !SapIdType.USER.equals(idType);
       }
     }
     String subject = token.getClaimAsString(TokenClaims.SUBJECT);

--- a/java-security/src/main/java/com/sap/cloud/security/token/SapIdToken.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/SapIdToken.java
@@ -61,15 +61,17 @@ public class SapIdToken extends AbstractToken {
 	}
 
 	/**
-	 * Returns the principal type carried by the {@code sap_id_type} claim. Issued by SAP Cloud
-	 * Identity Service to disambiguate human end-users ({@link SapIdType#USER}) from
-	 * technical/application principals ({@link SapIdType#APP}).
+	 * Returns the raw {@code sap_id_type} claim value carried by the token. Issued by SAP Cloud
+	 * Identity Service to disambiguate human end-users from technical/application principals.
 	 *
-	 * @return the resolved {@link SapIdType}, or {@code null} if the claim is absent or carries
-	 * 		an unknown value (e.g. a future principal type).
+	 * <p>Compare against the constants in {@link SapIdType} (e.g. {@link SapIdType#USER},
+	 * {@link SapIdType#APP}) for the values known today. The raw string is returned so callers
+	 * stay forward-compatible with future IAS values that this library does not yet know about.
+	 *
+	 * @return the raw claim value, or {@code null} if the claim is absent
 	 */
 	@Nullable
-	public SapIdType getIdType() {
-		return SapIdType.fromClaimValue(getClaimAsString(TokenClaims.SAP_ID_TYPE));
+	public String getIdType() {
+		return getClaimAsString(TokenClaims.SAP_ID_TYPE);
 	}
 }

--- a/java-security/src/main/java/com/sap/cloud/security/token/SapIdToken.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/SapIdToken.java
@@ -59,4 +59,17 @@ public class SapIdToken extends AbstractToken {
 	public String getCnfX509Thumbprint() {
 		return getAttributeFromClaimAsString(TokenClaims.CNF, TokenClaims.CNF_X5T);
 	}
+
+	/**
+	 * Returns the principal type carried by the {@code sap_id_type} claim. Issued by SAP Cloud
+	 * Identity Service to disambiguate human end-users ({@link SapIdType#USER}) from
+	 * technical/application principals ({@link SapIdType#APP}).
+	 *
+	 * @return the resolved {@link SapIdType}, or {@code null} if the claim is absent or carries
+	 * 		an unknown value (e.g. a future principal type).
+	 */
+	@Nullable
+	public SapIdType getIdType() {
+		return SapIdType.fromClaimValue(getClaimAsString(TokenClaims.SAP_ID_TYPE));
+	}
 }

--- a/java-security/src/test/java/com/sap/cloud/security/token/DefaultIdTokenExtensionTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/DefaultIdTokenExtensionTest.java
@@ -241,6 +241,17 @@ public class DefaultIdTokenExtensionTest {
   }
 
   @Test
+  public void resolveToken_sapIdTypeUnknownClaim_conservativelyTreatedAsTechnicalUser() {
+    // Any value other than "user" — including future IAS values this library does not yet know
+    // — must be treated as technical to avoid attempting an unintended token exchange.
+    SecurityContext.setToken(sapIdTokenWithPayload(
+        "{\"sap_id_type\":\"agent\",\"sub\":\"human\",\"azp\":\"" + clientId + "\"}"));
+
+    assertThatThrownBy(() -> cut.resolveIdToken(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
   public void resolveToken_sapIdTypeUserClaim_overridesSubEqualsAzpHeuristic()
       throws OAuth2ServiceException {
     // sub == azp would have flagged this as technical under the legacy heuristic; the explicit

--- a/java-security/src/test/java/com/sap/cloud/security/token/DefaultIdTokenExtensionTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/DefaultIdTokenExtensionTest.java
@@ -231,4 +231,53 @@ public class DefaultIdTokenExtensionTest {
     Map<String, String> params = paramCaptor.getValue();
     assertThat(params.get("app_tid")).isNull();
   }
+
+  @Test
+  public void resolveToken_sapIdTypeAppClaim_treatedAsTechnicalUser() {
+    SecurityContext.setToken(sapIdTokenWithPayload("{\"sap_id_type\":\"app\",\"sub\":\"user\",\"azp\":\"" + clientId + "\"}"));
+
+    assertThatThrownBy(() -> cut.resolveIdToken(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void resolveToken_sapIdTypeUserClaim_overridesSubEqualsAzpHeuristic()
+      throws OAuth2ServiceException {
+    // sub == azp would have flagged this as technical under the legacy heuristic; the explicit
+    // sap_id_type=user claim takes precedence so the exchange proceeds.
+    SapIdToken userToken = sapIdTokenWithPayload(
+        "{\"sap_id_type\":\"user\",\"sub\":\"" + clientId + "\",\"azp\":\"" + clientId
+            + "\",\"aud\":[\"audience\"],\"iss\":\"" + tokenUri + "\"}");
+    SecurityContext.setToken(userToken);
+
+    cut.resolveIdToken(null);
+
+    verify(tokenService)
+        .retrieveAccessTokenViaJwtBearerTokenGrant(
+            eq(completeTokenUri), any(), any(), any(), any(), eq(false));
+  }
+
+  private static SapIdToken sapIdTokenWithPayload(String payload) {
+    return new SapIdToken(new com.sap.cloud.security.xsuaa.jwt.DecodedJwt() {
+      @Override
+      public String getHeader() {
+        return "{}";
+      }
+
+      @Override
+      public String getPayload() {
+        return payload;
+      }
+
+      @Override
+      public String getSignature() {
+        return "";
+      }
+
+      @Override
+      public String getEncodedToken() {
+        return "encoded";
+      }
+    });
+  }
 }

--- a/java-security/src/test/java/com/sap/cloud/security/token/SapIdTokenTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/SapIdTokenTest.java
@@ -80,8 +80,8 @@ public class SapIdTokenTest {
 	}
 
 	@Test
-	public void getIdType_unknownClaimValue_returnsNull() {
-		assertThat(tokenWithPayload("{\"sap_id_type\":\"future-type\"}").getIdType()).isNull();
+	public void getIdType_unknownClaimValue_returnsRawString() {
+		assertThat(tokenWithPayload("{\"sap_id_type\":\"future-type\"}").getIdType()).isEqualTo("future-type");
 	}
 
 	private static SapIdToken tokenWithPayload(String payloadJson) {

--- a/java-security/src/test/java/com/sap/cloud/security/token/SapIdTokenTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/SapIdTokenTest.java
@@ -8,6 +8,7 @@ package com.sap.cloud.security.token;
 import org.junit.jupiter.api.Test;
 
 import com.sap.cloud.security.config.Service;
+import com.sap.cloud.security.xsuaa.jwt.DecodedJwt;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
@@ -61,5 +62,57 @@ public class SapIdTokenTest {
 	@Test
 	public void getAppTid() {
 		assertThat(cut.getAppTid()).isEqualTo("the-app-tid");
+	}
+
+	@Test
+	public void getIdType_user() {
+		assertThat(tokenWithPayload("{\"sap_id_type\":\"user\"}").getIdType()).isEqualTo(SapIdType.USER);
+	}
+
+	@Test
+	public void getIdType_app() {
+		assertThat(tokenWithPayload("{\"sap_id_type\":\"app\"}").getIdType()).isEqualTo(SapIdType.APP);
+	}
+
+	@Test
+	public void getIdType_claimMissing_returnsNull() {
+		assertThat(cut.getIdType()).isNull();
+	}
+
+	@Test
+	public void getIdType_unknownClaimValue_returnsNull() {
+		assertThat(tokenWithPayload("{\"sap_id_type\":\"future-type\"}").getIdType()).isNull();
+	}
+
+	private static SapIdToken tokenWithPayload(String payloadJson) {
+		return new SapIdToken(new StubDecodedJwt(payloadJson));
+	}
+
+	private static final class StubDecodedJwt implements DecodedJwt {
+		private final String payload;
+
+		StubDecodedJwt(String payload) {
+			this.payload = payload;
+		}
+
+		@Override
+		public String getHeader() {
+			return "{}";
+		}
+
+		@Override
+		public String getPayload() {
+			return payload;
+		}
+
+		@Override
+		public String getSignature() {
+			return "";
+		}
+
+		@Override
+		public String getEncodedToken() {
+			return "";
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- New `SapIdToken#getIdType()` returning a typed `SapIdType` enum (`USER` / `APP`) backed by the `sap_id_type` JWT claim issued by SAP Cloud Identity Service.
- New `TokenClaims.SAP_ID_TYPE` constant.
- `DefaultIdTokenExtension#isTechnicalUser` now prefers the claim and falls back to the `sub == azp` heuristic for tokens issued before the claim was introduced — no behavior change for pre-`sap_id_type` bindings, but new tokens drive the right decision when the heuristic would have been wrong.

## Why
The Node library exposes the same claim (`token.idType`) and uses it to replace the `sub === azp` heuristic at decision points like `DefaultIdTokenExtension._getIdToken` and `XsuaaLegacyExtension.appliesTo`. This brings the Java library in line.

## Design notes
- `SapIdType` lives in `java-api` next to `TokenClaims` so it can be referenced from both `java-api` and `java-security`.
- The enum returns `null` for both an absent claim and an unknown value (e.g. a future third principal type). This keeps consumers forward-compatible without throwing on tokens issued by newer IAS versions.
- `isTechnicalUser` keeps the legacy `sub == azp` path as a fallback to avoid breaking technical-user detection for tokens that don't yet carry `sap_id_type`.

## Test plan
- [x] `mvn -pl java-api,java-security -am test` — 330 tests green, including new coverage:
  - `SapIdTokenTest`: `getIdType` for `user`, `app`, missing claim, unknown value
  - `DefaultIdTokenExtensionTest`: `sap_id_type=app` is treated as technical user; `sap_id_type=user` overrides the `sub == azp` heuristic
- [x] `mvn install -DskipTests` (full repo compile + javadoc) — green

## Release
CHANGELOG entry added under `4.1.0` (minor bump for additive feature). The pom version bump will follow in a separate `chore: Release 4.1.0` commit once any in-flight Renovate PRs are merged.