### PR TITLE
Fix: Tolerate unsupported / malformed JWK entries in JWKS (3.x backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## 3.7.5
+
+- Tolerate unsupported or malformed entries in a JWKS response
+  - `JsonWebKeySetFactory` previously aborted the whole parse when a single entry resolved to an algorithm the library does not recognise (or was otherwise malformed), so an IdP adding a key for a new algorithm family broke token validation for every tenant sharing the endpoint — including tokens signed with algorithms this library DOES support
+  - Each entry is now parsed in isolation: unsupported alg/kty is skipped with an INFO log, a malformed entry is skipped with a WARN, and both carry the `kid`/`kty`/`alg` for diagnostics
+  - When a caller later requests a `kid` that was silently dropped at parse time, the pre-throw WARN in `OAuth2TokenKeyServiceWithCache` now points at the earlier `Skipping JWK entry` log lines so the root cause is discoverable. The existing `Key with kid <kid> not found in JWKS.` exception message is unchanged for downstream log-based alerts
+
 ## 3.7.4
 
 - Fix mTLS handshake regression introduced in 3.6.7 (`SSLContextFactory`)

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The SAP Cloud Security Services Integration is published to maven central: https
         <dependency>
             <groupId>com.sap.cloud.security</groupId>
             <artifactId>java-bom</artifactId>
-            <version>3.7.4</version>
+            <version>3.7.5</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-bom</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
     <packaging>pom</packaging>
     <name>java-bom</name>
 

--- a/env/pom.xml
+++ b/env/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>3.7.4</version>
+        <version>3.7.5</version>
     </parent>
 
     <groupId>com.sap.cloud.security</groupId>

--- a/java-api/README.md
+++ b/java-api/README.md
@@ -5,6 +5,6 @@
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-api</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 ```

--- a/java-api/pom.xml
+++ b/java-api/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security-it/pom.xml
+++ b/java-security-it/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
-        <version>3.7.4</version>
+        <version>3.7.5</version>
     </parent>
 
     <artifactId>java-security-it</artifactId>

--- a/java-security-test/README.md
+++ b/java-security-test/README.md
@@ -40,7 +40,7 @@ It is pre-configured with a security filter that only accepts valid tokens. Furt
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
    <artifactId>java-security-test</artifactId>
-      <version>3.7.4</version>
+      <version>3.7.5</version>
    <scope>test</scope>
 </dependency>
 ```

--- a/java-security-test/pom.xml
+++ b/java-security-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/README.md
+++ b/java-security/README.md
@@ -69,7 +69,7 @@ Since it requires the Tomcat 10 runtime, it needs to be deployed using the [SAP 
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>java-security</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/java-security/pom.xml
+++ b/java-security/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactory.java
@@ -7,8 +7,14 @@ package com.sap.cloud.security.token.validation.validators;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 class JsonWebKeySetFactory {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(JsonWebKeySetFactory.class);
 
 	private JsonWebKeySetFactory() {
 	}
@@ -20,13 +26,37 @@ class JsonWebKeySetFactory {
 
 			for (Object key : keys) {
 				if (key instanceof JSONObject) {
-					keySet.put(createJsonWebKey((JSONObject) key));
+					JsonWebKey jwk = tryCreateJsonWebKey((JSONObject) key);
+					if (jwk != null) {
+						keySet.put(jwk);
+					}
 				}
 			}
 		}
 		return keySet;
 	}
 
+	/**
+	 * Wraps {@link #createJsonWebKey(JSONObject)} so that a single malformed or unsupported entry does not tear down
+	 * the whole JWKS. This is important because identity providers may add keys for algorithms we do not (yet)
+	 * support (e.g. new EC curves, EdDSA, ...); dropping the full key set would break token validation for all
+	 * tenants that share this JWKS endpoint, including tokens signed with algorithms we DO support.
+	 */
+	@Nullable
+	private static JsonWebKey tryCreateJsonWebKey(JSONObject key) {
+		try {
+			return createJsonWebKey(key);
+		} catch (RuntimeException e) {
+			LOGGER.warn("Skipping JWK entry that could not be parsed (kid={}, kty={}, alg={}) in JWKS: {}",
+					key.optString(JsonWebKeyConstants.KID_PARAMETER_NAME, "<none>"),
+					key.optString(JsonWebKeyConstants.KEY_TYPE_PARAMETER_NAME, "<none>"),
+					key.optString(JsonWebKeyConstants.ALG_PARAMETER_NAME, "<none>"),
+					e.getMessage());
+			return null;
+		}
+	}
+
+	@Nullable
 	private static JsonWebKey createJsonWebKey(JSONObject key) {
 		String keyAlgorithm = null;
 		String pemEncodedPublicKey = null;
@@ -52,6 +82,17 @@ class JsonWebKeySetFactory {
 		}
 		JwtSignatureAlgorithm algorithm = keyAlgorithm != null ? JwtSignatureAlgorithm.fromValue(keyAlgorithm)
 				: JwtSignatureAlgorithm.fromType(keyType);
+
+		if (algorithm == null) {
+			// Neither the JWA "alg" value (e.g. "ES256") nor the JWK "kty" (e.g. "EC") mapped to a signature algorithm
+			// we support. Skip this JWK instead of failing the whole set — the JWKS may still contain other keys we
+			// can validate with.
+			LOGGER.info("Skipping JWK entry with unsupported algorithm (kid={}, kty={}, alg={}) in JWKS.",
+					keyId != null ? keyId : "<none>",
+					keyType,
+					keyAlgorithm != null ? keyAlgorithm : "<none>");
+			return null;
+		}
 
 		return new JsonWebKeyImpl(algorithm, keyId, modulus, publicExponent,
 				pemEncodedPublicKey);

--- a/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
+++ b/java-security/src/main/java/com/sap/cloud/security/token/validation/validators/OAuth2TokenKeyServiceWithCache.java
@@ -167,6 +167,9 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 		}
 
 		if (jwks.getAll().isEmpty()) {
+			// Note: an empty JWKS can also occur when the JWKS response was non-empty but ALL entries were
+			// dropped by JsonWebKeySetFactory (unsupported alg/kty, malformed entry). See earlier
+			// 'Skipping JWK entry' log lines for details.
 			LOGGER.error("Retrieved no token keys from {} for the given header parameters.", keyParameters.keyUri);
 			return null;
 		}
@@ -177,7 +180,15 @@ class OAuth2TokenKeyServiceWithCache implements Cacheable {
 			}
 		}
 
-		LOGGER.warn("No matching key found. Cached keys: {}", jwks);
+		// The exception below may also occur when the JWKS originally contained a matching key, but that
+		// entry was silently dropped by JsonWebKeySetFactory because its algorithm is not supported by
+		// this library (e.g. EC/EdDSA), or because the entry was malformed. In that case the dropped
+		// key does NOT appear in `jwks` below — see earlier 'Skipping JWK entry' log lines from
+		// JsonWebKeySetFactory for details.
+		LOGGER.warn("No matching key found. Cached keys: {}."
+				+ " Note: JWKS entries with algorithms not supported by this library, or malformed entries,"
+				+ " are dropped at parse time — see earlier 'Skipping JWK entry' log lines for details.",
+				jwks);
 		throw new IllegalArgumentException("Key with kid " + keyParameters.keyId + " not found in JWKS.");
 	}
 

