### PR TITLE
feat: Add withValidatorCustomizer to AbstractTokenAuthenticator (3.x backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 3.7.5
+
+- Add `AbstractTokenAuthenticator#withValidatorCustomizer(Consumer<JwtValidatorBuilder>)` to let callers adjust the internally constructed `JwtValidatorBuilder` just before it is built. Useful for narrowly opting out of individual default checks (e.g. `JwtValidatorBuilder#disableTenantIdCheck`) without having to replicate the rest of the default validator setup. Multiple customizers can be registered; they are applied in registration order.
+
 ## 3.7.4
 
 - Fix mTLS handshake regression introduced in 3.6.7 (`SSLContextFactory`)

--- a/java-security/src/main/java/com/sap/cloud/security/servlet/AbstractTokenAuthenticator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/servlet/AbstractTokenAuthenticator.java
@@ -28,7 +28,9 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static com.sap.cloud.security.x509.X509Constants.FWD_CLIENT_CERT_HEADER;
 
@@ -36,6 +38,7 @@ public abstract class AbstractTokenAuthenticator implements TokenAuthenticator {
 
 	private static final Logger logger = LoggerFactory.getLogger(AbstractTokenAuthenticator.class);
 	private final List<ValidationListener> validationListeners = new ArrayList<>();
+	private final List<Consumer<JwtValidatorBuilder>> validatorCustomizers = new ArrayList<>();
 	private Validator<Token> tokenValidator;
 	protected CloseableHttpClient httpClient;
 	protected OAuth2ServiceConfiguration serviceConfiguration;
@@ -116,6 +119,34 @@ public abstract class AbstractTokenAuthenticator implements TokenAuthenticator {
 	}
 
 	/**
+	 * Registers a callback that receives the {@link JwtValidatorBuilder} that the authenticator
+	 * uses internally to assemble its default validator, just before {@code build()} is invoked.
+	 * <p>
+	 * Use this to adjust the default validator setup without replicating it. For example, to opt
+	 * out of the tenant id check (see
+	 * {@link JwtValidatorBuilder#disableTenantIdCheck()} — use with caution):
+	 *
+	 * <pre>{@code
+	 * new IasTokenAuthenticator()
+	 *     .withServiceConfiguration(config)
+	 *     .withValidatorCustomizer(JwtValidatorBuilder::disableTenantIdCheck);
+	 * }</pre>
+	 *
+	 * Multiple customizers can be registered; they are applied in registration order. Callers
+	 * should keep customizations targeted — passing in a fully custom {@code Validator} is
+	 * intentionally not supported, because it would force callers to replicate the default
+	 * setup and drift as the defaults evolve.
+	 *
+	 * @param customizer
+	 * 		the customizer; must not be null
+	 * @return the authenticator instance
+	 */
+	public AbstractTokenAuthenticator withValidatorCustomizer(Consumer<JwtValidatorBuilder> customizer) {
+		this.validatorCustomizers.add(Objects.requireNonNull(customizer, "customizer must not be null"));
+		return this;
+	}
+
+	/**
 	 * Return configured service configuration or Environments.getCurrent() if not configured.
 	 *
 	 * @return the actual service configuration
@@ -148,6 +179,7 @@ public abstract class AbstractTokenAuthenticator implements TokenAuthenticator {
 			jwtValidatorBuilder.configureAnotherServiceInstance(getOtherServiceConfiguration());
 			Optional.ofNullable(tokenKeyCacheConfiguration).ifPresent(jwtValidatorBuilder::withCacheConfiguration);
 			validationListeners.forEach(jwtValidatorBuilder::withValidatorListener);
+			validatorCustomizers.forEach(customizer -> customizer.accept(jwtValidatorBuilder));
 			tokenValidator = jwtValidatorBuilder.build();
 		}
 		return tokenValidator;

--- a/java-security/src/test/java/com/sap/cloud/security/servlet/IasTokenAuthenticatorTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/servlet/IasTokenAuthenticatorTest.java
@@ -146,6 +146,50 @@ class IasTokenAuthenticatorTest {
 		Mockito.verify(validationListener2, times(1)).onValidationError(any());
 	}
 
+	@Test
+	void withValidatorCustomizer_invokesCustomizerBeforeBuild() {
+		OAuth2ServiceConfiguration configuration = OAuth2ServiceConfigurationBuilder
+				.forService(Service.IAS)
+				.withDomains("myauth.com")
+				.withClientId("T000310")
+				.build();
+		java.util.concurrent.atomic.AtomicBoolean called = new java.util.concurrent.atomic.AtomicBoolean();
+
+		AbstractTokenAuthenticator authenticator = new IasTokenAuthenticator()
+				.withServiceConfiguration(configuration)
+				.withValidatorCustomizer(builder -> {
+					called.set(true);
+					builder.disableTenantIdCheck();
+				});
+		authenticator.getOrCreateTokenValidator();
+
+		assertTrue(called.get(), "registered customizer must be invoked during validator construction");
+	}
+
+	@Test
+	void withValidatorCustomizer_multipleCustomizers_areInvokedInOrder() {
+		OAuth2ServiceConfiguration configuration = OAuth2ServiceConfigurationBuilder
+				.forService(Service.IAS)
+				.withDomains("myauth.com")
+				.withClientId("T000310")
+				.build();
+		java.util.List<Integer> calls = new java.util.ArrayList<>();
+
+		AbstractTokenAuthenticator authenticator = new IasTokenAuthenticator()
+				.withServiceConfiguration(configuration)
+				.withValidatorCustomizer(b -> calls.add(1))
+				.withValidatorCustomizer(b -> calls.add(2));
+		authenticator.getOrCreateTokenValidator();
+
+		assertEquals(java.util.List.of(1, 2), calls);
+	}
+
+	@Test
+	void withValidatorCustomizer_nullCustomizer_throws() {
+		assertThrows(NullPointerException.class,
+				() -> new IasTokenAuthenticator().withValidatorCustomizer(null));
+	}
+
 	private HttpServletRequest createRequestWithoutToken() {
 		return Mockito.mock(HttpServletRequest.class);
 	}


### PR DESCRIPTION
## Summary
3.x backport of #1988 (against `main`).

Adds `AbstractTokenAuthenticator#withValidatorCustomizer(Consumer<JwtValidatorBuilder>)` so callers can register a callback that receives the internally assembled `JwtValidatorBuilder` just before `build()` is invoked. Mirrors the existing `withValidationListener` pattern (list semantics, applied in registration order).

## Why
A stakeholder needs to disable the tenant id check (`JwtValidatorBuilder#disableTenantIdCheck`) for their setup. Today the only way to do that is to construct their own `Validator<Token>` entirely from scratch, which forces them to replicate the rest of the default validator setup and to track every future change to it — adjustments that internal-only refactors would happily make without anyone downstream noticing.

The customizer-callback approach lets the library keep ownership of the default validator setup while giving callers a narrow, targeted hook to opt out of individual defaults.

## Usage
```java
new IasTokenAuthenticator()
    .withServiceConfiguration(config)
    .withValidatorCustomizer(JwtValidatorBuilder::disableTenantIdCheck);
```

## Test plan
- [x] `mvn -pl java-security -am clean test` — green; `IasTokenAuthenticatorTest` goes from 6 → 9 tests
- [x] `mvn clean install -DskipTests` (full repo compile) — green
- [x] New tests cover: customizer is invoked during validator construction, multiple customizers run in registration order, null customizer is rejected

## Companion PR
- `main` (4.x): #1988

CHANGELOG entry added under `3.7.5`.