### PR TITLE
fix: Skip IAS proof-token validation for tokens with <=1 audience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 - Skip IAS proof-token validation for tokens with a single audience or no audience claim
   - `SapIdJwtSignatureValidator` previously gated the proof-token / forwarded-client-cert check on the presence of the `ias_apis` claim. It now gates on `token.getAudiences().size() > 1`, so the check only runs for genuine app-to-app tokens (multiple audiences) and is skipped for app-to-service tokens (single audience) and tokens with a missing/empty `aud` claim
-  - Matches the behavior implemented in the `@sap/xssec` Node.js library and eliminates spurious "client certificate could not be read" failures on requests where no `x-forwarded-client-cert` header is expected
+  - Eliminates spurious "client certificate could not be read" failures on requests where no `x-forwarded-client-cert` header is expected
 - Expose the `sap_id_type` claim on `SapIdToken`
   - New `SapIdToken#getIdType()` returning a typed `SapIdType` enum (`USER`, `APP`); resolves to `null` if the claim is absent or carries an unknown value
   - New `TokenClaims.SAP_ID_TYPE` constant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## 4.1.0
 
+- Skip IAS proof-token validation for tokens with a single audience or no audience claim
+  - `SapIdJwtSignatureValidator` previously gated the proof-token / forwarded-client-cert check on the presence of the `ias_apis` claim. It now gates on `token.getAudiences().size() > 1`, so the check only runs for genuine app-to-app tokens (multiple audiences) and is skipped for app-to-service tokens (single audience) and tokens with a missing/empty `aud` claim
+  - Matches the behavior implemented in the `@sap/xssec` Node.js library and eliminates spurious "client certificate could not be read" failures on requests where no `x-forwarded-client-cert` header is expected
 - Expose the `sap_id_type` claim on `SapIdToken`
   - New `SapIdToken#getIdType()` returning a typed `SapIdType` enum (`USER`, `APP`); resolves to `null` if the claim is absent or carries an unknown value
   - New `TokenClaims.SAP_ID_TYPE` constant

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidator.java
@@ -1,5 +1,8 @@
 package com.sap.cloud.security.token.validation.validators;
 
+import static com.sap.cloud.security.token.validation.validators.JsonWebKey.DEFAULT_KEY_ID;
+import static com.sap.cloud.security.token.validation.validators.JsonWebKeyConstants.KID_PARAMETER_NAME;
+
 import com.sap.cloud.security.config.OAuth2ServiceConfiguration;
 import com.sap.cloud.security.token.SecurityContext;
 import com.sap.cloud.security.token.Token;
@@ -10,7 +13,6 @@ import com.sap.cloud.security.xsuaa.client.DefaultOidcConfigurationService;
 import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
 import com.sap.cloud.security.xsuaa.client.OAuth2ServiceException;
 import com.sap.cloud.security.xsuaa.http.HttpHeaders;
-
 import jakarta.annotation.Nonnull;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
@@ -18,9 +20,6 @@ import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.HashMap;
 import java.util.Map;