--- a/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactoryTest.java
+++ b/java-security/src/test/java/com/sap/cloud/security/token/validation/validators/JsonWebKeySetFactoryTest.java
@@ -16,9 +16,24 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 public class JsonWebKeySetFactoryTest {
+
+	// A syntactically valid RSA JWK (kty=RSA, alg=RS256, kid=rsa-key) that we reuse in the
+	// unsupported-algorithm tests to prove that valid entries survive alongside unusable ones.
+	private static final String RSA_ENTRY = "{"
+			+ "\"kty\":\"RSA\","
+			+ "\"alg\":\"RS256\","
+			+ "\"kid\":\"rsa-key\","
+			+ "\"e\":\"AQAB\","
+			+ "\"n\":\"AJjTNzl32UtFLvHmGVwoBlhYFVkF-jB52nWJN8x2eTyD3g2NwKWkhqTBIlcJ9XE-ilFRzCx3Js9YLDcu"
+			+ "-KQp5gmttluydwaGbpc0dAN-2sjFa0R4d5334MkpPLufNZdNm723KWm93txKLUjeS4sRk9VVmbw22pV3-p-ZKuOfTVi"
+			+ "-mc5BLNtDKzhJOXC3Z7IoE0FB0iiEOU6ZXcg5CTJts8DpawdkffOPkHZQxZqFR-2Gro8a9oNGferu1vSJopOsE4hXPFu"
+			+ "3lF34Txp-63lS6tf-aNjc9CcdHoxRw8Exp3LPpNUQUug26UzjK_bZCRHN2bF9xbeDragpEVyOYVJmvh8\""
+			+ "}";
 
 	private String jsonWebTokenKeys;
 
@@ -60,5 +75,48 @@ public class JsonWebKeySetFactoryTest {
 		assertThat(jwk.getKeyAlgorithm().type(), equalTo("RSA"));
 		assertThat(jwk.getPublicKey().getAlgorithm(), equalTo(jwk.getKeyAlgorithm().type()));
 		assertThat(jwk.getId(), equalTo(JsonWebKey.DEFAULT_KEY_ID));
+	}
+
+	@Test
+	public void skipsJwksEntryWithUnsupportedAlgValue() {
+		// alg "ES256" (and kty "EC") is currently not supported by JwtSignatureAlgorithm.
+		// The unusable entry must be silently dropped so RSA keys next to it remain validatable.
+		String jwks = "{\"keys\":["
+				+ "{\"kty\":\"EC\",\"alg\":\"ES256\",\"kid\":\"ec-key\",\"crv\":\"P-256\",\"x\":\"foo\",\"y\":\"bar\"},"
+				+ RSA_ENTRY
+				+ "]}";
+
+		JsonWebKeySet result = JsonWebKeySetFactory.createFromJson(jwks);
+
+		assertThat(result.getAll(), hasSize(1));
+		assertThat(result.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.RS256, "rsa-key"), notNullValue());
+	}
+
+	@Test
+	public void skipsJwksEntryWithUnsupportedKty() {
+		// No "alg" present, and kty "OKP" (EdDSA family) does not resolve to any supported signature algorithm.
+		String jwks = "{\"keys\":["
+				+ "{\"kty\":\"OKP\",\"kid\":\"ed-key\",\"crv\":\"Ed25519\",\"x\":\"foo\"},"
+				+ RSA_ENTRY
+				+ "]}";
+
+		JsonWebKeySet result = JsonWebKeySetFactory.createFromJson(jwks);
+
+		assertThat(result.getAll(), hasSize(1));
+		assertThat(result.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.RS256, "rsa-key"), notNullValue());
+	}
+
+	@Test
+	public void skipsJwksEntryWithMissingKty() {
+		// Entirely malformed entry (missing mandatory "kty") must not tear down the whole set.
+		String jwks = "{\"keys\":["
+				+ "{\"kid\":\"broken\"},"
+				+ RSA_ENTRY
+				+ "]}";
+
+		JsonWebKeySet result = JsonWebKeySetFactory.createFromJson(jwks);
+
+		assertThat(result.getAll(), hasSize(1));
+		assertThat(result.getKeyByAlgorithmAndId(JwtSignatureAlgorithm.RS256, "rsa-key"), notNullValue());
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>com.sap.cloud.security.xsuaa</groupId>
 	<artifactId>parent</artifactId>
-	<version>3.7.4</version>
+	<version>3.7.5</version>
 	<packaging>pom</packaging>
 
 	<name>parent</name>

--- a/samples/java-security-usage-ias/pom.xml
+++ b/samples/java-security-usage-ias/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage-ias</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
     <packaging>war</packaging>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/samples/java-security-usage/pom.xml
+++ b/samples/java-security-usage/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-security-usage</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
     <packaging>war</packaging>
 
     <!--profiles>

--- a/samples/java-tokenclient-usage/pom.xml
+++ b/samples/java-tokenclient-usage/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cloud.security.xssec.samples</groupId>
     <artifactId>java-tokenclient-usage</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
     <packaging>war</packaging>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/samples/sap-java-buildpack-api-usage/pom.xml
+++ b/samples/sap-java-buildpack-api-usage/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.sap.cloud.security.xssec.samples</groupId>
 	<artifactId>sap-java-buildpack-api-usage</artifactId>
-	<version>3.7.4</version>
+	<version>3.7.5</version>
 	<packaging>war</packaging>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/samples/spring-security-basic-auth/pom.xml
+++ b/samples/spring-security-basic-auth/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 
 	<artifactId>spring-security-basic-auth</artifactId>
-	<version>3.7.4</version>
+	<version>3.7.5</version>
 	<name>spring-security-basic-auth</name>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>com.sap.cloud.security</groupId>
 			<artifactId>java-security-test</artifactId>
-			<version>3.7.4</version>
+			<version>3.7.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/samples/spring-security-hybrid-usage/pom.xml
+++ b/samples/spring-security-hybrid-usage/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-hybrid-usage</artifactId>
-	<version>3.7.4</version>
+	<version>3.7.5</version>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring security hybrid usage sample</description>

--- a/samples/spring-security-xsuaa-usage/pom.xml
+++ b/samples/spring-security-xsuaa-usage/pom.xml
@@ -16,7 +16,7 @@
 
 	<groupId>com.sap.cloud.security.samples</groupId>
 	<artifactId>spring-security-xsuaa-usage</artifactId>
-	<version>3.7.4</version>
+	<version>3.7.5</version>
 	<name>spring-security-xsuaa-usage</name>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/samples/spring-webflux-security-hybrid-usage/pom.xml
+++ b/samples/spring-webflux-security-hybrid-usage/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.sap.cloud.security.samples</groupId>
     <artifactId>spring-webflux-security-hybrid-usage</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
     <name>spring-webflux-security-hybrid-usage</name>
 
     <url>https://github.com/SAP/cloud-security-xsuaa-integration</url>

--- a/spring-security-compatibility/pom.xml
+++ b/spring-security-compatibility/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.sap.cloud.security.xsuaa</groupId>
         <artifactId>parent</artifactId>
-        <version>3.7.4</version>
+        <version>3.7.5</version>
     </parent>
 
     <groupId>com.sap.cloud.security.xsuaa</groupId>

--- a/spring-security-starter/pom.xml
+++ b/spring-security-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>

--- a/spring-security/README.md
+++ b/spring-security/README.md
@@ -68,7 +68,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 ```
 

--- a/spring-security/pom.xml
+++ b/spring-security/pom.xml
@@ -9,14 +9,14 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<groupId>com.sap.cloud.security</groupId>
 	<artifactId>spring-security</artifactId>
 	<name>spring-security</name>
 	<packaging>jar</packaging>
-	<version>3.7.4</version>
+	<version>3.7.5</version>
 
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring security library</description>

--- a/spring-xsuaa-it/pom.xml
+++ b/spring-xsuaa-it/pom.xml
@@ -14,7 +14,7 @@
 
 	<artifactId>spring-xsuaa-it</artifactId>
 	<name>spring-xsuaa-it</name>
-	<version>3.7.4</version>
+	<version>3.7.5</version>
 	<url>https://github.com/SAP/cloud-security-xsuaa-integration</url>
 	<description>Java Spring XSUAA IT library</description>
 

--- a/spring-xsuaa-starter/pom.xml
+++ b/spring-xsuaa-starter/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<artifactId>xsuaa-spring-boot-starter</artifactId>

--- a/spring-xsuaa-test/README.md
+++ b/spring-xsuaa-test/README.md
@@ -31,7 +31,7 @@ This includes for example a `JwtGenerator` that generates JSON Web Tokens (JWT) 
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa-test</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
     <scope>test</scope>
 </dependency>
 

--- a/spring-xsuaa-test/pom.xml
+++ b/spring-xsuaa-test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<artifactId>spring-xsuaa-test</artifactId>

--- a/spring-xsuaa/README.md
+++ b/spring-xsuaa/README.md
@@ -39,7 +39,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>spring-xsuaa</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 <dependency> <!-- new with version 1.5.0 -->
     <groupId>org.apache.logging.log4j</groupId>
@@ -53,7 +53,7 @@ These (spring) dependencies need to be provided:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>xsuaa-spring-boot-starter</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 ```
 

--- a/spring-xsuaa/pom.xml
+++ b/spring-xsuaa/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<artifactId>spring-xsuaa</artifactId>

--- a/token-client-core/README.md
+++ b/token-client-core/README.md
@@ -26,7 +26,7 @@ Use `token-client-core` if:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-core</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/token-client-core/pom.xml
+++ b/token-client-core/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<artifactId>token-client-core</artifactId>

--- a/token-client-spring/README.md
+++ b/token-client-spring/README.md
@@ -25,7 +25,7 @@ Use `token-client-spring` if:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-spring</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 <dependency>
     <groupId>org.springframework</groupId>
@@ -51,7 +51,7 @@ For Spring Boot applications, it's recommended to use the autoconfiguration prov
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 ```
 

--- a/token-client-spring/pom.xml
+++ b/token-client-spring/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<artifactId>token-client-spring</artifactId>

--- a/token-client/README.md
+++ b/token-client/README.md
@@ -43,7 +43,7 @@ Contains all core functionality without Spring dependencies:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-core</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 ```
 
@@ -58,7 +58,7 @@ Contains Spring-specific implementations:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-spring</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 ```
 
@@ -75,7 +75,7 @@ A convenience module that includes both `token-client-core` and `token-client-sp
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 ```
 
@@ -114,7 +114,7 @@ In context of a Spring Boot application you can leverage autoconfiguration provi
 <dependency>
     <groupId>com.sap.cloud.security</groupId>
     <artifactId>resourceserver-security-spring-boot-starter</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 ```
 In context of Spring Applications you will need the following dependencies:
@@ -123,19 +123,19 @@ In context of Spring Applications you will need the following dependencies:
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 
 <!-- Option 2: Use only what you need -->
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-core</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-spring</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 
 <!-- Apache HttpClient is still required -->
@@ -205,7 +205,7 @@ See the [OAuth2ServiceConfiguration](#oauth2serviceconfiguration) section and [H
 <dependency>
     <groupId>com.sap.cloud.security.xsuaa</groupId>
     <artifactId>token-client-core</artifactId>
-    <version>3.7.4</version>
+    <version>3.7.5</version>
 </dependency>
 <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/token-client/pom.xml
+++ b/token-client/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.sap.cloud.security.xsuaa</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.7.4</version>
+		<version>3.7.5</version>
 	</parent>
 
 	<artifactId>token-client</artifactId>


### PR DESCRIPTION
## Fix: Tolerate unsupported / malformed JWK entries in JWKS

> **Backport of the fix targeted at `main` (PR #2009) onto the `main-3.x` maintenance branch.
> Written against the branch's existing JUnit 4 + Hamcrest test style;
> `LogSanitizer` does not exist on 3.x, so the new log lines use plain parameters, consistent with the surrounding code.**

### Problem

If a JWKS response contains a key whose `alg`/`kty` does not resolve to a
known `JwtSignatureAlgorithm`, `JsonWebKeySetFactory` throws
`IllegalArgumentException("keyAlgorithm must be not null")` out of the
parse loop and drops the **entire** JWKS. Tokens signed with algorithms
the library does support then also fail to validate.

### Changes

- Parse each JWK entry in its own try/catch; a bad entry only drops itself.
- Unsupported alg/kty: skip explicitly with an INFO log (kid/kty/alg).
- New tests in `JsonWebKeySetFactoryTest` for unsupported `alg`,
  unsupported `kty`, and missing `kty`.

### Compatibility

- No public API changes.
- User-facing exception messages unchanged.
- Only log wording changes.

### Testing

Full `validators` test suite green (167 tests, 3 new).
