### PR TITLE
fix: Sanitize x-client_cert header for IAS proof-token validation (4.0.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## 4.1.0
+## 4.0.8
 
+- Fix IAS proof-token validation regression under Istio / Kyma with `credential-type: X509_GENERATED`
+  - `SapIdJwtSignatureValidator` was setting the `x-client_cert` request header directly from `X509Certificate#getPEM()`. When the certificate originates from Istio's `x-forwarded-client-cert` (XFCC) header, the PEM includes `-----BEGIN CERTIFICATE-----` / `-----END CERTIFICATE-----` delimiters and CR/LF line breaks
+  - Since 4.0.0, the token-client HTTP transport uses Java 11's `HttpClient`, which enforces RFC 7230 and rejects any header value containing CR/LF with `IllegalArgumentException` (surfaced as `"Token signature can not be validated because: invalid header value: <PEM>"`). Every authenticated request behind Istio failed proof-token validation as a result
+  - The header value is now sanitized to bare base64-encoded DER (PEM delimiters and all whitespace stripped) before being placed on the wire. The IAS JWKS endpoint accepts this form. A new `X509Certificate#getPEMHeaderValue()` accessor keeps the sanitization next to the PEM parsing; `getPEM()`'s existing contract is unchanged
+  - `JavaHttpClientAdapter` additionally fails fast with a message naming the offending header key (not the value, which may be sensitive) if a header value ever contains CR/LF, turning any future regression from a misleading `"invalid header value: <PEM>"` into an actionable transport-layer error
 - Update dependencies:
   - Spring Boot: 4.0.6 → 4.1.0
   - Spring Framework: 7.0.7 → 7.0.8

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If your application uses Spring Boot 3.x and you cannot immediately upgrade to S
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-3-starter</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 ```
 
@@ -275,7 +275,7 @@ The SAP Cloud Security Services Integration is published to maven central: https
         <dependency>
             <groupId>com.sap.cloud.security</groupId>
             <artifactId>java-bom</artifactId>
-            <version>4.0.7</version>
+            <version>4.0.8</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-bom</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
     <packaging>pom</packaging>
     <name>java-bom</name>
 

--- a/env/pom.xml
+++ b/env/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>4.0.7</version>
+        <version>4.0.8</version>
     </parent>
 
     <groupId>com.sap.cloud.security</groupId>

--- a/java-api/README.md
+++ b/java-api/README.md
@@ -5,6 +5,6 @@
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-api</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 ```

--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.0.7</version>
+		<version>4.0.8</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security-test/README.md
+++ b/java-security-test/README.md
@@ -40,7 +40,7 @@ It is pre-configured with a security filter that only accepts valid tokens. Furt
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
    <artifactId>java-security-test</artifactId>
-      <version>4.0.7</version>
+      <version>4.0.8</version>
    <scope>test</scope>
 </dependency>
 ```

--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.0.7</version>
+		<version>4.0.8</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -69,7 +69,7 @@ Since it requires the Tomcat 10 runtime, it needs to be deployed using the [SAP 
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-security</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.0.7</version>
+		<version>4.0.8</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
@@ -79,7 +79,7 @@ class SapIdJwtSignatureValidator extends JwtSignatureValidator {
 			} else {
 				Map<String, String> cacheKeyParams = new HashMap<>(requestParams);
 
-				requestParams.put(HttpHeaders.X_CLIENT_CERT, cert.getPEM());
+				requestParams.put(HttpHeaders.X_CLIENT_CERT, cert.getPEMHeaderValue());
 				cacheKeyParams.put(X509Constants.FWD_CLIENT_CERT_SUB, cert.getSubjectDN());
 
 				cacheKey = new OAuth2TokenKeyServiceWithCache.CacheKey(keyParams.keyUri(), cacheKeyParams);

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
@@ -79,7 +79,7 @@ class SapIdJwtSignatureValidator extends JwtSignatureValidator {
 			} else {
 				Map<String, String> cacheKeyParams = new HashMap<>(requestParams);
 
-				requestParams.put(HttpHeaders.X_CLIENT_CERT, cert.getPEMHeaderValue());
+				requestParams.put(HttpHeaders.X_CLIENT_CERT, cert.getLeafCertificateAsHeaderValue());
 				cacheKeyParams.put(X509Constants.FWD_CLIENT_CERT_SUB, cert.getSubjectDN());
 
 				cacheKey = new OAuth2TokenKeyServiceWithCache.CacheKey(keyParams.keyUri(), cacheKeyParams);

--- a/java-security/src/main/java/com/sap/cloud/security/x509/X509Certificate.java
+++ b/java-security/src/main/java/com/sap/cloud/security/x509/X509Certificate.java
@@ -142,11 +142,22 @@ public class X509Certificate implements Certificate {
 	}
 
 	/**
-	 * @return the certificate as bare base64-encoded DER, with PEM delimiters and all whitespace
-	 * 		removed. Safe to use as an HTTP header value (RFC 7230 forbids CR/LF in header values).
+	 * @return the leaf certificate as bare base64-encoded DER, safe to use as an HTTP header
+	 * 		value (RFC 7230 forbids CR/LF in header values). If the PEM contains multiple
+	 * 		concatenated certificates only the first is kept — consistent with
+	 * 		{@link #getSubjectDN()} and {@link #getThumbprint()}, which also operate on the first
+	 * 		(leaf) certificate.
 	 */
-	public String getPEMHeaderValue() {
-		return this.pem
+	public String getLeafCertificateAsHeaderValue() {
+		String pem = this.pem;
+		int begin = pem.indexOf("-----BEGIN CERTIFICATE-----");
+		if (begin >= 0) {
+			int end = pem.indexOf("-----END CERTIFICATE-----", begin);
+			if (end > begin) {
+				pem = pem.substring(begin, end + "-----END CERTIFICATE-----".length());
+			}
+		}
+		return pem
 				.replace("-----BEGIN CERTIFICATE-----", "")
 				.replace("-----END CERTIFICATE-----", "")
 				.replaceAll("\\s", "");

--- a/java-security/src/main/java/com/sap/cloud/security/x509/X509Certificate.java
+++ b/java-security/src/main/java/com/sap/cloud/security/x509/X509Certificate.java
@@ -149,18 +149,14 @@ public class X509Certificate implements Certificate {
 	 * 		(leaf) certificate.
 	 */
 	public String getLeafCertificateAsHeaderValue() {
-		String pem = this.pem;
-		int begin = pem.indexOf("-----BEGIN CERTIFICATE-----");
-		if (begin >= 0) {
-			int end = pem.indexOf("-----END CERTIFICATE-----", begin);
-			if (end > begin) {
-				pem = pem.substring(begin, end + "-----END CERTIFICATE-----".length());
-			}
+		int begin = pem.indexOf(X509Parser.BEGIN_CERTIFICATE);
+		if (begin < 0) {
+			return pem.replaceAll("\\s", "");
 		}
-		return pem
-				.replace("-----BEGIN CERTIFICATE-----", "")
-				.replace("-----END CERTIFICATE-----", "")
-				.replaceAll("\\s", "");
+		int bodyStart = begin + X509Parser.BEGIN_CERTIFICATE.length();
+		int end = pem.indexOf(X509Parser.END_CERTIFICATE, bodyStart);
+		int bodyEnd = end > bodyStart ? end : pem.length();
+		return pem.substring(bodyStart, bodyEnd).replaceAll("\\s", "");
 	}
 
 }

--- a/java-security/src/main/java/com/sap/cloud/security/x509/X509Certificate.java
+++ b/java-security/src/main/java/com/sap/cloud/security/x509/X509Certificate.java
@@ -141,4 +141,15 @@ public class X509Certificate implements Certificate {
 		return this.pem;
 	}
 
+	/**
+	 * @return the certificate as bare base64-encoded DER, with PEM delimiters and all whitespace
+	 * 		removed. Safe to use as an HTTP header value (RFC 7230 forbids CR/LF in header values).
+	 */
+	public String getPEMHeaderValue() {
+		return this.pem
+				.replace("-----BEGIN CERTIFICATE-----", "")
+				.replace("-----END CERTIFICATE-----", "")
+				.replaceAll("\\s", "");
+	}
+
 }

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidatorTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidatorTest.java
@@ -168,6 +168,47 @@ public class SapIdJwtSignatureValidatorTest {
 	}
 
 	@Test
+	public void validate_withEnabledProofTokenCheck_multiLinePemCert_headerIsSanitized() throws IOException {
+		String base64 = IOUtils.resourceToString("/cf-forwarded-client-cert.txt", UTF_8);
+		String multiLinePem = "-----BEGIN CERTIFICATE-----\n"
+				+ chunk(base64, 64)
+				+ "\n-----END CERTIFICATE-----\n";
+		Certificate cert = X509Certificate.newCertificate(multiLinePem);
+		SecurityContext.setClientCertificate(cert);
+
+		OAuth2TokenKeyService tokenKeyMock = Mockito.mock(OAuth2TokenKeyService.class);
+		ParamsCapturesClientCert capture = new ParamsCapturesClientCert();
+		when(tokenKeyMock
+				.retrieveTokenKeys(any(), argThat(capture)))
+				.thenReturn(IOUtils.resourceToString("/iasJsonWebTokenKeys.json", UTF_8));
+
+		SapIdJwtSignatureValidator cut = new SapIdJwtSignatureValidator(
+				mockConfiguration,
+				OAuth2TokenKeyServiceWithCache.getInstance()
+						.withTokenKeyService(tokenKeyMock),
+				OidcConfigurationServiceWithCache.getInstance()
+						.withOidcConfigurationService(oidcConfigServiceMock));
+		cut.enableProofTokenValidationCheck();
+		assertTrue(cut.validate(iasToken).isValid());
+
+		assertThat(capture.captured).isNotNull();
+		assertThat(capture.captured).doesNotContain("-----BEGIN");
+		assertThat(capture.captured).doesNotContain("-----END");
+		assertThat(capture.captured).doesNotContain("\n");
+		assertThat(capture.captured).doesNotContain("\r");
+		assertThat(capture.captured).doesNotContain(" ");
+	}
+
+	private static String chunk(String s, int width) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < s.length(); i += width) {
+			if (i > 0) sb.append('\n');
+			sb.append(s, i, Math.min(i + width, s.length()));
+		}
+		return sb.toString();
+	}
+
+	@Test
 	public void validate_withEnabledProofTokenCheck_app2app() {
 		Token iasToken = new SapIdToken(
 				"eyJraWQiOiJkZWZhdWx0LWtpZC1pYXMiLCJhbGciOiJSUzI1NiJ9.eyJleHAiOjY5NzQwMzE2MDAsImF6cCI6IlQwMDAzMTAiLCJjaWQiOiJUMDAwMzEwIiwiYXVkIjoiVDAwMDMxMCIsInpvbmVfdXVpZCI6InRoZS16b25lLWlkIiwiYXBwX3RpZCI6InRoZS1hcHAtdGlkIiwidXNlcl91dWlkIjoiMTIzNDU2Nzg5MCIsInNjaW1faWQiOiJzY2ltLTEyMzQ1Njc4OTAiLCJzdWIiOiJQMTc2OTQ1IiwiaXNzIjoiaHR0cHM6Ly9hcHBsaWNhdGlvbi5teWF1dGguY29tIiwiZ2l2ZW5fbmFtZSI6ImpvaG4iLCJmYW1pbHlfbmFtZSI6ImRvZSIsImVtYWlsIjoiam9obi5kb2VAZW1haWwub3JnIiwiaWFzX2FwaXMiOiJpYXNfYXBpcyJ9.XScl2bUr12mDNmVJahYIHEr7rlfaBFoyjR4UTJvOuEKXIQIgf58hRqbDNoKNM2pRiue8FvlD4TuI1OQ9r4wQgJ86sa0YIly7YfOhX6XQoDUXCcFVU_MsYTZJo2LMmOziD5EHt9wakRhWN3FqDM7KG4j_-HOhj3k0I72gFt83BToQHcMsW26eDQ7qfeeiNFsuUWzX8U-hZzCdOsl6EGYw2VU9kedEACH7xsOmfDdfLEPHu1HmjRmywdE118z4fPXpIvSN47V4VeXU8jZptRgxz1TDLT2w_zb4IPJInacadMVLNIVcrWqplQKTiS7nUCzCk2_aSKnBjerO5ugoERS9HA");
@@ -283,6 +324,20 @@ public class SapIdJwtSignatureValidatorTest {
 		@Override
 		public boolean matches(Map<String, String> map) {
 			return map.get(HttpHeaders.X_CLIENT_CERT) == null;
+		}
+	}
+
+	static class ParamsCapturesClientCert implements ArgumentMatcher<Map<String, String>> {
+		String captured;
+
+		@Override
+		public boolean matches(Map<String, String> map) {
+			String value = map.get(HttpHeaders.X_CLIENT_CERT);
+			if (value != null) {
+				this.captured = value;
+				return true;
+			}
+			return false;
 		}
 	}
 

--- a/java-security/src/test/java/com/sap/cloud/security/x509/X509CertificateTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/x509/X509CertificateTest.java
@@ -42,13 +42,13 @@ class X509CertificateTest {
 	}
 
 	@Test
-	void getPEMHeaderValue_stripsDelimitersAndWhitespace_fromMultilinePEM() {
+	void getLeafCertificateAsHeaderValue_stripsDelimitersAndWhitespace_fromMultilinePEM() {
 		String pem = "-----BEGIN CERTIFICATE-----\n"
 				+ chunk(x509_base64, 64)
 				+ "\n-----END CERTIFICATE-----\n";
 		X509Certificate fromPem = X509Certificate.newCertificate(pem);
 
-		String headerValue = fromPem.getPEMHeaderValue();
+		String headerValue = fromPem.getLeafCertificateAsHeaderValue();
 		assertThat(headerValue).isEqualTo(x509_base64);
 		assertThat(headerValue).doesNotContain("-----BEGIN");
 		assertThat(headerValue).doesNotContain("-----END");
@@ -58,7 +58,7 @@ class X509CertificateTest {
 	}
 
 	@Test
-	void getPEMHeaderValue_fromXfccUrlEncodedPEM() throws Exception {
+	void getLeafCertificateAsHeaderValue_fromXfccUrlEncodedPEM() throws Exception {
 		String pem = "-----BEGIN CERTIFICATE-----\n"
 				+ chunk(x509_base64, 64)
 				+ "\n-----END CERTIFICATE-----\n";
@@ -68,7 +68,24 @@ class X509CertificateTest {
 		X509Certificate fromXfcc = X509Certificate.newCertificate(xfcc);
 
 		assertThat(fromXfcc).isNotNull();
-		assertThat(fromXfcc.getPEMHeaderValue()).isEqualTo(x509_base64);
+		assertThat(fromXfcc.getLeafCertificateAsHeaderValue()).isEqualTo(x509_base64);
+	}
+
+	@Test
+	void getLeafCertificateAsHeaderValue_multiCertPEM_keepsOnlyFirstCert() {
+		String pem = "-----BEGIN CERTIFICATE-----\n"
+				+ chunk(x509_base64, 64)
+				+ "\n-----END CERTIFICATE-----\n"
+				+ "-----BEGIN CERTIFICATE-----\nMIIGARBITRARYSECONDCERTDATA==\n-----END CERTIFICATE-----\n";
+		X509Certificate cert = X509Certificate.newCertificate(pem);
+
+		assertThat(cert).isNotNull();
+		String headerValue = cert.getLeafCertificateAsHeaderValue();
+		assertThat(headerValue).isEqualTo(x509_base64);
+		assertThat(headerValue).doesNotContain("MIIGARBITRARYSECONDCERTDATA");
+		assertThat(headerValue).doesNotContain("-----BEGIN");
+		assertThat(headerValue).doesNotContain("-----END");
+		assertThat(headerValue).doesNotContain("\n");
 	}
 
 	private static String chunk(String s, int width) {

--- a/java-security/src/test/java/com/sap/cloud/security/x509/X509CertificateTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/x509/X509CertificateTest.java
@@ -42,6 +42,45 @@ class X509CertificateTest {
 	}
 
 	@Test
+	void getPEMHeaderValue_stripsDelimitersAndWhitespace_fromMultilinePEM() {
+		String pem = "-----BEGIN CERTIFICATE-----\n"
+				+ chunk(x509_base64, 64)
+				+ "\n-----END CERTIFICATE-----\n";
+		X509Certificate fromPem = X509Certificate.newCertificate(pem);
+
+		String headerValue = fromPem.getPEMHeaderValue();
+		assertThat(headerValue).isEqualTo(x509_base64);
+		assertThat(headerValue).doesNotContain("-----BEGIN");
+		assertThat(headerValue).doesNotContain("-----END");
+		assertThat(headerValue).doesNotContain("\n");
+		assertThat(headerValue).doesNotContain("\r");
+		assertThat(headerValue).doesNotContain(" ");
+	}
+
+	@Test
+	void getPEMHeaderValue_fromXfccUrlEncodedPEM() throws Exception {
+		String pem = "-----BEGIN CERTIFICATE-----\n"
+				+ chunk(x509_base64, 64)
+				+ "\n-----END CERTIFICATE-----\n";
+		String xfcc = "Hash=abc;Cert=\""
+				+ java.net.URLEncoder.encode(pem, java.nio.charset.StandardCharsets.UTF_8)
+				+ "\"";
+		X509Certificate fromXfcc = X509Certificate.newCertificate(xfcc);
+
+		assertThat(fromXfcc).isNotNull();
+		assertThat(fromXfcc.getPEMHeaderValue()).isEqualTo(x509_base64);
+	}
+
+	private static String chunk(String s, int width) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < s.length(); i += width) {
+			if (i > 0) sb.append('\n');
+			sb.append(s, i, Math.min(i + width, s.length()));
+		}
+		return sb.toString();
+	}
+
+	@Test
 	void getSubjectDN() {
 		assertThat(cut.getSubjectDN()).isEqualTo(
 				"CN=bdcd300c-b202-4a7a-bb95-2a7e6d15fe47/2b585405-d391-4986-b76d-b4f24685f3c8, L=aoxk2addh.accounts400.ondemand.com, OU=8e1affb2-62a1-43cc-a687-2ba75e4b3d84, OU=Canary, OU=SAP Cloud Platform Clients, O=SAP SE, C=DE");

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>com.sap.cloud.security.xsuaa</groupId>
 	<artifactId>parent</artifactId>
-	<version>4.0.7</version>
+	<version>4.0.8</version>
 	<packaging>pom</packaging>
 
 	<name>parent</name>

--- a/spring-security-3-starter/pom.xml
+++ b/spring-security-3-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.0.7</version>
+		<version>4.0.8</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/spring-security-3/README.md
+++ b/spring-security-3/README.md
@@ -23,7 +23,7 @@ Use the Spring Boot 3.x starter instead:
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-3-starter</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 ```
 

--- a/spring-security-3/pom.xml
+++ b/spring-security-3/pom.xml
@@ -9,14 +9,14 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.0.7</version>
+		<version>4.0.8</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>
 	<artifactId>spring-security-3</artifactId>
 	<name>spring-security-3</name>
 	<packaging>jar</packaging>
-	<version>4.0.7</version>
+	<version>4.0.8</version>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring security library for Spring Boot 3</description>

--- a/spring-security-starter/pom.xml
+++ b/spring-security-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.0.7</version>
+		<version>4.0.8</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/spring-security/README.md
+++ b/spring-security/README.md
@@ -69,7 +69,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 ```
 

--- a/spring-security/pom.xml
+++ b/spring-security/pom.xml
@@ -9,14 +9,14 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.0.7</version>
+		<version>4.0.8</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>
 	<artifactId>spring-security</artifactId>
 	<name>spring-security</name>
 	<packaging>jar</packaging>
-	<version>4.0.7</version>
+	<version>4.0.8</version>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring security library</description>

--- a/token-client-spring-3/README.md
+++ b/token-client-spring-3/README.md
@@ -25,7 +25,7 @@ This module is the Spring Boot 3.x compatible version of [token-client-spring](.
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-spring-3</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 ```
 

--- a/token-client-spring-3/pom.xml
+++ b/token-client-spring-3/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.0.7</version>
+		<version>4.0.8</version>
 	</parent>
 
 	<artifactId>token-client-spring-3</artifactId>

--- a/token-client-spring/README.md
+++ b/token-client-spring/README.md
@@ -27,7 +27,7 @@ Starting with version 4.0.0, Spring-specific implementations have been moved to 
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-spring</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 ```
 
@@ -65,7 +65,7 @@ If you were using `XsuaaOAuth2TokenService`, `SpringOAuth2TokenKeyService`, or `
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-spring</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 ```
 

--- a/token-client-spring/pom.xml
+++ b/token-client-spring/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.0.7</version>
+		<version>4.0.8</version>
 	</parent>
 
 	<artifactId>token-client-spring</artifactId>

--- a/token-client/README.md
+++ b/token-client/README.md
@@ -33,7 +33,7 @@ Additionally, it offers an API with the [XsuaaTokenFlows](./src/main/java/com/sa
    <dependency>
        <groupId>com.sap.cloud.security.xsuaa</groupId>
        <artifactId>token-client-spring</artifactId>
-       <version>4.0.7</version>
+       <version>4.0.8</version>
    </dependency>
    ```
 
@@ -72,7 +72,7 @@ In context of a Spring Boot application you can leverage autoconfiguration provi
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 ```
 In context of Spring Applications you will need the following dependencies:
@@ -80,7 +80,7 @@ In context of Spring Applications you will need the following dependencies:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 <!-- No additional HTTP client dependency needed - Java 11 HttpClient is used by default -->
 <!-- Apache HttpClient 4 is included transitively for backward compatibility (deprecated constructors) -->
@@ -181,7 +181,7 @@ See the [OAuth2ServiceConfiguration](#oauth2serviceconfiguration) section and [H
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>4.0.7</version>
+    <version>4.0.8</version>
 </dependency>
 ```
 

--- a/token-client/pom.xml
+++ b/token-client/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.0.7</version>
+		<version>4.0.8</version>
 	</parent>
 
 	<artifactId>token-client</artifactId>

--- a/token-client/src/main/java/com/sap/cloud/security/client/JavaHttpClientAdapter.java
+++ b/token-client/src/main/java/com/sap/cloud/security/client/JavaHttpClientAdapter.java
@@ -37,7 +37,13 @@ class JavaHttpClientAdapter implements SecurityHttpClient {
 					.timeout(Duration.ofSeconds(socketTimeoutSeconds));
 
 			// Add headers
-			request.getHeaders().forEach(builder::header);
+			request.getHeaders().forEach((name, value) -> {
+				if (value != null && (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0)) {
+					throw new IllegalArgumentException(
+							"Header value for '" + name + "' contains illegal CR/LF characters.");
+				}
+				builder.header(name, value);
+			});
 
 			// Set method and body
 			if (request.getBody() != null && request.getBody().length > 0) {

--- a/token-client/src/test/java/com/sap/cloud/security/client/JavaHttpClientAdapterTest.java
+++ b/token-client/src/test/java/com/sap/cloud/security/client/JavaHttpClientAdapterTest.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: 2018-2023 SAP SE or an SAP affiliate company and Cloud Security Client Java contributors
+ * <p>
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.sap.cloud.security.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JavaHttpClientAdapterTest {
+
+	private final JavaHttpClientAdapter cut = new JavaHttpClientAdapter(HttpClient.newHttpClient(), 30);
+
+	@Test
+	void execute_rejectsHeaderValueWithLineFeed() {
+		SecurityHttpRequest request = SecurityHttpRequest.newBuilder()
+				.uri(URI.create("https://example.com/jwks"))
+				.header("x-client_cert", "abc\ndef")
+				.build();
+
+		assertThatThrownBy(() -> cut.execute(request))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("x-client_cert")
+				.hasMessageContaining("CR/LF");
+	}
+
+	@Test
+	void execute_rejectsHeaderValueWithCarriageReturn() {
+		SecurityHttpRequest request = SecurityHttpRequest.newBuilder()
+				.uri(URI.create("https://example.com/jwks"))
+				.header("x-client_cert", "abc\rdef")
+				.build();
+
+		assertThatThrownBy(() -> cut.execute(request))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("x-client_cert");
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a regression introduced in 4.0.0 that breaks IAS proof-token validation in Kyma/Istio environments with `credential-type: X509_GENERATED`.

- `SapIdJwtSignatureValidator` was setting the `x-client_cert` request header directly from `X509Certificate#getPEM()`. When the certificate originates from Istio's `x-forwarded-client-cert` (XFCC) header, the PEM includes `-----BEGIN CERTIFICATE-----` / `-----END CERTIFICATE-----` delimiters and CR/LF line breaks.
- Since 4.0.0, the token-client HTTP transport uses Java 11's `HttpClient` (`JavaHttpClientAdapter`), which enforces RFC 7230 and rejects any header value containing CR/LF with `IllegalArgumentException` (surfaced as `"Token signature can not be validated because: invalid header value: <PEM>"`).
- Result: every authenticated request behind Istio failed proof-token validation.

## Fix

- New `X509Certificate#getPEMHeaderValue()` accessor that returns bare base64-encoded DER (PEM delimiters and all whitespace stripped). The IAS JWKS endpoint accepts this form. `getPEM()`'s existing contract is unchanged so other callers aren't affected.
- `SapIdJwtSignatureValidator` now uses `getPEMHeaderValue()` when populating the `x-client_cert` header.
- Defensive check in `JavaHttpClientAdapter`: any header value containing CR or LF fails fast with a clear message naming the offending header key (not the value, which may be sensitive), so future regressions surface as an actionable transport-layer error instead of a misleading `"invalid header value: <full PEM dumped>"`.

## Release

Prepares 4.0.8:
- Version bumped 4.0.7 → 4.0.8 across all modules, READMEs and samples.
- CHANGELOG updated. Dependency updates and the `junit-bom` import fix that were previously staged for 4.1.0 are now part of 4.0.8.

## Test plan

- [x] `mvn -pl java-security,token-client test` — 327 tests, 0 failures, 0 errors, 2 skipped (pre-existing), BUILD SUCCESS
- [x] `X509CertificateTest`: new tests for multi-line PEM and XFCC-wrapped URL-encoded PEM inputs
- [x] `SapIdJwtSignatureValidatorTest`: new test feeding a multi-line PEM cert through the proof-token path, asserting the captured `x-client_cert` header contains no `-----BEGIN`, whitespace, `\n`, or `\r`
- [x] `JavaHttpClientAdapterTest`: new file with tests for `\n` and `\r` rejection with clear error message
- [ ] Manual verification behind Istio in Kyma with `credential-type: X509_GENERATED`