-
-import static com.sap.cloud.security.token.validation.validators.JsonWebKey.DEFAULT_KEY_ID;
-import static com.sap.cloud.security.token.validation.validators.JsonWebKeyConstants.KID_PARAMETER_NAME;
 
 /**
  * Jwt Signature validator for OIDC tokens issued by Identity service. This validator MUST only be
@@ -51,6 +50,9 @@ class SapIdJwtSignatureValidator extends JwtSignatureValidator {
 	 * Enables ProofToken Validation check for forwarded client certificates. If the check is enabled and no forwarded
 	 * certificate in the request is available, the token will be evaluated as invalid.
 	 * With this check enabled, the forwarded certificate is added to the token keys request.
+	 * <p>
+	 * The check is gated on the token's audience count and only runs for tokens with more than one audience (app-to-app
+	 * scenarios). Tokens with a single audience or no audience claim skip the certificate requirement.
 	 */
 	protected void enableProofTokenValidationCheck() {
 		this.isProofTokenValidationEnabled = true;
@@ -71,7 +73,7 @@ class SapIdJwtSignatureValidator extends JwtSignatureValidator {
 		requestParams.put(HttpHeaders.X_APP_TID, token.getAppTid());
 		requestParams.put(HttpHeaders.X_CLIENT_ID, configuration.getClientId());
 		requestParams.put(HttpHeaders.X_AZP, token.getClaimAsString(TokenClaims.AUTHORIZATION_PARTY));
-		if (isProofTokenValidationEnabled && !token.hasClaim(TokenClaims.IAS_APIS)) {
+		if (isProofTokenValidationEnabled && token.getAudiences().size() > 1) {
 			X509Certificate cert = (X509Certificate) SecurityContext.getClientCertificate();
 
 			if (cert == null) {

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidatorTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/SapIdJwtSignatureValidatorTest.java
@@ -239,6 +239,39 @@ public class SapIdJwtSignatureValidatorTest {
 	}
 
 	@Test
+	public void validationSucceeds_withEnabledProofTokenCheck_singleAudience_noCert() {
+		// Single-audience token (aud = "T000310") skips the cert requirement even when the check is enabled.
+		Token singleAudienceToken = new SapIdToken(
+				"eyJraWQiOiJkZWZhdWx0LWtpZC1pYXMiLCJhbGciOiJSUzI1NiJ9.eyJleHAiOjY5NzQwMzE2MDAsImF6cCI6IlQwMDAzMTAiLCJjaWQiOiJUMDAwMzEwIiwiYXVkIjoiVDAwMDMxMCIsInpvbmVfdXVpZCI6InRoZS16b25lLWlkIiwiYXBwX3RpZCI6InRoZS1hcHAtdGlkIiwidXNlcl91dWlkIjoiMTIzNDU2Nzg5MCIsInNjaW1faWQiOiJzY2ltLTEyMzQ1Njc4OTAiLCJzdWIiOiJQMTc2OTQ1IiwiaXNzIjoiaHR0cHM6Ly9hcHBsaWNhdGlvbi5teWF1dGguY29tIiwiZ2l2ZW5fbmFtZSI6ImpvaG4iLCJmYW1pbHlfbmFtZSI6ImRvZSIsImVtYWlsIjoiam9obi5kb2VAZW1haWwub3JnIiwiaWFzX2FwaXMiOiJpYXNfYXBpcyJ9.XScl2bUr12mDNmVJahYIHEr7rlfaBFoyjR4UTJvOuEKXIQIgf58hRqbDNoKNM2pRiue8FvlD4TuI1OQ9r4wQgJ86sa0YIly7YfOhX6XQoDUXCcFVU_MsYTZJo2LMmOziD5EHt9wakRhWN3FqDM7KG4j_-HOhj3k0I72gFt83BToQHcMsW26eDQ7qfeeiNFsuUWzX8U-hZzCdOsl6EGYw2VU9kedEACH7xsOmfDdfLEPHu1HmjRmywdE118z4fPXpIvSN47V4VeXU8jZptRgxz1TDLT2w_zb4IPJInacadMVLNIVcrWqplQKTiS7nUCzCk2_aSKnBjerO5ugoERS9HA");
+		assertThat(singleAudienceToken.getAudiences()).hasSize(1);
+
+		SapIdJwtSignatureValidator cut = new SapIdJwtSignatureValidator(
+				mockConfiguration,
+				OAuth2TokenKeyServiceWithCache.getInstance()
+						.withTokenKeyService(tokenKeyServiceMock),
+				OidcConfigurationServiceWithCache.getInstance()
+						.withOidcConfigurationService(oidcConfigServiceMock));
+		cut.enableProofTokenValidationCheck();
+		assertTrue(cut.validate(singleAudienceToken).isValid());
+	}
+
+	@Test
+	public void validationSucceeds_withEnabledProofTokenCheck_emptyAudience_noCert() {
+		// Missing/empty aud → getAudiences().size() == 0 → skip the cert requirement.
+		Token tokenSpy = Mockito.spy(iasToken);
+		doReturn(java.util.Collections.emptySet()).when(tokenSpy).getAudiences();
+
+		SapIdJwtSignatureValidator cut = new SapIdJwtSignatureValidator(
+				mockConfiguration,
+				OAuth2TokenKeyServiceWithCache.getInstance()
+						.withTokenKeyService(tokenKeyServiceMock),
+				OidcConfigurationServiceWithCache.getInstance()
+						.withOidcConfigurationService(oidcConfigServiceMock));
+		cut.enableProofTokenValidationCheck();
+		assertTrue(cut.validate(tokenSpy).isValid());
+	}
+
+	@Test
 	public void validationFails_WhenZoneIdIsNull_ButIssuerMatchesOAuth2Url() {
 		when(mockConfiguration.getUrl()).thenReturn(URI.create("https://application.myauth.com"));
 		ValidationResult validationResult = cut.validate(iasPaasToken);


### PR DESCRIPTION
## Summary
- `SapIdJwtSignatureValidator` previously gated the proof-token / forwarded-client-cert check on the presence of the `ias_apis` claim. It now gates on `token.getAudiences().size() > 1`, so the check only runs for genuine app-to-app tokens (multiple audiences) and is skipped for app-to-service tokens (single audience) and tokens with a missing/empty `aud` claim.
- Matches the behavior implemented in the `@sap/xssec` Node.js library (see [node-xs2sec#418](https://github.wdf.sap.corp/CPSecurity/node-xs2sec/pull/418/files)) and eliminates spurious "client certificate could not be read" failures on requests where no `x-forwarded-client-cert` header is expected.

## Changes
- `SapIdJwtSignatureValidator`: swap the `ias_apis`-claim gate for an audience-count gate (`> 1`).
- Javadoc on `enableProofTokenValidationCheck()` documents the new gating.
- Two new tests in `SapIdJwtSignatureValidatorTest` lock in the skip behavior:
  - `validationSucceeds_withEnabledProofTokenCheck_singleAudience_noCert`
  - `validationSucceeds_withEnabledProofTokenCheck_emptyAudience_noCert`
- `CHANGELOG.md` entry under 4.1.0.

## Test plan
- [x] `mvn test -Dtest=SapIdJwtSignatureValidatorTest` — 19/19 passing locally
- [ ] CI passes
- [ ] Reviewer confirms alignment with node-xs2sec behavior