### PR TITLE
Fix: Tolerate unsupported / malformed JWK entries in JWKS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
   - New `SapIdToken#getIdType()` returning a typed `SapIdType` enum (`USER`, `APP`); resolves to `null` if the claim is absent or carries an unknown value
   - New `TokenClaims.SAP_ID_TYPE` constant
   - `DefaultIdTokenExtension#isTechnicalUser` now prefers the `sap_id_type` claim and falls back to the `sub == azp` heuristic for tokens issued before the claim was introduced
+- Tolerate unsupported or malformed entries in a JWKS response
+  - `JsonWebKeySetFactory` previously aborted the whole parse when a single entry resolved to an algorithm the library does not recognise (or was otherwise malformed), so an IdP adding a key for a new algorithm family broke token validation for every tenant sharing the endpoint — including tokens signed with algorithms this library DOES support
+  - Each entry is now parsed in isolation: unsupported alg/kty is skipped with an INFO log, a malformed entry is skipped with a WARN, and both carry sanitized `kid`/`kty`/`alg` for diagnostics
+  - When a caller later requests a `kid` that was silently dropped at parse time, the pre-throw WARN in `OAuth2TokenKeyServiceWithCache` now points at the earlier `Skipping JWK entry` log lines so the root cause is discoverable. The existing `Key with kid <kid> not found in JWKS.` exception message is unchanged for downstream log-based alerts
 
 ## 4.0.8
 

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
@@ -5,10 +5,16 @@
  */
 package com.sap.cloud.security.token.validation.validators;
 
+import com.sap.cloud.security.util.LogSanitizer;
+import jakarta.annotation.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class JsonWebKeySetFactory {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(JsonWebKeySetFactory.class);
 
 	private JsonWebKeySetFactory() {
 	}
@@ -20,13 +26,37 @@ class JsonWebKeySetFactory {
 
 			for (Object key : keys) {
 				if (key instanceof JSONObject) {
-					keySet.put(createJsonWebKey((JSONObject) key));
+					JsonWebKey jwk = tryCreateJsonWebKey((JSONObject) key);
+					if (jwk != null) {
+						keySet.put(jwk);
+					}
 				}
 			}
 		}
 		return keySet;
 	}
 
