### PR TITLE
feat: Support ES256/ES384/ES512 JWT signature algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## 4.1.0
 
-- Support additional JWT signature algorithms in `JwtSignatureValidator`. In addition to the previously supported `RS256`, tokens signed with the following RSA-based algorithms (RFC 7518 §3.3 / §3.5) can now be validated:
+- Support additional JWT signature algorithms in `JwtSignatureValidator`. In addition to the previously supported `RS256`, tokens signed with the following algorithms (RFC 7518 §3.3 / §3.4 / §3.5) can now be validated:
   - `RS384`, `RS512` (RSASSA-PKCS1-v1_5 with SHA-384 / SHA-512)
   - `PS256`, `PS384`, `PS512` (RSASSA-PSS with SHA-256 / SHA-384 / SHA-512). The corresponding `PSSParameterSpec` is set automatically before signature verification.
+  - `ES256`, `ES384`, `ES512` (ECDSA on P-256 / P-384 / P-521 with SHA-256 / SHA-384 / SHA-512). The JCA name `SHA*withECDSAinP1363Format` is used so the raw `R||S` signature format mandated by RFC 7518 §3.4 is accepted directly. EC JWKs are constructed from `crv`/`x`/`y` with strict curve and coordinate-length validation per RFC 7518 §6.2.1.
   - Selection is driven by the JWT header `alg` value. Unknown values continue to be rejected with the existing "is not supported" error.
 - Update dependencies:
   - Spring Boot: 4.0.6 → 4.1.0

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeyConstants.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeyConstants.java
@@ -13,6 +13,10 @@ class JsonWebKeyConstants {
 	static final String RSA_KEY_MODULUS_PARAMETER_NAME = "n";
 	static final String RSA_KEY_PUBLIC_EXPONENT_PARAMETER_NAME = "e";
 
+	static final String EC_CURVE_PARAMETER_NAME = "crv";
+	static final String EC_X_COORDINATE_PARAMETER_NAME = "x";
+	static final String EC_Y_COORDINATE_PARAMETER_NAME = "y";
+
 	// Parameter names as defined in https://tools.ietf.org/html/rfc7517
 	static final String KEYS_PARAMETER_NAME = "keys";
 	static final String KEY_TYPE_PARAMETER_NAME = "kty";

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeyImpl.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeyImpl.java
@@ -8,55 +8,23 @@ package com.sap.cloud.security.token.validation.validators;
 import com.sap.cloud.security.xsuaa.Assertions;
 
 import jakarta.annotation.Nullable;
-import java.math.BigInteger;
-import java.security.AlgorithmParameters;
-import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-import java.security.spec.ECParameterSpec;
-import java.security.spec.ECPoint;
-import java.security.spec.ECPublicKeySpec;
-import java.security.spec.ECGenParameterSpec;
 import java.security.spec.InvalidKeySpecException;
-import java.security.spec.InvalidParameterSpecException;
-import java.security.spec.KeySpec;
-import java.security.spec.RSAPublicKeySpec;
-import java.security.spec.X509EncodedKeySpec;
-import java.util.Base64;
 import java.util.Objects;
-
-import static com.sap.cloud.security.token.validation.validators.JsonWebKeyConstants.BEGIN_PUBLIC_KEY;
-import static com.sap.cloud.security.token.validation.validators.JsonWebKeyConstants.END_PUBLIC_KEY;
 
 class JsonWebKeyImpl implements JsonWebKey {
 	private final JwtSignatureAlgorithm keyAlgorithm;
 	private final String keyId;
-	private final String pemEncodedPublicKey;
-	private final String modulus;
-	private final String publicExponent;
-	private final String curve;
-	private final String xCoordinate;
-	private final String yCoordinate;
+	private final KeyMaterial keyMaterial;
 	private PublicKey publicKey;
 
-	JsonWebKeyImpl(JwtSignatureAlgorithm keyAlgorithm, @Nullable String keyId, String modulus,
-			String publicExponent, @Nullable String pemEncodedPublicKey) {
-		this(keyAlgorithm, keyId, modulus, publicExponent, null, null, null, pemEncodedPublicKey);
-	}
-
-	JsonWebKeyImpl(JwtSignatureAlgorithm keyAlgorithm, @Nullable String keyId, @Nullable String modulus,
-			@Nullable String publicExponent, @Nullable String curve, @Nullable String xCoordinate,
-			@Nullable String yCoordinate, @Nullable String pemEncodedPublicKey) {
+	JsonWebKeyImpl(JwtSignatureAlgorithm keyAlgorithm, @Nullable String keyId, KeyMaterial keyMaterial) {
 		Assertions.assertNotNull(keyAlgorithm, "keyAlgorithm must be not null");
-		this.keyId = keyId != null ? keyId : DEFAULT_KEY_ID;
-
-		this.pemEncodedPublicKey = pemEncodedPublicKey;
-		this.publicExponent = publicExponent;
-		this.modulus = modulus;
-		this.curve = curve;
-		this.xCoordinate = xCoordinate;
-		this.yCoordinate = yCoordinate;
+		Assertions.assertNotNull(keyMaterial, "keyMaterial must be not null");
 		this.keyAlgorithm = keyAlgorithm;
+		this.keyId = keyId != null ? keyId : DEFAULT_KEY_ID;
+		this.keyMaterial = keyMaterial;
 	}
 
 	@Override
@@ -72,101 +40,15 @@ class JsonWebKeyImpl implements JsonWebKey {
 
 	@Override
 	public PublicKey getPublicKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
-		if (publicKey != null) {
-			return publicKey;
-		}
-		if (pemEncodedPublicKey != null) {
-			publicKey = createPublicKeyFromPemEncodedPublicKey(keyAlgorithm, pemEncodedPublicKey);
-		} else if (keyAlgorithm.type().equalsIgnoreCase("RSA")) {
-			publicKey = createRSAPublicKey(publicExponent, modulus);
-		} else if (keyAlgorithm.type().equalsIgnoreCase("EC")) {
-			publicKey = createECPublicKey(keyAlgorithm, curve, xCoordinate, yCoordinate);
-		} else {
-			throw new IllegalStateException("JWT token with web key type " + keyAlgorithm + " can not be verified.");
+		if (publicKey == null) {
+			publicKey = keyMaterial.toPublicKey(keyAlgorithm);
 		}
 		return publicKey;
 	}
 
-	static PublicKey createRSAPublicKey(String publicExponent, String modulus)
-			throws NoSuchAlgorithmException, InvalidKeySpecException {
-		BigInteger n = new BigInteger(1, Base64.getUrlDecoder().decode(modulus));
-		BigInteger e = new BigInteger(1, Base64.getUrlDecoder().decode(publicExponent));
-		KeySpec keySpec = new RSAPublicKeySpec(n, e);
-
-		KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-		return keyFactory.generatePublic(keySpec);
-	}
-
-	/**
-	 * Builds an EC {@link PublicKey} from JWK {@code crv}/{@code x}/{@code y} parameters per
-	 * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-6.2.1">RFC 7518 §6.2.1</a>.
-	 * <p>
-	 * Validates that {@code crv} matches the curve expected by {@code algorithm} and that both
-	 * coordinates have the exact octet length mandated for that curve — a missing or short
-	 * coordinate would otherwise produce a key on the wrong subgroup and silently succeed.
-	 */
-	static PublicKey createECPublicKey(JwtSignatureAlgorithm algorithm, String curve, String xCoordinate,
-			String yCoordinate) throws NoSuchAlgorithmException, InvalidKeySpecException {
-		if (curve == null || xCoordinate == null || yCoordinate == null) {
-			throw new InvalidKeySpecException(
-					"EC JWK is missing required parameters 'crv', 'x' or 'y' for algorithm " + algorithm.value());
-		}
-		if (!curve.equals(algorithm.curveName())) {
-			throw new InvalidKeySpecException("EC JWK curve '" + curve + "' does not match algorithm "
-					+ algorithm.value() + " which requires '" + algorithm.curveName() + "'.");
-		}
-		byte[] xBytes = Base64.getUrlDecoder().decode(xCoordinate);
-		byte[] yBytes = Base64.getUrlDecoder().decode(yCoordinate);
-		int expectedLength = algorithm.coordinateLength();
-		if (xBytes.length != expectedLength || yBytes.length != expectedLength) {
-			throw new InvalidKeySpecException("EC JWK coordinates for " + algorithm.value()
-					+ " must be " + expectedLength + " octets each (got x=" + xBytes.length + ", y=" + yBytes.length + ").");
-		}
-
-		ECPoint point = new ECPoint(new BigInteger(1, xBytes), new BigInteger(1, yBytes));
-		ECParameterSpec ecParameterSpec;
-		try {
-			AlgorithmParameters parameters = AlgorithmParameters.getInstance("EC");
-			// SunEC's AlgorithmParameters accepts "P-256" but not "P-384"/"P-521" as a curve name;
-			// the standard NIST names work for all three. Map JWK → NIST to stay portable.
-			parameters.init(new ECGenParameterSpec(toJcaCurveName(curve)));
-			ecParameterSpec = parameters.getParameterSpec(ECParameterSpec.class);
-		} catch (InvalidParameterSpecException e) {
-			throw new InvalidKeySpecException("EC curve " + curve + " is not supported by the JCA provider.", e);
-		}
-		KeyFactory keyFactory = KeyFactory.getInstance("EC");
-		return keyFactory.generatePublic(new ECPublicKeySpec(point, ecParameterSpec));
-	}
-
-	private static String toJcaCurveName(String jwkCurveName) throws InvalidKeySpecException {
-		switch (jwkCurveName) {
-			case "P-256": return "secp256r1";
-			case "P-384": return "secp384r1";
-			case "P-521": return "secp521r1";
-			default: throw new InvalidKeySpecException("Unsupported EC curve: " + jwkCurveName);
-		}
-	}
-
-	public static PublicKey createPublicKeyFromPemEncodedPublicKey(JwtSignatureAlgorithm algorithm,
-			String pemEncodedKey)
-			throws NoSuchAlgorithmException, InvalidKeySpecException {
-		byte[] decodedBytes = Base64.getMimeDecoder().decode(convertPEMKey(pemEncodedKey));
-
-		X509EncodedKeySpec keySpecX509 = new X509EncodedKeySpec(decodedBytes);
-		KeyFactory keyFactory = KeyFactory.getInstance(algorithm.type());
-		return keyFactory.generatePublic(keySpecX509);
-	}
-
-	public static String convertPEMKey(String pemEncodedKey) {
-		String key = pemEncodedKey;
-		key = key.replace(BEGIN_PUBLIC_KEY, "");
-		key = key.replace(END_PUBLIC_KEY, "");
-		return key;
-	}
-
 	@Override
 	public int hashCode() {
-		return Objects.hash(keyAlgorithm, keyId != null ? keyId : DEFAULT_KEY_ID);
+		return Objects.hash(keyAlgorithm, keyId);
 	}
 
 	@Override

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeyImpl.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeyImpl.java
@@ -9,10 +9,16 @@ import com.sap.cloud.security.xsuaa.Assertions;
 
 import jakarta.annotation.Nullable;
 import java.math.BigInteger;
+import java.security.AlgorithmParameters;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.ECGenParameterSpec;
 import java.security.spec.InvalidKeySpecException;
+import java.security.spec.InvalidParameterSpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.RSAPublicKeySpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -28,16 +34,28 @@ class JsonWebKeyImpl implements JsonWebKey {
 	private final String pemEncodedPublicKey;
 	private final String modulus;
 	private final String publicExponent;
+	private final String curve;
+	private final String xCoordinate;
+	private final String yCoordinate;
 	private PublicKey publicKey;
 
 	JsonWebKeyImpl(JwtSignatureAlgorithm keyAlgorithm, @Nullable String keyId, String modulus,
 			String publicExponent, @Nullable String pemEncodedPublicKey) {
+		this(keyAlgorithm, keyId, modulus, publicExponent, null, null, null, pemEncodedPublicKey);
+	}
+
+	JsonWebKeyImpl(JwtSignatureAlgorithm keyAlgorithm, @Nullable String keyId, @Nullable String modulus,
+			@Nullable String publicExponent, @Nullable String curve, @Nullable String xCoordinate,
+			@Nullable String yCoordinate, @Nullable String pemEncodedPublicKey) {
 		Assertions.assertNotNull(keyAlgorithm, "keyAlgorithm must be not null");
 		this.keyId = keyId != null ? keyId : DEFAULT_KEY_ID;
 
 		this.pemEncodedPublicKey = pemEncodedPublicKey;
 		this.publicExponent = publicExponent;
 		this.modulus = modulus;
+		this.curve = curve;
+		this.xCoordinate = xCoordinate;
+		this.yCoordinate = yCoordinate;
 		this.keyAlgorithm = keyAlgorithm;
 	}
 
@@ -61,6 +79,8 @@ class JsonWebKeyImpl implements JsonWebKey {
 			publicKey = createPublicKeyFromPemEncodedPublicKey(keyAlgorithm, pemEncodedPublicKey);
 		} else if (keyAlgorithm.type().equalsIgnoreCase("RSA")) {
 			publicKey = createRSAPublicKey(publicExponent, modulus);
+		} else if (keyAlgorithm.type().equalsIgnoreCase("EC")) {
+			publicKey = createECPublicKey(keyAlgorithm, curve, xCoordinate, yCoordinate);
 		} else {
 			throw new IllegalStateException("JWT token with web key type " + keyAlgorithm + " can not be verified.");
 		}
@@ -75,6 +95,56 @@ class JsonWebKeyImpl implements JsonWebKey {
 
 		KeyFactory keyFactory = KeyFactory.getInstance("RSA");
 		return keyFactory.generatePublic(keySpec);
+	}
+
+	/**
+	 * Builds an EC {@link PublicKey} from JWK {@code crv}/{@code x}/{@code y} parameters per
+	 * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-6.2.1">RFC 7518 §6.2.1</a>.
+	 * <p>
+	 * Validates that {@code crv} matches the curve expected by {@code algorithm} and that both
+	 * coordinates have the exact octet length mandated for that curve — a missing or short
+	 * coordinate would otherwise produce a key on the wrong subgroup and silently succeed.
+	 */
+	static PublicKey createECPublicKey(JwtSignatureAlgorithm algorithm, String curve, String xCoordinate,
+			String yCoordinate) throws NoSuchAlgorithmException, InvalidKeySpecException {
+		if (curve == null || xCoordinate == null || yCoordinate == null) {
+			throw new InvalidKeySpecException(
+					"EC JWK is missing required parameters 'crv', 'x' or 'y' for algorithm " + algorithm.value());
+		}
+		if (!curve.equals(algorithm.curveName())) {
+			throw new InvalidKeySpecException("EC JWK curve '" + curve + "' does not match algorithm "
+					+ algorithm.value() + " which requires '" + algorithm.curveName() + "'.");
+		}
+		byte[] xBytes = Base64.getUrlDecoder().decode(xCoordinate);
+		byte[] yBytes = Base64.getUrlDecoder().decode(yCoordinate);
+		int expectedLength = algorithm.coordinateLength();
+		if (xBytes.length != expectedLength || yBytes.length != expectedLength) {
+			throw new InvalidKeySpecException("EC JWK coordinates for " + algorithm.value()
+					+ " must be " + expectedLength + " octets each (got x=" + xBytes.length + ", y=" + yBytes.length + ").");
+		}
+
+		ECPoint point = new ECPoint(new BigInteger(1, xBytes), new BigInteger(1, yBytes));
+		ECParameterSpec ecParameterSpec;
+		try {
+			AlgorithmParameters parameters = AlgorithmParameters.getInstance("EC");
+			// SunEC's AlgorithmParameters accepts "P-256" but not "P-384"/"P-521" as a curve name;
+			// the standard NIST names work for all three. Map JWK → NIST to stay portable.
+			parameters.init(new ECGenParameterSpec(toJcaCurveName(curve)));
+			ecParameterSpec = parameters.getParameterSpec(ECParameterSpec.class);
+		} catch (InvalidParameterSpecException e) {
+			throw new InvalidKeySpecException("EC curve " + curve + " is not supported by the JCA provider.", e);
+		}
+		KeyFactory keyFactory = KeyFactory.getInstance("EC");
+		return keyFactory.generatePublic(new ECPublicKeySpec(point, ecParameterSpec));
+	}
+
+	private static String toJcaCurveName(String jwkCurveName) throws InvalidKeySpecException {
+		switch (jwkCurveName) {
+			case "P-256": return "secp256r1";
+			case "P-384": return "secp384r1";
+			case "P-521": return "secp521r1";
+			default: throw new InvalidKeySpecException("Unsupported EC curve: " + jwkCurveName);
+		}
 	}
 
 	public static PublicKey createPublicKeyFromPemEncodedPublicKey(JwtSignatureAlgorithm algorithm,

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
@@ -33,6 +33,9 @@ class JsonWebKeySetFactory {
 		String keyId = null;
 		String modulus = null;
 		String publicExponent = null;
+		String curve = null;
+		String xCoordinate = null;
+		String yCoordinate = null;
 
 		String keyType = key.getString(JsonWebKeyConstants.KEY_TYPE_PARAMETER_NAME);
 		if (key.has(JsonWebKeyConstants.ALG_PARAMETER_NAME)) {
@@ -50,10 +53,19 @@ class JsonWebKeySetFactory {
 		if (key.has(JsonWebKeyConstants.RSA_KEY_PUBLIC_EXPONENT_PARAMETER_NAME)) {
 			publicExponent = key.getString(JsonWebKeyConstants.RSA_KEY_PUBLIC_EXPONENT_PARAMETER_NAME);
 		}
+		if (key.has(JsonWebKeyConstants.EC_CURVE_PARAMETER_NAME)) {
+			curve = key.getString(JsonWebKeyConstants.EC_CURVE_PARAMETER_NAME);
+		}
+		if (key.has(JsonWebKeyConstants.EC_X_COORDINATE_PARAMETER_NAME)) {
+			xCoordinate = key.getString(JsonWebKeyConstants.EC_X_COORDINATE_PARAMETER_NAME);
+		}
+		if (key.has(JsonWebKeyConstants.EC_Y_COORDINATE_PARAMETER_NAME)) {
+			yCoordinate = key.getString(JsonWebKeyConstants.EC_Y_COORDINATE_PARAMETER_NAME);
+		}
 		JwtSignatureAlgorithm algorithm = keyAlgorithm != null ? JwtSignatureAlgorithm.fromValue(keyAlgorithm)
 				: JwtSignatureAlgorithm.fromType(keyType);
 
-		return new JsonWebKeyImpl(algorithm, keyId, modulus, publicExponent,
+		return new JsonWebKeyImpl(algorithm, keyId, modulus, publicExponent, curve, xCoordinate, yCoordinate,
 				pemEncodedPublicKey);
 	}
 

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
@@ -28,45 +28,41 @@ class JsonWebKeySetFactory {
 	}
 
 	private static JsonWebKey createJsonWebKey(JSONObject key) {
-		String keyAlgorithm = null;
-		String pemEncodedPublicKey = null;
-		String keyId = null;
-		String modulus = null;
-		String publicExponent = null;
-		String curve = null;
-		String xCoordinate = null;
-		String yCoordinate = null;
-
 		String keyType = key.getString(JsonWebKeyConstants.KEY_TYPE_PARAMETER_NAME);
-		if (key.has(JsonWebKeyConstants.ALG_PARAMETER_NAME)) {
-			keyAlgorithm = key.getString(JsonWebKeyConstants.ALG_PARAMETER_NAME);
-		}
-		if (key.has(JsonWebKeyConstants.VALUE_PARAMETER_NAME)) {
-			pemEncodedPublicKey = key.getString(JsonWebKeyConstants.VALUE_PARAMETER_NAME);
-		}
-		if (key.has(JsonWebKeyConstants.KID_PARAMETER_NAME)) {
-			keyId = key.getString(JsonWebKeyConstants.KID_PARAMETER_NAME);
-		}
-		if (key.has(JsonWebKeyConstants.RSA_KEY_MODULUS_PARAMETER_NAME)) {
-			modulus = key.getString(JsonWebKeyConstants.RSA_KEY_MODULUS_PARAMETER_NAME);
-		}
-		if (key.has(JsonWebKeyConstants.RSA_KEY_PUBLIC_EXPONENT_PARAMETER_NAME)) {
-			publicExponent = key.getString(JsonWebKeyConstants.RSA_KEY_PUBLIC_EXPONENT_PARAMETER_NAME);
-		}
-		if (key.has(JsonWebKeyConstants.EC_CURVE_PARAMETER_NAME)) {
-			curve = key.getString(JsonWebKeyConstants.EC_CURVE_PARAMETER_NAME);
-		}
-		if (key.has(JsonWebKeyConstants.EC_X_COORDINATE_PARAMETER_NAME)) {
-			xCoordinate = key.getString(JsonWebKeyConstants.EC_X_COORDINATE_PARAMETER_NAME);
-		}
-		if (key.has(JsonWebKeyConstants.EC_Y_COORDINATE_PARAMETER_NAME)) {
-			yCoordinate = key.getString(JsonWebKeyConstants.EC_Y_COORDINATE_PARAMETER_NAME);
-		}
-		JwtSignatureAlgorithm algorithm = keyAlgorithm != null ? JwtSignatureAlgorithm.fromValue(keyAlgorithm)
+		String keyAlgorithmName = optionalString(key, JsonWebKeyConstants.ALG_PARAMETER_NAME);
+		String keyId = optionalString(key, JsonWebKeyConstants.KID_PARAMETER_NAME);
+
+		JwtSignatureAlgorithm algorithm = keyAlgorithmName != null
+				? JwtSignatureAlgorithm.fromValue(keyAlgorithmName)
 				: JwtSignatureAlgorithm.fromType(keyType);
 
-		return new JsonWebKeyImpl(algorithm, keyId, modulus, publicExponent, curve, xCoordinate, yCoordinate,
-				pemEncodedPublicKey);
+		return new JsonWebKeyImpl(algorithm, keyId, extractKeyMaterial(key));
+	}
+
+	/**
+	 * Chooses the appropriate {@link KeyMaterial} carrier for a JWK entry. PEM ({@code value})
+	 * takes precedence — that's the XSUAA JKU response format, which supplies the key as a
+	 * pre-encoded {@code SubjectPublicKeyInfo} regardless of {@code kty}. Otherwise a JWK with a
+	 * {@code crv} field is EC; anything else is treated as RSA (the historical default).
+	 */
+	private static KeyMaterial extractKeyMaterial(JSONObject key) {
+		String pem = optionalString(key, JsonWebKeyConstants.VALUE_PARAMETER_NAME);
+		if (pem != null) {
+			return new KeyMaterial.Pem(pem);
+		}
+		if (key.has(JsonWebKeyConstants.EC_CURVE_PARAMETER_NAME)) {
+			return new KeyMaterial.Ec(
+					key.getString(JsonWebKeyConstants.EC_CURVE_PARAMETER_NAME),
+					optionalString(key, JsonWebKeyConstants.EC_X_COORDINATE_PARAMETER_NAME),
+					optionalString(key, JsonWebKeyConstants.EC_Y_COORDINATE_PARAMETER_NAME));
+		}
+		return new KeyMaterial.Rsa(
+				optionalString(key, JsonWebKeyConstants.RSA_KEY_MODULUS_PARAMETER_NAME),
+				optionalString(key, JsonWebKeyConstants.RSA_KEY_PUBLIC_EXPONENT_PARAMETER_NAME));
+	}
+
+	private static String optionalString(JSONObject key, String field) {
+		return key.has(field) ? key.getString(field) : null;
 	}
 
 }

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtSignatureAlgorithm.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JwtSignatureAlgorithm.java
@@ -16,13 +16,19 @@ import java.security.spec.PSSParameterSpec;
  * <p>
  * Each entry carries:
  * <ul>
- *   <li>the {@code kty} JWK key type ({@code RSA} for RS* and PS* families),
+ *   <li>the {@code kty} JWK key type ({@code RSA} for RS* and PS* families, {@code EC} for ES*),
  *   <li>the {@code alg} value as it appears in JWK and JWT headers,
  *   <li>the corresponding standard JCA signature algorithm name passed to
  *       {@link java.security.Signature#getInstance(String)},
  *   <li>an optional {@link AlgorithmParameterSpec} for algorithms that require explicit
- *       parameters (RSASSA-PSS).
+ *       parameters (RSASSA-PSS),
+ *   <li>for EC algorithms: the curve name ({@code P-256}/{@code P-384}/{@code P-521}) and the
+ *       fixed coordinate length in octets per RFC 7518 §6.2.1.
  * </ul>
+ * <p>
+ * For ECDSA the JCA name {@code SHA*withECDSAinP1363Format} is used so that
+ * {@link java.security.Signature#verify(byte[])} accepts the raw {@code R||S} concatenation
+ * mandated by RFC 7518 §3.4 directly, without DER transcoding.
  */
 public enum JwtSignatureAlgorithm {
 
@@ -32,23 +38,38 @@ public enum JwtSignatureAlgorithm {
 
 	PS256("RSA", "PS256", "RSASSA-PSS", "SHA-256", 32),
 	PS384("RSA", "PS384", "RSASSA-PSS", "SHA-384", 48),
-	PS512("RSA", "PS512", "RSASSA-PSS", "SHA-512", 64);
+	PS512("RSA", "PS512", "RSASSA-PSS", "SHA-512", 64),
+
+	ES256("EC", "ES256", "SHA256withECDSAinP1363Format", "P-256", 32),
+	ES384("EC", "ES384", "SHA384withECDSAinP1363Format", "P-384", 48),
+	ES512("EC", "ES512", "SHA512withECDSAinP1363Format", "P-521", 66);
 
 	private final String type;
 	private final String value;
 	private final String javaSignatureAlgorithm;
 	@Nullable
 	private final AlgorithmParameterSpec parameterSpec;
+	@Nullable
+	private final String curveName;
+	private final int coordinateLength;
 
 	JwtSignatureAlgorithm(String type, String algorithm, String javaSignatureAlgorithm,
-			@Nullable String pssHashAlgorithm, int pssSaltLength) {
+			@Nullable String extraParam, int saltOrCoordinateLength) {
 		this.type = type;
 		this.value = algorithm; // jwks, jwt header
 		this.javaSignatureAlgorithm = javaSignatureAlgorithm;
-		this.parameterSpec = pssHashAlgorithm == null
-				? null
-				: new PSSParameterSpec(pssHashAlgorithm, "MGF1",
-						new MGF1ParameterSpec(pssHashAlgorithm), pssSaltLength, 1);
+		if ("EC".equals(type)) {
+			this.parameterSpec = null;
+			this.curveName = extraParam;
+			this.coordinateLength = saltOrCoordinateLength;
+		} else {
+			this.parameterSpec = extraParam == null
+					? null
+					: new PSSParameterSpec(extraParam, "MGF1",
+							new MGF1ParameterSpec(extraParam), saltOrCoordinateLength, 1);
+			this.curveName = null;
+			this.coordinateLength = 0;
+		}
 	}
 
 	public String value() {
@@ -72,6 +93,25 @@ public enum JwtSignatureAlgorithm {
 		return parameterSpec;
 	}
 
+	/**
+	 * For EC algorithms: the JWK curve name as defined in
+	 * <a href="https://www.rfc-editor.org/rfc/rfc7518.html#section-6.2.1.1">RFC 7518 §6.2.1.1</a>
+	 * ({@code P-256}, {@code P-384}, or {@code P-521}). Returns {@code null} for RSA-based algorithms.
+	 */
+	@Nullable
+	public String curveName() {
+		return curveName;
+	}
+
+	/**
+	 * For EC algorithms: the required octet length of each of the {@code x} and {@code y} coordinates
+	 * of the public key per RFC 7518 §6.2.1.2/§6.2.1.3 (32/48/66 for P-256/P-384/P-521). Returns
+	 * {@code 0} for RSA-based algorithms.
+	 */
+	public int coordinateLength() {
+		return coordinateLength;
+	}
+
 	public static JwtSignatureAlgorithm fromValue(String value) {
 		for (JwtSignatureAlgorithm algorithm : values()) {
 			if (algorithm.value.equals(value)) {
@@ -84,7 +124,8 @@ public enum JwtSignatureAlgorithm {
 	/**
 	 * Returns the default algorithm for the given JWK key type. Used as a fallback when a JWK
 	 * entry omits its {@code alg}. Falls back to {@link #RS256} for {@code RSA} keys; returns
-	 * {@code null} for unknown types.
+	 * {@code null} for {@code EC} (unlike RSA, EC keys are curve-bound and a single default
+	 * cannot be assumed safely) and for unknown types.
 	 */
 	public static JwtSignatureAlgorithm fromType(String type) {
 		if ("RSA".equals(type)) {

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/KeyMaterial.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/KeyMaterial.java
@@ -1,0 +1,118 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.token.validation.validators;
+
+import java.math.BigInteger;
+import java.security.AlgorithmParameters;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.InvalidParameterSpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+import static com.sap.cloud.security.token.validation.validators.JsonWebKeyConstants.BEGIN_PUBLIC_KEY;
+import static com.sap.cloud.security.token.validation.validators.JsonWebKeyConstants.END_PUBLIC_KEY;
+
+/**
+ * Algorithm-typed carrier for the raw parameters a JWK contributes to key construction.
+ * Splitting these fields out of {@link JsonWebKeyImpl} keeps each key type's parameter set
+ * self-contained: an {@link Rsa} record cannot accidentally reach EC-specific code and vice
+ * versa, which the previous "flat bag of nullable strings" constructor made too easy.
+ * <p>
+ * Sealed to a closed set of implementations — adding a new JWK key type (e.g. OKP for EdDSA)
+ * means adding one more record and one more case, not another optional constructor parameter.
+ */
+sealed interface KeyMaterial permits KeyMaterial.Rsa, KeyMaterial.Ec, KeyMaterial.Pem {
+
+	PublicKey toPublicKey(JwtSignatureAlgorithm algorithm) throws NoSuchAlgorithmException, InvalidKeySpecException;
+
+	/** RSA JWK: {@code n} (modulus) and {@code e} (public exponent), both base64url-encoded. */
+	record Rsa(String modulus, String publicExponent) implements KeyMaterial {
+		@Override
+		public PublicKey toPublicKey(JwtSignatureAlgorithm algorithm)
+				throws NoSuchAlgorithmException, InvalidKeySpecException {
+			BigInteger n = new BigInteger(1, Base64.getUrlDecoder().decode(modulus));
+			BigInteger e = new BigInteger(1, Base64.getUrlDecoder().decode(publicExponent));
+			return KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(n, e));
+		}
+	}
+
+	/**
+	 * EC JWK: {@code crv} + affine coordinates {@code x}/{@code y} per RFC 7518 §6.2.1.
+	 * The strict validation done here (curve/algorithm match, exact coordinate length) exists
+	 * because a short or truncated coordinate would otherwise produce a key on the wrong
+	 * subgroup and silently succeed.
+	 */
+	record Ec(String curve, String xCoordinate, String yCoordinate) implements KeyMaterial {
+		@Override
+		public PublicKey toPublicKey(JwtSignatureAlgorithm algorithm)
+				throws NoSuchAlgorithmException, InvalidKeySpecException {
+			if (curve == null || xCoordinate == null || yCoordinate == null) {
+				throw new InvalidKeySpecException(
+						"EC JWK is missing required parameters 'crv', 'x' or 'y' for algorithm " + algorithm.value());
+			}
+			if (!curve.equals(algorithm.curveName())) {
+				throw new InvalidKeySpecException("EC JWK curve '" + curve + "' does not match algorithm "
+						+ algorithm.value() + " which requires '" + algorithm.curveName() + "'.");
+			}
+			byte[] xBytes = Base64.getUrlDecoder().decode(xCoordinate);
+			byte[] yBytes = Base64.getUrlDecoder().decode(yCoordinate);
+			int expectedLength = algorithm.coordinateLength();
+			if (xBytes.length != expectedLength || yBytes.length != expectedLength) {
+				throw new InvalidKeySpecException("EC JWK coordinates for " + algorithm.value()
+						+ " must be " + expectedLength + " octets each (got x=" + xBytes.length + ", y="
+						+ yBytes.length + ").");
+			}
+
+			ECPoint point = new ECPoint(new BigInteger(1, xBytes), new BigInteger(1, yBytes));
+			ECParameterSpec ecParameterSpec;
+			try {
+				AlgorithmParameters parameters = AlgorithmParameters.getInstance("EC");
+				// SunEC's AlgorithmParameters accepts "P-256" but not "P-384"/"P-521" as a curve
+				// name; the standard NIST names work for all three. Map JWK → NIST to stay portable.
+				parameters.init(new ECGenParameterSpec(toJcaCurveName(curve)));
+				ecParameterSpec = parameters.getParameterSpec(ECParameterSpec.class);
+			} catch (InvalidParameterSpecException e) {
+				throw new InvalidKeySpecException("EC curve " + curve + " is not supported by the JCA provider.", e);
+			}
+			return KeyFactory.getInstance("EC").generatePublic(new ECPublicKeySpec(point, ecParameterSpec));
+		}
+
+		private static String toJcaCurveName(String jwkCurveName) throws InvalidKeySpecException {
+			return switch (jwkCurveName) {
+				case "P-256" -> "secp256r1";
+				case "P-384" -> "secp384r1";
+				case "P-521" -> "secp521r1";
+				default -> throw new InvalidKeySpecException("Unsupported EC curve: " + jwkCurveName);
+			};
+		}
+	}
+
+	/**
+	 * PEM-encoded {@code SubjectPublicKeyInfo} (used by the XSUAA JKU response format). The
+	 * enclosing algorithm's {@code kty} tells JCA which {@link KeyFactory} to load.
+	 */
+	record Pem(String pemEncodedKey) implements KeyMaterial {
+		@Override
+		public PublicKey toPublicKey(JwtSignatureAlgorithm algorithm)
+				throws NoSuchAlgorithmException, InvalidKeySpecException {
+			byte[] decodedBytes = Base64.getMimeDecoder().decode(stripDelimiters(pemEncodedKey));
+			return KeyFactory.getInstance(algorithm.type())
+					.generatePublic(new X509EncodedKeySpec(decodedBytes));
+		}
+
+		static String stripDelimiters(String pem) {
+			return pem.replace(BEGIN_PUBLIC_KEY, "").replace(END_PUBLIC_KEY, "");
+		}
+	}
+}

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/XsuaaJwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/XsuaaJwtSignatureValidator.java
@@ -68,8 +68,7 @@ class XsuaaJwtSignatureValidator extends JwtSignatureValidator {
 
 			String fallbackKey = configuration.getProperty(ServiceConstants.XSUAA.VERIFICATION_KEY);
 			try {
-				key = JsonWebKeyImpl.createPublicKeyFromPemEncodedPublicKey(JwtSignatureAlgorithm.RS256,
-						fallbackKey);
+				key = new KeyMaterial.Pem(fallbackKey).toPublicKey(JwtSignatureAlgorithm.RS256);
 			} catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
 				IllegalArgumentException illegalArgEx = new IllegalArgumentException(
 						"Fallback validation key supplied via " + ServiceConstants.XSUAA.VERIFICATION_KEY

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactoryTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactoryTest.java
@@ -12,11 +12,18 @@ import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECGenParameterSpec;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class JsonWebKeySetFactoryTest {
 
@@ -60,5 +67,140 @@ public class JsonWebKeySetFactoryTest {
 		assertThat(jwk.getKeyAlgorithm().type()).isEqualTo("RSA");
 		assertThat(jwk.getPublicKey().getAlgorithm()).isEqualTo(jwk.getKeyAlgorithm().type());
 		assertThat(jwk.getId()).isEqualTo(JsonWebKey.DEFAULT_KEY_ID);
+	}
+
+	@Test
+	public void parsesPs256Key() throws Exception {
+		KeyPair keyPair = generateRsaKey();
+		String jwks = buildRsaJwks("PS256", "ps256-kid", keyPair);
+
+		JsonWebKey jwk = JsonWebKeySetFactory.createFromJson(jwks)
+				.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.PS256, "ps256-kid");
+
+		assertThat(jwk.getKeyAlgorithm()).isEqualTo(JwtSignatureAlgorithm.PS256);
+		assertThat(jwk.getPublicKey().getAlgorithm()).isEqualTo("RSA");
+	}
+
+	@Test
+	public void parsesEs256Key() throws Exception {
+		KeyPair keyPair = generateEcKey("secp256r1");
+		String jwks = buildEcJwks("ES256", "P-256", "es256-kid", keyPair, 32);
+
+		JsonWebKey jwk = JsonWebKeySetFactory.createFromJson(jwks)
+				.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.ES256, "es256-kid");
+
+		assertThat(jwk.getKeyAlgorithm()).isEqualTo(JwtSignatureAlgorithm.ES256);
+		assertThat(jwk.getPublicKey().getAlgorithm()).isEqualTo("EC");
+	}
+
+	@Test
+	public void parsesEs384Key() throws Exception {
+		KeyPair keyPair = generateEcKey("secp384r1");
+		String jwks = buildEcJwks("ES384", "P-384", "es384-kid", keyPair, 48);
+
+		JsonWebKey jwk = JsonWebKeySetFactory.createFromJson(jwks)
+				.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.ES384, "es384-kid");
+
+		assertThat(jwk.getPublicKey().getAlgorithm()).isEqualTo("EC");
+	}
+
+	@Test
+	public void parsesEs512Key() throws Exception {
+		KeyPair keyPair = generateEcKey("secp521r1");
+		String jwks = buildEcJwks("ES512", "P-521", "es512-kid", keyPair, 66);
+
+		JsonWebKey jwk = JsonWebKeySetFactory.createFromJson(jwks)
+				.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.ES512, "es512-kid");
+
+		assertThat(jwk.getPublicKey().getAlgorithm()).isEqualTo("EC");
+	}
+
+	@Test
+	public void ecKey_rejectsMismatchedCurve() throws Exception {
+		// Build a JWK that announces alg=ES256 (curve P-256) but provides a P-384 key.
+		KeyPair keyPair = generateEcKey("secp384r1");
+		String jwks = buildEcJwks("ES256", "P-384", "mismatch-kid", keyPair, 48);
+
+		JsonWebKey jwk = JsonWebKeySetFactory.createFromJson(jwks)
+				.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.ES256, "mismatch-kid");
+
+		assertThatThrownBy(jwk::getPublicKey)
+				.isInstanceOf(InvalidKeySpecException.class)
+				.hasMessageContaining("does not match algorithm ES256");
+	}
+
+	@Test
+	public void ecKey_rejectsWrongCoordinateLength() throws Exception {
+		KeyPair keyPair = generateEcKey("secp256r1");
+		ECPublicKey ecKey = (ECPublicKey) keyPair.getPublic();
+		// Pad the x coordinate to 33 bytes instead of the expected 32 to trigger the length check.
+		byte[] xOverlong = new byte[33];
+		System.arraycopy(toUnsignedFixedLength(ecKey.getW().getAffineX().toByteArray(), 32), 0,
+				xOverlong, 1, 32);
+		String x = base64Url(xOverlong);
+		String y = base64Url(toUnsignedFixedLength(ecKey.getW().getAffineY().toByteArray(), 32));
+		String jwks = "{\"keys\":[{\"kty\":\"EC\",\"kid\":\"bad-len\",\"alg\":\"ES256\","
+				+ "\"crv\":\"P-256\",\"x\":\"" + x + "\",\"y\":\"" + y + "\"}]}";
+
+		JsonWebKey jwk = JsonWebKeySetFactory.createFromJson(jwks)
+				.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.ES256, "bad-len");
+
+		assertThatThrownBy(jwk::getPublicKey)
+				.isInstanceOf(InvalidKeySpecException.class)
+				.hasMessageContaining("must be 32 octets each");
+	}
+
+	private static KeyPair generateRsaKey() throws NoSuchAlgorithmException {
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+		generator.initialize(2048);
+		return generator.generateKeyPair();
+	}
+
+	private static KeyPair generateEcKey(String nistCurve) throws Exception {
+		KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+		generator.initialize(new ECGenParameterSpec(nistCurve));
+		return generator.generateKeyPair();
+	}
+
+	private static String buildRsaJwks(String alg, String kid, KeyPair keyPair) {
+		RSAPublicKey rsa = (RSAPublicKey) keyPair.getPublic();
+		String n = base64Url(stripLeadingZero(rsa.getModulus().toByteArray()));
+		String e = base64Url(stripLeadingZero(rsa.getPublicExponent().toByteArray()));
+		return "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"" + kid + "\",\"alg\":\"" + alg
+				+ "\",\"n\":\"" + n + "\",\"e\":\"" + e + "\"}]}";
+	}
+
+	private static String buildEcJwks(String alg, String crv, String kid, KeyPair keyPair, int coordLen) {
+		ECPublicKey ec = (ECPublicKey) keyPair.getPublic();
+		String x = base64Url(toUnsignedFixedLength(ec.getW().getAffineX().toByteArray(), coordLen));
+		String y = base64Url(toUnsignedFixedLength(ec.getW().getAffineY().toByteArray(), coordLen));
+		return "{\"keys\":[{\"kty\":\"EC\",\"kid\":\"" + kid + "\",\"alg\":\"" + alg
+				+ "\",\"crv\":\"" + crv + "\",\"x\":\"" + x + "\",\"y\":\"" + y + "\"}]}";
+	}
+
+	private static byte[] stripLeadingZero(byte[] bytes) {
+		if (bytes.length > 1 && bytes[0] == 0) {
+			byte[] out = new byte[bytes.length - 1];
+			System.arraycopy(bytes, 1, out, 0, out.length);
+			return out;
+		}
+		return bytes;
+	}
+
+	private static byte[] toUnsignedFixedLength(byte[] bytes, int length) {
+		byte[] unsigned = stripLeadingZero(bytes);
+		if (unsigned.length == length) {
+			return unsigned;
+		}
+		if (unsigned.length > length) {
+			throw new IllegalStateException("coordinate longer than expected");
+		}
+		byte[] padded = new byte[length];
+		System.arraycopy(unsigned, 0, padded, length - unsigned.length, unsigned.length);
+		return padded;
+	}
+
+	private static String base64Url(byte[] bytes) {
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
 	}
 }

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JsonWebKeyTestFactory.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JsonWebKeyTestFactory.java
@@ -20,10 +20,11 @@ public class JsonWebKeyTestFactory {
 	private static final String MODULUS = "j9XvbTYr3uXbkrAM10zQmOXkt4Gaj-SKZHbOK1y_eIdvrZge_LeSKVIgce6ZtC5b7F3HfJ1TAPy2kCSfusQ-P17egl6ka6-kMvPhDltWnurgAgfjDPnt6NckHxadut7L_-s9kd2L84GO-PznvcHGbc8ntTjtlgLmxDq-gZgCJKJqhWM3NYifUkLbbQT-c4dK6my-JtNyuye2fd2cR_G7IQE1UrZm7zqu9DttjN5A-R1eLYmtTuTC3xSHRCLVks6OyzIjzXP1TcyxXUvbwZWD6LpTidcapztRcwckO_AJHsztAvtC2hsPbl03lKzloHqQeRSEWVzRcgtK5ViRxcH7VQ";
 
 	public static JsonWebKey create() {
-		return new JsonWebKeyImpl(JwtSignatureAlgorithm.RS256, KEY_ID, MODULUS, "AQAB", PUBLIC_KEY);
+		return new JsonWebKeyImpl(JwtSignatureAlgorithm.RS256, KEY_ID, new KeyMaterial.Pem(PUBLIC_KEY));
 	}
 
 	public static JsonWebKey createDefault() {
-		return new JsonWebKeyImpl(JwtSignatureAlgorithm.RS256, JsonWebKey.DEFAULT_KEY_ID, MODULUS, "AQAB", null);
+		return new JsonWebKeyImpl(JwtSignatureAlgorithm.RS256, JsonWebKey.DEFAULT_KEY_ID,
+				new KeyMaterial.Rsa(MODULUS, "AQAB"));
 	}
 }

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JwtSignatureAlgorithmTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JwtSignatureAlgorithmTest.java
@@ -20,6 +20,7 @@ import java.security.KeyPairGenerator;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,7 +37,7 @@ class JwtSignatureAlgorithmTest {
 	void enum_values_areTheExpectedSet() {
 		assertThat(JwtSignatureAlgorithm.values())
 				.extracting(JwtSignatureAlgorithm::value)
-				.containsExactly("RS256", "RS384", "RS512", "PS256", "PS384", "PS512");
+				.containsExactly("RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512");
 	}
 
 	@Test
@@ -51,6 +52,7 @@ class JwtSignatureAlgorithmTest {
 
 	@Test
 	void fromType_unknown_returnsNull() {
+		// EC has no safe default — the algorithm is curve-bound and must come from the JWK's alg field
 		assertThat(JwtSignatureAlgorithm.fromType("EC")).isNull();
 		assertThat(JwtSignatureAlgorithm.fromType("oct")).isNull();
 	}
@@ -96,8 +98,23 @@ class JwtSignatureAlgorithmTest {
 
 	private static KeyPair generateKeyPair(JwtSignatureAlgorithm algorithm) throws Exception {
 		KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm.type());
-		generator.initialize(2048);
+		if ("EC".equals(algorithm.type())) {
+			// SunEC's KeyPairGenerator accepts only the standard NIST curve names (secp256r1, ...).
+			// Map from the JWK curve name (P-256, ...) to the matching NIST name.
+			generator.initialize(new ECGenParameterSpec(nistCurveName(algorithm.curveName())));
+		} else {
+			generator.initialize(2048);
+		}
 		return generator.generateKeyPair();
+	}
+
+	private static String nistCurveName(String jwkCurveName) {
+		switch (jwkCurveName) {
+			case "P-256": return "secp256r1";
+			case "P-384": return "secp384r1";
+			case "P-521": return "secp521r1";
+			default: throw new IllegalArgumentException("Unknown JWK curve: " + jwkCurveName);
+		}
 	}
 
 	private static String createSignedToken(JwtSignatureAlgorithm algorithm, KeyPair keyPair) throws Exception {

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidatorAlgorithmsTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidatorAlgorithmsTest.java
@@ -1,0 +1,230 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.token.validation.validators;
+
+import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
+import com.sap.cloud.security.config.Service;
+import com.sap.cloud.security.token.SapIdToken;
+import com.sap.cloud.security.token.Token;
+import com.sap.cloud.security.token.validation.ValidationResult;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
+import com.sap.cloud.security.xsuaa.client.OAuth2TokenKeyService;
+import com.sap.cloud.security.xsuaa.client.OidcConfigurationService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mockito;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end test of the IAS signature validation path for every algorithm declared in
+ * {@link JwtSignatureAlgorithm}. Each iteration:
+ * <ol>
+ *   <li>generates a fresh key pair for the algorithm,
+ *   <li>builds a synthetic JWKS JSON containing the matching public key,
+ *   <li>signs a token whose claims satisfy {@link SapIdJwtSignatureValidator}'s issuer / app_tid rules,
+ *   <li>routes the token through the real validator with mocked transport.
+ * </ol>
+ * Complements {@link JwtSignatureAlgorithmTest}, which exercises {@code validateSignature} in
+ * isolation: this test additionally drives the JWKS parser and key construction path that
+ * {@link SapIdJwtSignatureValidator#getPublicKey} relies on.
+ */
+class SapIdJwtSignatureValidatorAlgorithmsTest {
+
+	private static final String ISSUER = "https://test.example.com";
+	private static final String CLIENT_ID = "client-id";
+	private static final String KEY_ID = "test-kid";
+	private static final URI JWKS_URI = URI.create("https://test.example.com/jwks_uri");
+
+	private OAuth2TokenKeyService tokenKeyServiceMock;
+	private SapIdJwtSignatureValidator cut;
+
+	@BeforeEach
+	void setup() throws OAuth2ServiceException {
+		OAuth2ServiceConfiguration mockConfiguration = Mockito.mock(OAuth2ServiceConfiguration.class);
+		when(mockConfiguration.getService()).thenReturn(Service.IAS);
+		when(mockConfiguration.getClientId()).thenReturn(CLIENT_ID);
+		when(mockConfiguration.getUrl()).thenReturn(URI.create(ISSUER));
+
+		tokenKeyServiceMock = Mockito.mock(OAuth2TokenKeyService.class);
+
+		OAuth2ServiceEndpointsProvider endpointsProviderMock = Mockito.mock(OAuth2ServiceEndpointsProvider.class);
+		when(endpointsProviderMock.getJwksUri()).thenReturn(JWKS_URI);
+
+		OidcConfigurationService oidcConfigServiceMock = Mockito.mock(OidcConfigurationService.class);
+		when(oidcConfigServiceMock.retrieveEndpoints(any())).thenReturn(endpointsProviderMock);
+
+		cut = new SapIdJwtSignatureValidator(
+				mockConfiguration,
+				OAuth2TokenKeyServiceWithCache.getInstance().withTokenKeyService(tokenKeyServiceMock),
+				OidcConfigurationServiceWithCache.getInstance()
+						.withOidcConfigurationService(oidcConfigServiceMock));
+	}
+
+	@AfterEach
+	void tearDown() {
+		// Singleton caches outlive the test instance; clear both so the next iteration cannot
+		// pick up the previous algorithm's key set from the cache.
+		OAuth2TokenKeyServiceWithCache.getInstance().clearCache();
+		OidcConfigurationServiceWithCache.getInstance().clearCache();
+	}
+
+	@ParameterizedTest
+	@EnumSource(JwtSignatureAlgorithm.class)
+	void validate_acceptsTokenForEveryAlgorithm(JwtSignatureAlgorithm algorithm) throws Exception {
+		KeyPair keyPair = generateKeyPair(algorithm);
+		String jwks = buildJwks(algorithm, keyPair);
+		when(tokenKeyServiceMock.retrieveTokenKeys(any(), anyMap())).thenReturn(jwks);
+
+		String tokenValue = createSignedToken(algorithm, keyPair);
+		Token token = new SapIdToken(tokenValue);
+
+		ValidationResult result = cut.validate(token);
+
+		assertThat(result.isValid())
+				.as("end-to-end validation should accept a freshly signed %s token: %s",
+						algorithm.value(), result.getErrorDescription())
+				.isTrue();
+	}
+
+	@ParameterizedTest
+	@EnumSource(JwtSignatureAlgorithm.class)
+	void validate_rejectsTamperedTokenForEveryAlgorithm(JwtSignatureAlgorithm algorithm) throws Exception {
+		KeyPair keyPair = generateKeyPair(algorithm);
+		when(tokenKeyServiceMock.retrieveTokenKeys(any(), anyMap())).thenReturn(buildJwks(algorithm, keyPair));
+
+		String tokenValue = createSignedToken(algorithm, keyPair);
+		String[] parts = tokenValue.split("\\.");
+		// Flip the FIRST char of the signature, not the last. Base64url without padding can have
+		// up-to-four bits at the tail that don't map to a decoded byte — flipping the last char
+		// may leave the decoded signature bytes unchanged for signatures whose length isn't a
+		// multiple of three. The first char always contributes six real bits, so this is safe.
+		char first = parts[2].charAt(0);
+		String tamperedSig = (first == 'A' ? 'B' : 'A') + parts[2].substring(1);
+		Token tampered = new SapIdToken(parts[0] + "." + parts[1] + "." + tamperedSig);
+
+		assertThat(cut.validate(tampered).isErroneous())
+				.as("tampered %s token must be rejected", algorithm.value())
+				.isTrue();
+	}
+
+	private static KeyPair generateKeyPair(JwtSignatureAlgorithm algorithm) throws Exception {
+		KeyPairGenerator generator = KeyPairGenerator.getInstance(algorithm.type());
+		if ("EC".equals(algorithm.type())) {
+			generator.initialize(new ECGenParameterSpec(nistCurveName(algorithm.curveName())));
+		} else {
+			generator.initialize(2048);
+		}
+		return generator.generateKeyPair();
+	}
+
+	private static String buildJwks(JwtSignatureAlgorithm algorithm, KeyPair keyPair) {
+		if ("EC".equals(algorithm.type())) {
+			ECPublicKey ecKey = (ECPublicKey) keyPair.getPublic();
+			int len = algorithm.coordinateLength();
+			String x = base64Url(toUnsignedFixedLength(ecKey.getW().getAffineX().toByteArray(), len));
+			String y = base64Url(toUnsignedFixedLength(ecKey.getW().getAffineY().toByteArray(), len));
+			return "{\"keys\":[{"
+					+ "\"kty\":\"EC\","
+					+ "\"kid\":\"" + KEY_ID + "\","
+					+ "\"alg\":\"" + algorithm.value() + "\","
+					+ "\"crv\":\"" + algorithm.curveName() + "\","
+					+ "\"x\":\"" + x + "\","
+					+ "\"y\":\"" + y + "\"}]}";
+		}
+		RSAPublicKey rsaKey = (RSAPublicKey) keyPair.getPublic();
+		String n = base64Url(stripLeadingZero(rsaKey.getModulus().toByteArray()));
+		String e = base64Url(stripLeadingZero(rsaKey.getPublicExponent().toByteArray()));
+		return "{\"keys\":[{"
+				+ "\"kty\":\"RSA\","
+				+ "\"kid\":\"" + KEY_ID + "\","
+				+ "\"alg\":\"" + algorithm.value() + "\","
+				+ "\"n\":\"" + n + "\","
+				+ "\"e\":\"" + e + "\"}]}";
+	}
+
+	private static String createSignedToken(JwtSignatureAlgorithm algorithm, KeyPair keyPair) throws Exception {
+		String header = base64Url(("{\"alg\":\"" + algorithm.value() + "\",\"kid\":\"" + KEY_ID + "\",\"typ\":\"JWT\"}")
+				.getBytes(StandardCharsets.UTF_8));
+		// Issuer matches the configured URL → SapIdJwtSignatureValidator does not require app_tid.
+		String payload = base64Url(("{\"iss\":\"" + ISSUER + "\","
+				+ "\"sub\":\"test-user\","
+				+ "\"aud\":\"" + CLIENT_ID + "\","
+				+ "\"cid\":\"" + CLIENT_ID + "\","
+				+ "\"exp\":6974031600}").getBytes(StandardCharsets.UTF_8));
+		String signingInput = header + "." + payload;
+
+		Signature signature = Signature.getInstance(algorithm.javaSignature());
+		AlgorithmParameterSpec parameterSpec = algorithm.parameterSpec();
+		if (parameterSpec != null) {
+			signature.setParameter(parameterSpec);
+		}
+		signature.initSign(keyPair.getPrivate());
+		signature.update(signingInput.getBytes(StandardCharsets.UTF_8));
+		return signingInput + "." + base64Url(signature.sign());
+	}
+
+	private static String nistCurveName(String jwkCurveName) {
+		switch (jwkCurveName) {
+			case "P-256": return "secp256r1";
+			case "P-384": return "secp384r1";
+			case "P-521": return "secp521r1";
+			default: throw new IllegalArgumentException("Unknown JWK curve: " + jwkCurveName);
+		}
+	}
+
+	/**
+	 * BigInteger#toByteArray returns a two's-complement representation that may include a leading
+	 * 0x00 sign byte for positive values whose top bit is set. JWK n/e are unsigned big-endian
+	 * (RFC 7518), so the leading zero has to go.
+	 */
+	private static byte[] stripLeadingZero(byte[] bytes) {
+		if (bytes.length > 1 && bytes[0] == 0) {
+			byte[] out = new byte[bytes.length - 1];
+			System.arraycopy(bytes, 1, out, 0, out.length);
+			return out;
+		}
+		return bytes;
+	}
+
+	/**
+	 * Coerces a BigInteger's two's-complement bytes to a fixed-length unsigned big-endian octet
+	 * string, as RFC 7518 §6.2.1.2/§6.2.1.3 requires for the EC x and y coordinates.
+	 */
+	private static byte[] toUnsignedFixedLength(byte[] bytes, int length) {
+		byte[] unsigned = stripLeadingZero(bytes);
+		if (unsigned.length == length) {
+			return unsigned;
+		}
+		if (unsigned.length > length) {
+			throw new IllegalStateException("coordinate longer than expected: " + unsigned.length + " > " + length);
+		}
+		byte[] padded = new byte[length];
+		System.arraycopy(unsigned, 0, padded, length - unsigned.length, unsigned.length);
+		return padded;
+	}
+
+	private static String base64Url(byte[] bytes) {
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds ECDSA support (ES256/ES384/ES512) to `JwtSignatureValidator`, completing the RFC 7518 §3.1 algorithm set on top of the RS*/PS* families added in #<rs-pr>. Builds on `feature/jwt-rsa-algorithms`.
- Uses the JCA name `SHA*withECDSAinP1363Format` so the raw `R||S` signature format mandated by RFC 7518 §3.4 is accepted directly, without DER transcoding.
- Constructs EC public keys from JWK `crv`/`x`/`y` with strict validation: the curve must match the algorithm and each coordinate must have the exact octet length per RFC 7518 §6.2.1.
- `JwtSignatureAlgorithm.fromType(\"EC\")` deliberately returns `null` — unlike RSA, EC keys are curve-bound and no safe default exists when a JWK omits its `alg` field.

## Implementation notes

- JWK curve names `P-256`/`P-384`/`P-521` are mapped to the NIST names `secp256r1`/`secp384r1`/`secp521r1` before being passed to `AlgorithmParameters.init(ECGenParameterSpec)`. SunEC accepts only the NIST names for the larger two curves; without this mapping ES384/ES512 would fail at runtime on the reference JCA provider.
- The PEM-encoded-key path in `JsonWebKeyImpl` is unchanged; EC support is implemented via a new `createECPublicKey` branch using `ECPublicKeySpec`.
- `JsonWebKeyImpl` constructor is overloaded — the existing 5-arg signature is preserved for backwards compatibility, EC fields go through a new 8-arg overload that only `JsonWebKeySetFactory` calls.

## Test plan

- [x] `JwtSignatureAlgorithmTest` (existing, now parametrized over all 9 algorithms) — happy path + tamper rejection in isolation.
- [x] New `SapIdJwtSignatureValidatorAlgorithmsTest` — end-to-end through the real `SapIdJwtSignatureValidator` with mocked transport: generates a fresh key pair per algorithm, builds a synthetic JWKS, signs a token, validates it. 9 × happy + 9 × tamper.
- [x] `JsonWebKeySetFactoryTest` extended with PS256, ES256/384/512 parsing, plus EC curve-mismatch and coordinate-length-mismatch error cases.
- [x] All keys/tokens are generated at test time — no real tenant material in the repo.
- [x] `mvn -pl java-security test` → 370 tests, 0 failures, 2 pre-existing `@Disabled` skipped.