+	/**
+	 * Wraps {@link #createJsonWebKey(JSONObject)} so that one bad JWK entry does not tear down the
+	 * whole JWKS. Identity providers may publish keys for algorithms this library does not (yet)
+	 * support (new EC curves, EdDSA, …); dropping the entire key set would break token validation
+	 * for tokens signed with algorithms we DO support that happen to share the same JWKS endpoint.
+	 */
+	@Nullable
+	private static JsonWebKey tryCreateJsonWebKey(JSONObject key) {
+		try {
+			return createJsonWebKey(key);
+		} catch (RuntimeException e) {
+			LOGGER.warn("Skipping unusable JWK entry (kid={}, kty={}, alg={}) in JWKS: {}",
+					LogSanitizer.sanitize(key.optString(JsonWebKeyConstants.KID_PARAMETER_NAME, "<none>")),
+					LogSanitizer.sanitize(key.optString(JsonWebKeyConstants.KEY_TYPE_PARAMETER_NAME, "<none>")),
+					LogSanitizer.sanitize(key.optString(JsonWebKeyConstants.ALG_PARAMETER_NAME, "<none>")),
+					e.getMessage());
+			return null;
+		}
+	}
+
+	@Nullable
 	private static JsonWebKey createJsonWebKey(JSONObject key) {
 		String keyType = key.getString(JsonWebKeyConstants.KEY_TYPE_PARAMETER_NAME);
 		String keyAlgorithmName = optionalString(key, JsonWebKeyConstants.ALG_PARAMETER_NAME);
@@ -35,6 +65,16 @@ class JsonWebKeySetFactory {
 		JwtSignatureAlgorithm algorithm = keyAlgorithmName != null
 				? JwtSignatureAlgorithm.fromValue(keyAlgorithmName)
 				: JwtSignatureAlgorithm.fromType(keyType);
+
+		if (algorithm == null) {
+			// Neither the JWA "alg" value nor the JWK "kty" mapped to a signature algorithm this library
+			// supports. Skip so tokens signed with a key we DO support elsewhere in the JWKS still validate.
+			LOGGER.info("Ignoring JWK entry with unsupported algorithm (kid={}, kty={}, alg={}).",
+					LogSanitizer.sanitize(keyId != null ? keyId : "<none>"),
+					LogSanitizer.sanitize(keyType),
+					LogSanitizer.sanitize(keyAlgorithmName != null ? keyAlgorithmName : "<none>"));
+			return null;
+		}
 
 		return new JsonWebKeyImpl(algorithm, keyId, extractKeyMaterial(key));
 	}

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
@@ -39,8 +39,8 @@ class JsonWebKeySetFactory {
 	/**
 	 * Wraps {@link #createJsonWebKey(JSONObject)} so that one bad JWK entry does not tear down the
 	 * whole JWKS. Identity providers may publish keys for algorithms this library does not (yet)
-	 * support (new EC curves, EdDSA, …); dropping the entire key set would break token validation
-	 * for tokens signed with algorithms we DO support that happen to share the same JWKS endpoint.
+	 * support (e.g. EdDSA); dropping the entire key set would break token validation for tokens
+	 * signed with algorithms we DO support that happen to share the same JWKS endpoint.
 	 */
 	@Nullable
 	private static JsonWebKey tryCreateJsonWebKey(JSONObject key) {
@@ -67,9 +67,9 @@ class JsonWebKeySetFactory {
 				: JwtSignatureAlgorithm.fromType(keyType);
 
 		if (algorithm == null) {
-			// Neither the JWA "alg" value (e.g. "ES256") nor the JWK "kty" (e.g. "EC") mapped to a signature algorithm
-			// we support. Skip this JWK instead of failing the whole set — the JWKS may still contain other keys we
-			// can validate with.
+			// The JWA "alg" value (or the JWK "kty" when no "alg" is present) did not map to a signature
+			// algorithm this library supports — e.g. an EdDSA/OKP key on a shared JWKS endpoint. Skip this
+			// JWK instead of failing the whole set — other keys in the JWKS may still be usable.
 			LOGGER.info("Skipping JWK entry with unsupported algorithm (kid={}, kty={}, alg={}) in JWKS.",
 					LogSanitizer.sanitize(keyId != null ? keyId : "<none>"),
 					LogSanitizer.sanitize(keyType),

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
@@ -47,7 +47,7 @@ class JsonWebKeySetFactory {
 		try {
 			return createJsonWebKey(key);
 		} catch (RuntimeException e) {
-			LOGGER.warn("Skipping unusable JWK entry (kid={}, kty={}, alg={}) in JWKS: {}",
+			LOGGER.warn("Skipping JWK entry that could not be parsed (kid={}, kty={}, alg={}) in JWKS: {}",
 					LogSanitizer.sanitize(key.optString(JsonWebKeyConstants.KID_PARAMETER_NAME, "<none>")),
 					LogSanitizer.sanitize(key.optString(JsonWebKeyConstants.KEY_TYPE_PARAMETER_NAME, "<none>")),
 					LogSanitizer.sanitize(key.optString(JsonWebKeyConstants.ALG_PARAMETER_NAME, "<none>")),
@@ -67,9 +67,10 @@ class JsonWebKeySetFactory {
 				: JwtSignatureAlgorithm.fromType(keyType);
 
 		if (algorithm == null) {
-			// Neither the JWA "alg" value nor the JWK "kty" mapped to a signature algorithm this library
-			// supports. Skip so tokens signed with a key we DO support elsewhere in the JWKS still validate.
-			LOGGER.info("Ignoring JWK entry with unsupported algorithm (kid={}, kty={}, alg={}).",
+			// Neither the JWA "alg" value (e.g. "ES256") nor the JWK "kty" (e.g. "EC") mapped to a signature algorithm
+			// we support. Skip this JWK instead of failing the whole set — the JWKS may still contain other keys we
+			// can validate with.
+			LOGGER.info("Skipping JWK entry with unsupported algorithm (kid={}, kty={}, alg={}) in JWKS.",
 					LogSanitizer.sanitize(keyId != null ? keyId : "<none>"),
 					LogSanitizer.sanitize(keyType),
 					LogSanitizer.sanitize(keyAlgorithmName != null ? keyAlgorithmName : "<none>"));

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
@@ -168,6 +168,9 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 		}
 
 		if (jwks.getAll().isEmpty()) {
+			// Note: an empty JWKS can also occur when the JWKS response was non-empty but ALL entries were
+			// dropped by JsonWebKeySetFactory (unsupported alg/kty, malformed entry). See earlier
+			// 'Skipping JWK entry' log lines for details.
 			LOGGER.error("Retrieved no token keys from {} for the given header parameters.", LogSanitizer.sanitize(keyParameters.keyUri));
 			return null;
 		}
@@ -178,7 +181,15 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 			}
 		}
 
-		LOGGER.warn("No matching key found. Cached keys: {}", jwks);
+		// The exception below may also occur when the JWKS originally contained a matching key, but that
+		// entry was silently dropped by JsonWebKeySetFactory because its algorithm is not supported by
+		// this library (e.g. EC/EdDSA), or because the entry was malformed. In that case the dropped
+		// key does NOT appear in `jwks` below — see earlier 'Skipping JWK entry' log lines from
+		// JsonWebKeySetFactory for details.
+		LOGGER.warn("No matching key with kid '{}' and algorithm '{}' found. Cached keys: {}."
+				+ " Note: JWKS entries with algorithms not supported by this library, or malformed entries,"
+				+ " are dropped at parse time — see earlier 'Skipping JWK entry' log lines for details.",
+				LogSanitizer.sanitize(keyParameters.keyId), keyParameters.keyAlgorithm, jwks);
 		throw new IllegalArgumentException("Key with kid " + keyParameters.keyId + " not found in JWKS.");
 	}
 

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
@@ -189,7 +189,8 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 		LOGGER.warn("No matching key with kid '{}' and algorithm '{}' found. Cached keys: {}."
 				+ " Note: JWKS entries with algorithms not supported by this library, or malformed entries,"
 				+ " are dropped at parse time — see earlier 'Skipping JWK entry' log lines for details.",
-				LogSanitizer.sanitize(keyParameters.keyId), keyParameters.keyAlgorithm, jwks);
+				LogSanitizer.sanitize(keyParameters.keyId), LogSanitizer.sanitize(keyParameters.keyAlgorithm),
+				LogSanitizer.sanitize(jwks));
 		throw new IllegalArgumentException("Key with kid " + keyParameters.keyId + " not found in JWKS.");
 	}
 

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
@@ -183,8 +183,8 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 
 		// The exception below may also occur when the JWKS originally contained a matching key, but that
 		// entry was silently dropped by JsonWebKeySetFactory because its algorithm is not supported by
-		// this library (e.g. EC/EdDSA), or because the entry was malformed. In that case the dropped
-		// key does NOT appear in `jwks` below — see earlier 'Skipping JWK entry' log lines from
+		// this library (e.g. EdDSA), or because the entry was malformed. In that case the dropped key
+		// does NOT appear in `jwks` below — see earlier 'Skipping JWK entry' log lines from
 		// JsonWebKeySetFactory for details.
 		LOGGER.warn("No matching key with kid '{}' and algorithm '{}' found. Cached keys: {}."
 				+ " Note: JWKS entries with algorithms not supported by this library, or malformed entries,"

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactoryTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactoryTest.java
@@ -203,4 +203,60 @@ public class JsonWebKeySetFactoryTest {
 	private static String base64Url(byte[] bytes) {
 		return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
 	}
+
+	// A syntactically valid RSA JWK reused in the tolerance tests below to prove that valid entries
+	// survive alongside entries the library cannot use.
+	private static final String RSA_ENTRY = "{"
+			+ "\"kty\":\"RSA\","
+			+ "\"alg\":\"RS256\","
+			+ "\"kid\":\"rsa-key\","
+			+ "\"e\":\"AQAB\","
+			+ "\"n\":\"AJjTNzl32UtFLvHmGVwoBlhYFVkF-jB52nWJN8x2eTyD3g2NwKWkhqTBIlcJ9XE-ilFRzCx3Js9YLDcu"
+			+ "-KQp5gmttluydwaGbpc0dAN-2sjFa0R4d5334MkpPLufNZdNm723KWm93txKLUjeS4sRk9VVmbw22pV3-p-ZKuOfTVi"
+			+ "-mc5BLNtDKzhJOXC3Z7IoE0FB0iiEOU6ZXcg5CTJts8DpawdkffOPkHZQxZqFR-2Gro8a9oNGferu1vSJopOsE4hXPFu"
+			+ "3lF34Txp-63lS6tf-aNjc9CcdHoxRw8Exp3LPpNUQUug26UzjK_bZCRHN2bF9xbeDragpEVyOYVJmvh8\""
+			+ "}";
+
+	@Test
+	public void skipsJwksEntryWithUnsupportedAlgValue() {
+		// "EdDSA" is not part of the supported set. The unusable entry must be silently dropped so
+		// the RSA key alongside it remains validatable.
+		String jwks = "{\"keys\":["
+				+ "{\"kty\":\"OKP\",\"alg\":\"EdDSA\",\"kid\":\"ed-key\",\"crv\":\"Ed25519\",\"x\":\"foo\"},"
+				+ RSA_ENTRY
+				+ "]}";
+
+		JsonWebKeySet result = JsonWebKeySetFactory.createFromJson(jwks);
+
+		assertThat(result.getAll()).hasSize(1);
+		assertThat(result.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.RS256, "rsa-key")).isNotNull();
+	}
+
+	@Test
+	public void skipsJwksEntryWithUnsupportedKty() {
+		// No "alg" present; kty "OKP" (EdDSA family) does not resolve to any supported signature algorithm.
+		String jwks = "{\"keys\":["
+				+ "{\"kty\":\"OKP\",\"kid\":\"ed-key\",\"crv\":\"Ed25519\",\"x\":\"foo\"},"
+				+ RSA_ENTRY
+				+ "]}";
+
+		JsonWebKeySet result = JsonWebKeySetFactory.createFromJson(jwks);
+
+		assertThat(result.getAll()).hasSize(1);
+		assertThat(result.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.RS256, "rsa-key")).isNotNull();
+	}
+
+	@Test
+	public void skipsJwksEntryWithMissingKty() {
+		// Entirely malformed entry (missing mandatory "kty") must not tear down the whole set.
+		String jwks = "{\"keys\":["
+				+ "{\"kid\":\"broken\"},"
+				+ RSA_ENTRY
+				+ "]}";
+
+		JsonWebKeySet result = JsonWebKeySetFactory.createFromJson(jwks);
+
+		assertThat(result.getAll()).hasSize(1);
+		assertThat(result.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.RS256, "rsa-key")).isNotNull();
+	}
 }


### PR DESCRIPTION
### Problem
If a JWKS response contains a key whose alg/kty does not resolve to a
known JwtSignatureAlgorithm, JsonWebKeySetFactory throws
IllegalArgumentException("keyAlgorithm must be not null") out of the
parse loop and drops the entire JWKS. Tokens signed with algorithms
the library does support then also fail to validate.

### Changes
Parse each JWK entry in its own try/catch; a bad entry only drops itself.
Unsupported alg/kty: skip explicitly with an INFO log (kid/kty/alg
sanitized).
New tests in JsonWebKeySetFactoryTest for unsupported alg,
unsupported kty, and missing kty.
### Compatibility
No public API changes.
User-facing exception messages unchanged.
Only log wording changes.
### Testing
Full validators test suite green (168 tests, 3 new).